### PR TITLE
Fix percentage and currency formatting

### DIFF
--- a/business_insights.py
+++ b/business_insights.py
@@ -104,6 +104,7 @@ def _growth_evidence(dataframe: pd.DataFrame, roles: ColumnRoles) -> Evidence | 
     change = (current - previous) / abs(previous) * 100
     period = trend.iloc[-1]["Period"].strftime("%b %Y")
     measure = roles.measure or "Records"
+    measure_values = dataframe[roles.measure].dropna() if roles.measure else None
     direction = "increased" if change >= 0 else "decreased"
     context = _movement_in_context(values, change)
     return Evidence(
@@ -112,8 +113,8 @@ def _growth_evidence(dataframe: pd.DataFrame, roles: ColumnRoles) -> Evidence | 
         value=f"{change:+.1f}%",
         statement=(
             f"{measure} {direction} {abs(change):.1f}% in the latest complete period "
-            f"({period}), from {format_number(previous, roles.measure)} to "
-            f"{format_number(current, roles.measure)}.{context}"
+            f"({period}), from {format_number(previous, roles.measure, column_values=measure_values)} to "
+            f"{format_number(current, roles.measure, column_values=measure_values)}.{context}"
         ),
         calculation=(
             "(Latest period − previous period) ÷ |previous period|, set against the spread "
@@ -129,6 +130,7 @@ def _change_driver_evidence(dataframe: pd.DataFrame, roles: ColumnRoles) -> Evid
     if result is None:
         return None
     grouped, previous_period, current_period = result
+    measure_values = dataframe[roles.measure].dropna() if roles.measure else None
     changes = grouped["Change"]
     net_change = float(changes.sum())
     gross_change = float(changes.abs().sum())
@@ -144,9 +146,10 @@ def _change_driver_evidence(dataframe: pd.DataFrame, roles: ColumnRoles) -> Evid
 
     movement = (
         f"{driver_name} moved the most of any {roles.dimension.lower()}: "
-        f"{roles.measure} {direction} by {format_number(abs(driver_change), roles.measure)}, "
-        f"from {format_number(previous_value, roles.measure)} to "
-        f"{format_number(current_value, roles.measure)}."
+        f"{roles.measure} {direction} by "
+        f"{format_number(abs(driver_change), roles.measure, column_values=measure_values)}, "
+        f"from {format_number(previous_value, roles.measure, column_values=measure_values)} to "
+        f"{format_number(current_value, roles.measure, column_values=measure_values)}."
     )
 
     # Segments that cancel out leave a tiny net change, and a share of that
@@ -156,8 +159,9 @@ def _change_driver_evidence(dataframe: pd.DataFrame, roles: ColumnRoles) -> Evid
         share = abs(driver_change) / gross_change * 100
         statement = (
             f"{movement} Segments largely offset each other this period — "
-            f"{format_number(gross_change, roles.measure)} of movement nets to just "
-            f"{format_number(abs(net_change), roles.measure)} — so this is "
+            f"{format_number(gross_change, roles.measure, column_values=measure_values)} "
+            f"of movement nets to just "
+            f"{format_number(abs(net_change), roles.measure, column_values=measure_values)} — so this is "
             f"{share:.1f}% of all movement rather than of the net."
         )
         calculation = (
@@ -175,7 +179,7 @@ def _change_driver_evidence(dataframe: pd.DataFrame, roles: ColumnRoles) -> Evid
     return Evidence(
         kind="driver",
         title="Largest change driver",
-        value=f"{sign}{format_number(abs(driver_change), roles.measure)}",
+        value=f"{sign}{format_number(abs(driver_change), roles.measure, column_values=measure_values)}",
         statement=statement,
         calculation=calculation,
         tone="positive" if driver_change > 0 else "negative",
@@ -192,6 +196,7 @@ def _anomaly_evidence(dataframe: pd.DataFrame, roles: ColumnRoles) -> Evidence |
     grain = preferred_frequency(dataframe[roles.date])
     worst = anomalies[0]
     measure = roles.measure or "Records"
+    measure_values = dataframe[roles.measure].dropna() if roles.measure else None
     label = format_period(worst.period, grain)
     plural = "periods sit" if len(anomalies) > 1 else "period sits"
     return Evidence(
@@ -200,9 +205,10 @@ def _anomaly_evidence(dataframe: pd.DataFrame, roles: ColumnRoles) -> Evidence |
         value=f"{len(anomalies)}",
         statement=(
             f"{label} is the sharpest anomaly: {measure.lower()} reached "
-            f"{format_number(worst.value, roles.measure)}, {worst.direction} the expected "
-            f"{format_number(worst.expected_low, roles.measure)}–"
-            f"{format_number(worst.expected_high, roles.measure)} range. "
+            f"{format_number(worst.value, roles.measure, column_values=measure_values)}, "
+            f"{worst.direction} the expected "
+            f"{format_number(worst.expected_low, roles.measure, column_values=measure_values)}–"
+            f"{format_number(worst.expected_high, roles.measure, column_values=measure_values)} range. "
             f"{len(anomalies)} {plural} outside the trendline band."
         ),
         calculation=(
@@ -247,6 +253,7 @@ def _segment_evidence(dataframe: pd.DataFrame, roles: ColumnRoles) -> tuple[Evid
     top_three_share = float(segments.head(3)["Value"].sum() / total * 100)
     effective = _effective_segments(segments["Value"].to_numpy(dtype=float), total)
     measure = roles.measure or "records"
+    measure_values = dataframe[roles.measure].dropna() if roles.measure else None
     dimension = roles.dimension or "segment"
     return (
         Evidence(
@@ -256,7 +263,7 @@ def _segment_evidence(dataframe: pd.DataFrame, roles: ColumnRoles) -> tuple[Evid
             statement=(
                 f"{leader['Segment']} is the largest {dimension.lower()}, contributing "
                 f"{leader_share:.1f}% of {measure.lower()} "
-                f"({format_number(float(leader['Value']), roles.measure)})."
+                f"({format_number(float(leader['Value']), roles.measure, column_values=measure_values)})."
             ),
             calculation=f"{leader['Segment']} {measure} ÷ total {measure}",
             tone="positive",
@@ -607,12 +614,12 @@ def analyze_business(dataframe: pd.DataFrame, roles: ColumnRoles | None = None) 
             [
                 KPI(
                     f"Total {roles.measure}",
-                    format_number(total, roles.measure),
+                    format_number(total, roles.measure, column_values=measure_values),
                     "Across all analyzed records",
                 ),
                 KPI(
                     f"Average {roles.measure}",
-                    format_number(average, roles.measure),
+                    format_number(average, roles.measure, column_values=measure_values),
                     "Per non-missing record",
                 ),
             ]
@@ -660,7 +667,12 @@ def analyze_business(dataframe: pd.DataFrame, roles: ColumnRoles | None = None) 
     elif leader:
         headline = leader.statement
     elif roles.measure:
-        total_measure = format_number(float(dataframe[roles.measure].sum()), roles.measure)
+        measure_values = dataframe[roles.measure].dropna()
+        total_measure = format_number(
+            float(measure_values.sum()),
+            roles.measure,
+            column_values=measure_values,
+        )
         headline = f"{roles.measure} totals {total_measure} across the analyzed data."
     else:
         headline = f"{len(dataframe):,} records are ready for operational review."

--- a/formatting.py
+++ b/formatting.py
@@ -33,14 +33,44 @@ def normalized_name(name: str) -> str:
 def is_currency(column: str | None) -> bool:
     return bool(column and any(token in normalized_name(column) for token in CURRENCY_TOKENS))
 
+def is_percentage(column: str | None) -> bool:
+    """Return if the column name represents a percentage."""
+    return bool(
+        column
+        and any(
+            token in normalized_name(column)
+            for token in ("%", "rate", "margin", "ratio")
+        )
+    )
+
+def currency_symbol(column: str | None) -> str:
+    """Return the currency symbol as in the column name"""
+    name = normalized_name(column) if column else ""
+
+    if "eur" in name or "€" in name:
+        return "€"
+    if "gbp" in name or "£" in name:
+        return "£"
+    if "usd" in name or "$" in name:
+        return "$"
+    if is_currency(column):
+        return "$"
+
+    return ""
+
 
 def format_number(value: float, column: str | None = None, *, compact: bool = True) -> str:
     """Format a metric according to likely business meaning."""
     if not np.isfinite(value):
         return "—"
 
+    if is_percentage(column):
+        if value >= 0 and value <= 1:
+            value *= 100
+        return f"{value:.1f}%"
+
     absolute = abs(value)
-    prefix = "$" if is_currency(column) else ""
+    prefix = currency_symbol(column)
     suffix = ""
     scaled = value
     if compact and absolute >= 1_000_000_000:

--- a/formatting.py
+++ b/formatting.py
@@ -7,6 +7,8 @@ engine reach for the same rendering rather than growing their own.
 
 from __future__ import annotations
 
+import re
+
 import numpy as np
 import pandas as pd
 
@@ -24,55 +26,120 @@ CURRENCY_TOKENS = (
     "balance",
 )
 
+CURRENCY_CODES = {
+    "eur": "€",
+    "gbp": "£",
+    "usd": "$",
+}
+
+PERCENTAGE_TOKENS = {"rate", "margin", "ratio"}
+
 
 def normalized_name(name: str) -> str:
     """Column names compared on meaning rather than punctuation."""
     return " ".join(name.lower().replace("_", " ").replace("-", " ").split())
 
 
+def _name_tokens(name: str) -> set[str]:
+    """Return whole-word tokens from a column name."""
+    return set(re.findall(r"[a-z0-9]+", normalized_name(name)))
+
+
 def is_currency(column: str | None) -> bool:
-    return bool(column and any(token in normalized_name(column) for token in CURRENCY_TOKENS))
+    """Return whether the column name represents currency."""
+    if not column:
+        return False
+
+    tokens = _name_tokens(column)
+    return bool(tokens & set(CURRENCY_TOKENS)) or bool(tokens & set(CURRENCY_CODES))
+
 
 def is_percentage(column: str | None) -> bool:
-    """Return if the column name represents a percentage."""
-    return bool(
-        column
-        and any(
-            token in normalized_name(column)
-            for token in ("%", "rate", "margin", "ratio")
-        )
-    )
+    """Return whether the column name represents a percentage."""
+    if not column:
+        return False
+
+    name = normalized_name(column)
+    tokens = _name_tokens(column)
+
+    return "%" in name or bool(tokens & PERCENTAGE_TOKENS)
+
 
 def currency_symbol(column: str | None) -> str:
-    """Return the currency symbol as in the column name"""
-    name = normalized_name(column) if column else ""
+    """Return the currency symbol indicated by the column name."""
+    if not column:
+        return ""
 
-    if "eur" in name or "€" in name:
-        return "€"
-    if "gbp" in name or "£" in name:
-        return "£"
-    if "usd" in name or "$" in name:
-        return "$"
+    name = normalized_name(column)
+    tokens = _name_tokens(column)
+
+    for code, symbol in CURRENCY_CODES.items():
+        if code in tokens or symbol in name:
+            return symbol
+
     if is_currency(column):
         return "$"
 
     return ""
 
 
-def format_number(value: float, column: str | None = None, *, compact: bool = True) -> str:
+def _percentage_uses_fraction_scale(
+    value: float,
+    column_values: pd.Series | None,
+) -> bool:
+    """Determine the percentage convention once for the available column."""
+    if column_values is None:
+        return 0 <= value <= 1
+
+    values = pd.to_numeric(column_values, errors="coerce").dropna()
+    if values.empty:
+        return False
+
+    # A column is treated as fractions only when every observed value is
+    # within [0, 1]. Negative or >1 values therefore use percentage points.
+    return bool(values.min() >= 0 and values.max() <= 1)
+
+
+def format_number(
+    value: float,
+    column: str | None = None,
+    *,
+    compact: bool = True,
+    column_values: pd.Series | None = None,
+) -> str:
     """Format a metric according to likely business meaning."""
     if not np.isfinite(value):
         return "—"
 
+    # Currency semantics always take precedence over percentage semantics.
+    if is_currency(column):
+        absolute = abs(value)
+        prefix = currency_symbol(column)
+        suffix = ""
+        scaled = value
+
+        if compact and absolute >= 1_000_000_000:
+            scaled, suffix = value / 1_000_000_000, "B"
+        elif compact and absolute >= 1_000_000:
+            scaled, suffix = value / 1_000_000, "M"
+        elif compact and absolute >= 1_000:
+            scaled, suffix = value / 1_000, "K"
+
+        if suffix:
+            return f"{prefix}{scaled:,.1f}{suffix}"
+
+        return f"{prefix}{value:,.2f}"
+
     if is_percentage(column):
-        if value >= 0 and value <= 1:
+        if _percentage_uses_fraction_scale(value, column_values):
             value *= 100
+
         return f"{value:.1f}%"
 
     absolute = abs(value)
-    prefix = currency_symbol(column)
-    suffix = ""
     scaled = value
+    suffix = ""
+
     if compact and absolute >= 1_000_000_000:
         scaled, suffix = value / 1_000_000_000, "B"
     elif compact and absolute >= 1_000_000:
@@ -81,10 +148,12 @@ def format_number(value: float, column: str | None = None, *, compact: bool = Tr
         scaled, suffix = value / 1_000, "K"
 
     if suffix:
-        return f"{prefix}{scaled:,.1f}{suffix}"
-    if float(value).is_integer() and not is_currency(column):
+        return f"{scaled:,.1f}{suffix}"
+
+    if float(value).is_integer():
         return f"{int(value):,}"
-    return f"{prefix}{value:,.2f}"
+
+    return f"{value:,.2f}"
 
 
 def format_period(period: pd.Timestamp, grain: str) -> str:

--- a/tests/test_business_insights.py
+++ b/tests/test_business_insights.py
@@ -193,6 +193,59 @@ class BusinessAnalysisTests(unittest.TestCase):
         self.assertEqual(format_number(1250, "Price GBP"), "£1.2K")
         self.assertEqual(format_number(1250, "Amount USD"), "$1.2K")
 
+        # Currency semantics must take precedence over rate/margin words.
+        self.assertEqual(format_number(350_000, "Corporate Revenue"), "$350.0K")
+        self.assertEqual(format_number(500, "Total EUR"), "€500.00")
+
+        # Currency codes must match whole words, not substrings.
+        self.assertEqual(format_number(30_000, "Europe Sales"), "$30.0K")
+
+        # Percentage detection/scaling must be consistent for negative values.
+        self.assertEqual(format_number(-0.3, "Negative Rate"), "-0.3%")
+
+
+    def test_percentage_formatting_uses_column_level_range(self):
+        negative_values = pd.Series([-0.3, -0.1, 0.1, 0.3])
+        mixed_values = pd.Series([0.9, 1.0, 1.1, 25.0])
+        fraction_values = pd.Series([0.12, 0.18, 0.25, 0.30])
+
+        self.assertEqual(
+            format_number(-0.3, "Negative Rate", column_values=negative_values),
+            "-0.3%",
+        )
+        self.assertEqual(
+            format_number(0.9, "Mixed Rate", column_values=mixed_values),
+            "0.9%",
+        )
+        self.assertEqual(
+            format_number(25.0, "Mixed Rate", column_values=mixed_values),
+            "25.0%",
+        )
+        self.assertEqual(
+            format_number(0.25, "Margin %", column_values=fraction_values),
+            "25.0%",
+        )
+
+
+    def test_currency_detection_precedes_percentage_detection(self):
+        self.assertEqual(
+            format_number(350_000, "Corporate Revenue"),
+            "$350.0K",
+        )
+
+
+    def test_integer_currency_is_formatted_as_currency(self):
+        self.assertEqual(
+            format_number(500, "Total EUR"),
+            "€500.00",
+        )
+
+
+    def test_currency_code_requires_a_whole_token(self):
+        self.assertEqual(
+            format_number(30_000, "Europe Sales"),
+            "$30.0K",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_business_insights.py
+++ b/tests/test_business_insights.py
@@ -187,6 +187,12 @@ class BusinessAnalysisTests(unittest.TestCase):
     def test_business_number_formatting(self):
         self.assertEqual(format_number(1_250_000, "Revenue"), "$1.2M")
         self.assertEqual(format_number(12_000, "Units"), "12.0K")
+        self.assertEqual(format_number(0.25, "Margin %"), "25.0%")
+        self.assertEqual(format_number(25, "Conversion Rate"), "25.0%")
+        self.assertEqual(format_number(1250, "Cost (EUR)"), "€1.2K")
+        self.assertEqual(format_number(1250, "Price GBP"), "£1.2K")
+        self.assertEqual(format_number(1250, "Amount USD"), "$1.2K")
+
 
 
 if __name__ == "__main__":

--- a/tests/test_business_insights.py
+++ b/tests/test_business_insights.py
@@ -103,6 +103,34 @@ class BusinessAnalysisTests(unittest.TestCase):
         self.assertIn("Calculation:", report)
         self.assertIn("not causal proof", report)
 
+    def test_semantic_percentage_formatting_flows_through_kpi_and_report(self):
+        dataframe = pd.DataFrame(
+            {
+                "Date": pd.to_datetime(
+                    ["2025-01-01", "2025-02-01", "2025-03-01", "2025-04-01"]
+                ),
+                "Gross Margin": [0.35, 0.42, 0.28, 0.31],
+                "Region": ["West", "East", "West", "East"],
+            }
+        )
+
+        roles = detect_roles(dataframe)
+        self.assertEqual(roles.measure, "Gross Margin")
+
+        brief = analyze_business(dataframe, roles)
+        report = build_business_report(
+            dataframe,
+            brief,
+            source_name="formatting_test.csv",
+        )
+
+        kpi_values = [item.value for item in brief.kpis]
+
+        self.assertIn("136.0%", kpi_values)
+        self.assertIn("34.0%", kpi_values)
+        self.assertIn("Gross Margin increased 10.7%", report)
+        self.assertIn("from 28.0% to 31.0%", report)
+
     def test_negative_latest_period_prioritizes_diagnosis(self):
         dataframe = pd.DataFrame(
             {


### PR DESCRIPTION
Closes #7

## What changed
- Added percentage column-name detection for `%`, `rate`, `margin`, and `ratio`.
- Formats values in 0–1 as percentages without changing stored data.
- Added currency-symbol detection for EUR, GBP, and USD while preserving the existing default for generic currency columns.
- Added focused tests for the new formatting behavior.

## Testing
- `python -m unittest discover -s tests -p "test_business_insights.py" -v` — 15/15 passed
- `ruff check .` — passed
- Full test suite still has 4 unrelated Streamlit test errors and 1 unrelated Streamlit failure in `test_app.py` due to the installed Streamlit API mismatch.