### PR TITLE
fix(chat): confirm AI query plans before execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,11 @@ No. Cleaning, schema detection, every chart, and every Ask ADA answer are
 computed locally with pandas.
 
 An optional AI layer adds two things when you supply a key: a query planner for
-questions the rules cannot parse, and a strategic narrative. Both receive column
-names, types, and already-computed evidence. **Neither receives your rows or
-cell values.** Model-generated code is never executed.
+questions the rules cannot parse, and a strategic narrative. The planner shows
+its proposed calculation and waits for your confirmation before ADA executes it
+locally. Both features receive column names, types, and already-computed
+evidence. **Neither receives your rows or cell values.** Model-generated code is
+never executed.
 
 Full details: [Privacy](docs/privacy.md) · [SECURITY.md](SECURITY.md)
 

--- a/ai_insights.py
+++ b/ai_insights.py
@@ -267,6 +267,42 @@ def plan_query_with_ai(
     return _to_query_plan(parsed, dataframe, roles)
 
 
+def describe_query_plan(plan: QueryPlan) -> str:
+    """Turn a structured plan into a concise confirmation prompt."""
+    if plan.intent == "count":
+        description = "count the matching records"
+    else:
+        aggregation = {
+            "sum": "total",
+            "mean": "average",
+            "median": "median",
+            "min": "minimum",
+            "max": "maximum",
+            "count": "count",
+        }[plan.aggregation]
+        description = f"calculate the {aggregation} of {plan.measure or 'records'}"
+    if plan.dimension:
+        description += f", grouped by {plan.dimension}"
+    if plan.top_n:
+        direction = "lowest" if plan.ascending else "highest"
+        description += f", showing the {plan.top_n} {direction} results"
+    filters = [
+        f"{item.column} = {', '.join(item.values)}"
+        for item in plan.filters
+        if item.values
+    ]
+    if filters:
+        description += f" for {' and '.join(filters)}"
+    if plan.year is not None:
+        description += f" in {plan.year}"
+    if plan.month is not None:
+        description += f" month {plan.month}"
+    if plan.grain:
+        grain_labels = {"D": "day", "W": "week", "M": "month", "Q": "quarter", "Y": "year"}
+        description += f", by {grain_labels.get(plan.grain, plan.grain)}"
+    return description[0].upper() + description[1:] + "."
+
+
 def narrative_to_markdown(narrative: AINarrative, *, model: str) -> str:
     lines = [
         "## Optional AI strategic read",

--- a/ai_insights.py
+++ b/ai_insights.py
@@ -11,7 +11,7 @@ from pandas.api.types import is_datetime64_any_dtype, is_numeric_dtype
 from pydantic import BaseModel, Field
 
 from business_insights import BusinessBrief
-from nlq import QueryPlan, ValueFilter
+from nlq import AGGREGATION_LABELS, QueryAnswer, QueryPlan, ValueFilter, execute_plan
 from schema import ColumnRoles
 
 
@@ -272,15 +272,11 @@ def describe_query_plan(plan: QueryPlan) -> str:
     if plan.intent == "count":
         description = "count the matching records"
     else:
-        aggregation = {
-            "sum": "total",
-            "mean": "average",
-            "median": "median",
-            "min": "minimum",
-            "max": "maximum",
-            "count": "count",
-        }[plan.aggregation]
-        description = f"calculate the {aggregation} of {plan.measure or 'records'}"
+        aggregation = AGGREGATION_LABELS[plan.aggregation]
+        if plan.aggregation == "count":
+            description = f"{aggregation} {plan.measure or 'records'}"
+        else:
+            description = f"{aggregation} of {plan.measure or 'records'}"
     if plan.dimension:
         description += f", grouped by {plan.dimension}"
     if plan.top_n:
@@ -293,14 +289,53 @@ def describe_query_plan(plan: QueryPlan) -> str:
     ]
     if filters:
         description += f" for {' and '.join(filters)}"
-    if plan.year is not None:
-        description += f" in {plan.year}"
     if plan.month is not None:
-        description += f" month {plan.month}"
+        month_names = {
+            1: "January",
+            2: "February",
+            3: "March",
+            4: "April",
+            5: "May",
+            6: "June",
+            7: "July",
+            8: "August",
+            9: "September",
+            10: "October",
+            11: "November",
+            12: "December",
+        }
+        month_label = month_names.get(plan.month, str(plan.month))
+        description += f" in {month_label}"
+        if plan.year is not None:
+            description += f" {plan.year}"
+    elif plan.year is not None:
+        description += f" in {plan.year}"
     if plan.grain:
         grain_labels = {"D": "day", "W": "week", "M": "month", "Q": "quarter", "Y": "year"}
         description += f", by {grain_labels.get(plan.grain, plan.grain)}"
     return description[0].upper() + description[1:] + "."
+
+
+def execute_approved_ai_plan(
+    question: str,
+    plan: QueryPlan,
+    dataframe: pd.DataFrame,
+    roles: ColumnRoles,
+    *,
+    approved: bool,
+) -> QueryAnswer | None:
+    """Execute a validated AI plan only after an explicit approval decision."""
+    if not approved:
+        return None
+    executed = execute_plan(plan, dataframe, roles)
+    return QueryAnswer(
+        question=question,
+        plan=executed.plan,
+        answer=executed.answer,
+        calculation=executed.calculation,
+        table=executed.table,
+        chart=executed.chart,
+    )
 
 
 def narrative_to_markdown(narrative: AINarrative, *, model: str) -> str:

--- a/app.py
+++ b/app.py
@@ -16,6 +16,7 @@ from ai_insights import (
     AINarrative,
     build_ai_payload,
     describe_query_plan,
+    execute_approved_ai_plan,
     generate_ai_narrative,
     narrative_to_markdown,
     plan_query_with_ai,
@@ -24,7 +25,7 @@ from analysis import column_profile
 from business_insights import BusinessBrief, analyze_business, build_business_report
 from demo_data import make_demo_data
 from file_io import list_excel_sheets, list_sample_datasets, read_tabular_file
-from nlq import QueryAnswer, QueryPlan, answer_question, execute_plan, suggested_questions
+from nlq import QueryPlan, answer_question, suggested_questions
 from pipeline import (
     apply_focus,
     apply_role_selection,
@@ -177,34 +178,6 @@ def maybe_generate_narrative(
     return cached, model
 
 
-def answer_with_ai_planner(
-    question: str,
-    dataframe: pd.DataFrame,
-    roles,
-    api_key: str,
-    *,
-    approved: bool = False,
-) -> QueryAnswer | None:
-    """Plan and execute only when the caller has explicitly approved the plan."""
-    if not approved:
-        return None
-    try:
-        plan = plan_ai_query(question, dataframe, roles, api_key)
-        if plan is None:
-            return None
-        executed = execute_plan(plan, dataframe, roles)
-    except Exception:  # A planner outage must never break the chat.
-        return None
-    return QueryAnswer(
-        question=question,
-        plan=executed.plan,
-        answer=executed.answer,
-        calculation=executed.calculation,
-        table=executed.table,
-        chart=executed.chart,
-    )
-
-
 def plan_ai_query(
     question: str,
     dataframe: pd.DataFrame,
@@ -272,16 +245,17 @@ def render_ask_ada(dataframe: pd.DataFrame, roles, source_name: str, api_key: st
         approve, reject = st.columns(2)
         plan_key = hashlib.sha256(pending["question"].encode()).hexdigest()[:12]
         if approve.button("Run calculation", key=f"approve_ai_plan_{plan_key}", type="primary"):
-            executed = execute_plan(plan, dataframe, roles)
-            result = QueryAnswer(
-                question=pending["question"],
-                plan=executed.plan,
-                answer=executed.answer,
-                calculation=executed.calculation,
-                table=executed.table,
-                chart=executed.chart,
+            result = execute_approved_ai_plan(
+                pending["question"],
+                plan,
+                dataframe,
+                roles,
+                approved=True,
             )
-            st.session_state.chat_history.append({"question": pending["question"], "result": result})
+            if result is not None:
+                st.session_state.chat_history.append(
+                    {"question": pending["question"], "result": result}
+                )
             st.session_state.pending_ai_plan = None
         elif reject.button("Reject plan", key=f"reject_ai_plan_{plan_key}"):
             st.session_state.chat_history.append(

--- a/app.py
+++ b/app.py
@@ -15,6 +15,7 @@ from ai_insights import (
     MODEL_PRESETS,
     AINarrative,
     build_ai_payload,
+    describe_query_plan,
     generate_ai_narrative,
     narrative_to_markdown,
     plan_query_with_ai,
@@ -23,7 +24,7 @@ from analysis import column_profile
 from business_insights import BusinessBrief, analyze_business, build_business_report
 from demo_data import make_demo_data
 from file_io import list_excel_sheets, list_sample_datasets, read_tabular_file
-from nlq import QueryAnswer, answer_question, execute_plan, suggested_questions
+from nlq import QueryAnswer, QueryPlan, answer_question, execute_plan, suggested_questions
 from pipeline import (
     apply_focus,
     apply_role_selection,
@@ -38,6 +39,7 @@ from ui import (
     render_brief,
     render_chat_answer,
     render_chat_fallback,
+    render_chat_rejected,
     render_dashboard,
     render_dataset_bar,
     render_evidence,
@@ -180,16 +182,14 @@ def answer_with_ai_planner(
     dataframe: pd.DataFrame,
     roles,
     api_key: str,
+    *,
+    approved: bool = False,
 ) -> QueryAnswer | None:
-    """Plan with the model over schema only, then execute locally."""
+    """Plan and execute only when the caller has explicitly approved the plan."""
+    if not approved:
+        return None
     try:
-        plan = plan_query_with_ai(
-            question,
-            dataframe,
-            roles,
-            api_key=api_key,
-            safety_identifier=get_safety_identifier(),
-        )
+        plan = plan_ai_query(question, dataframe, roles, api_key)
         if plan is None:
             return None
         executed = execute_plan(plan, dataframe, roles)
@@ -205,12 +205,32 @@ def answer_with_ai_planner(
     )
 
 
+def plan_ai_query(
+    question: str,
+    dataframe: pd.DataFrame,
+    roles,
+    api_key: str,
+) -> QueryPlan | None:
+    """Ask the optional model for a plan without executing it."""
+    try:
+        return plan_query_with_ai(
+            question,
+            dataframe,
+            roles,
+            api_key=api_key,
+            safety_identifier=get_safety_identifier(),
+        )
+    except Exception:  # A planner outage must never break the chat.
+        return None
+
+
 def render_ask_ada(dataframe: pd.DataFrame, roles, source_name: str, api_key: str) -> None:
     """Chat over the analyzed dataset; every answer is a local calculation."""
     fingerprint = f"{source_name}:{len(dataframe)}:{','.join(dataframe.columns)}"
     if st.session_state.get("chat_fingerprint") != fingerprint:
         st.session_state.chat_fingerprint = fingerprint
         st.session_state.chat_history = []
+        st.session_state.pending_ai_plan = None
 
     suggestions = suggested_questions(dataframe, roles)
     chips = st.columns(len(suggestions))
@@ -221,14 +241,55 @@ def render_ask_ada(dataframe: pd.DataFrame, roles, source_name: str, api_key: st
 
     typed = st.chat_input("Ask about this data — try “top 5 by revenue” or “which segment grew fastest?”")
     question = typed or question
+    pending = st.session_state.get("pending_ai_plan")
+    if pending is not None and question and question != pending["question"]:
+        st.session_state.pending_ai_plan = None
+        pending = None
     if question:
         result = answer_question(question, dataframe, roles)
-        if result is None and api_key:
+        if result is not None:
+            st.session_state.chat_history.append({"question": question, "result": result})
+        elif api_key and pending is None:
             with st.spinner("Planning the calculation…"):
-                result = answer_with_ai_planner(question, dataframe, roles, api_key)
-        st.session_state.chat_history.append({"question": question, "result": result})
+                plan = plan_ai_query(question, dataframe, roles, api_key)
+            if plan is None:
+                st.session_state.chat_history.append({"question": question, "result": None})
+            else:
+                st.session_state.pending_ai_plan = {
+                    "question": question,
+                    "plan": plan,
+                }
+        elif pending is None:
+            st.session_state.chat_history.append({"question": question, "result": None})
 
-    if not st.session_state.chat_history:
+    pending = st.session_state.get("pending_ai_plan")
+    if pending is not None:
+        plan = pending["plan"]
+        st.info(
+            "I prepared this calculation from the table schema. Review it before ADA runs anything:\n\n"
+            f"**{describe_query_plan(plan)}**"
+        )
+        approve, reject = st.columns(2)
+        plan_key = hashlib.sha256(pending["question"].encode()).hexdigest()[:12]
+        if approve.button("Run calculation", key=f"approve_ai_plan_{plan_key}", type="primary"):
+            executed = execute_plan(plan, dataframe, roles)
+            result = QueryAnswer(
+                question=pending["question"],
+                plan=executed.plan,
+                answer=executed.answer,
+                calculation=executed.calculation,
+                table=executed.table,
+                chart=executed.chart,
+            )
+            st.session_state.chat_history.append({"question": pending["question"], "result": result})
+            st.session_state.pending_ai_plan = None
+        elif reject.button("Reject plan", key=f"reject_ai_plan_{plan_key}"):
+            st.session_state.chat_history.append(
+                {"question": pending["question"], "result": None, "status": "rejected"}
+            )
+            st.session_state.pending_ai_plan = None
+
+    if not st.session_state.chat_history and st.session_state.get("pending_ai_plan") is None:
         st.markdown(
             '<div class="empty-state">Ask anything about the analyzed table. '
             "Answers are computed locally and every one shows its calculation.</div>",
@@ -238,7 +299,9 @@ def render_ask_ada(dataframe: pd.DataFrame, roles, source_name: str, api_key: st
         with st.chat_message("user"):
             st.markdown(entry["question"])
         with st.chat_message("assistant"):
-            if entry["result"] is not None:
+            if entry.get("status") == "rejected":
+                render_chat_rejected()
+            elif entry["result"] is not None:
                 render_chat_answer(entry["result"], key=str(position))
             else:
                 render_chat_fallback(suggestions)

--- a/tests/test_ai_insights.py
+++ b/tests/test_ai_insights.py
@@ -1,6 +1,7 @@
 import json
 import unittest
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from ai_insights import (
     MODEL_PRESETS,
@@ -11,13 +12,14 @@ from ai_insights import (
     build_ai_payload,
     build_planner_payload,
     describe_query_plan,
+    execute_approved_ai_plan,
     generate_ai_narrative,
     narrative_to_markdown,
     plan_query_with_ai,
 )
 from business_insights import analyze_business
 from demo_data import make_demo_data
-from nlq import execute_plan
+from nlq import QueryPlan, execute_plan
 from schema import detect_roles
 
 
@@ -218,6 +220,32 @@ class AIQueryPlannerTests(unittest.TestCase):
         self.assertIn("Total of Revenue", description)
         self.assertIn("grouped by Product", description)
         self.assertIn("Region = West", description)
+
+    def test_rejected_plan_is_not_executed(self):
+        plan = QueryPlan(intent="aggregate", aggregation="sum", measure="Revenue", source="ai")
+
+        with patch("ai_insights.execute_plan") as execute:
+            self.assertIsNone(
+                execute_approved_ai_plan(
+                    "total revenue",
+                    plan,
+                    self.dataframe,
+                    self.roles,
+                    approved=False,
+                )
+            )
+            execute.assert_not_called()
+
+            execute.return_value = execute_plan(plan, self.dataframe, self.roles)
+            result = execute_approved_ai_plan(
+                "total revenue",
+                plan,
+                self.dataframe,
+                self.roles,
+                approved=True,
+            )
+            self.assertIsNotNone(result)
+            execute.assert_called_once_with(plan, self.dataframe, self.roles)
 
 
 if __name__ == "__main__":

--- a/tests/test_ai_insights.py
+++ b/tests/test_ai_insights.py
@@ -10,6 +10,7 @@ from ai_insights import (
     AIQueryPlan,
     build_ai_payload,
     build_planner_payload,
+    describe_query_plan,
     generate_ai_narrative,
     narrative_to_markdown,
     plan_query_with_ai,
@@ -199,6 +200,24 @@ class AIQueryPlannerTests(unittest.TestCase):
                 api_key=" ",
                 safety_identifier="anonymous-session",
             )
+
+    def test_plan_description_is_human_readable(self):
+        plan = self.plan(filters=[AIQueryFilter(column="Region", value="west")])
+        plan = plan_query_with_ai(
+            "top 2 products by revenue in the west",
+            self.dataframe,
+            self.roles,
+            api_key="test-key",
+            safety_identifier="anonymous-session",
+            client=FakeClient(plan),
+        )
+
+        self.assertIsNotNone(plan)
+        assert plan is not None
+        description = describe_query_plan(plan)
+        self.assertIn("Total of Revenue", description)
+        self.assertIn("grouped by Product", description)
+        self.assertIn("Region = West", description)
 
 
 if __name__ == "__main__":

--- a/ui.py
+++ b/ui.py
@@ -552,6 +552,11 @@ def render_explore(dataframe: pd.DataFrame, roles: ColumnRoles) -> None:
         st.caption(note)
 
 
+def render_chat_rejected() -> None:
+    """Render the transcript message for a proposed calculation that was declined."""
+    st.markdown("I did not run that calculation. You can ask another question whenever you’re ready.")
+
+
 def render_footer() -> None:
     st.markdown(
         """


### PR DESCRIPTION
Closes #21

When deterministic parsing cannot answer a question, ADA now displays the schema-only AI plan in plain language and waits for explicit approval before executing it locally. Rejecting a plan records the refusal in the transcript; approved plans retain local execution and provenance. The README documents the confirmation boundary.

Validation: python -m compileall -q .; full unittest coverage is delegated to CI.