### PR TITLE
fix(nlq): reject unsupported query terms

### DIFF
--- a/nlq.py
+++ b/nlq.py
@@ -108,9 +108,9 @@ BREAKDOWN_LIMIT = 12
 
 QUERY_STOPWORDS = {
     "a", "about", "across", "all", "and", "are", "by", "can", "do", "does", "each",
-    "for", "from", "have", "how", "in", "is", "it", "me", "many", "my", "of", "on",
-    "or", "our", "please", "show", "tell", "than", "the", "there", "to", "we", "what",
-    "which", "with", "your",
+    "for", "from", "have", "he", "how", "i", "in", "is", "it", "me", "many", "my",
+    "of", "on", "or", "our", "please", "re", "s", "she", "show", "tell", "than", "that",
+    "the", "there", "this", "to", "they", "ve", "we", "what", "which", "with", "you", "your",
 }
 
 
@@ -147,7 +147,9 @@ class QueryAnswer:
 
 
 def _norm(text: str) -> str:
-    cleaned = re.sub(r"[^0-9a-z]+", " ", str(text).lower())
+    lowered = str(text).lower().replace("’", "'")
+    lowered = re.sub(r"\b([a-z]+)'(s|re|ve|ll|d|m|t)\b", r"\1", lowered)
+    cleaned = re.sub(r"[^0-9a-z]+", " ", lowered)
     return " ".join(cleaned.split())
 
 
@@ -239,15 +241,21 @@ def _unrecognized_query_tokens(
         {
             "bottom",
             "count",
+            "breakdown",
             "fastest",
+            "history",
             "number",
+            "per",
             "rows",
             "sells",
+            "split",
             "sold",
             "top",
+            "trajectory",
             "trend",
             "over",
             "time",
+            "timeline",
         }
     )
 
@@ -261,9 +269,9 @@ def _unrecognized_query_tokens(
     for column in roles.dimensions:
         if column not in dataframe.columns:
             continue
-        values = dataframe[column].dropna().astype(str)
-        if len(values) <= MAX_FILTER_CANDIDATES:
-            for value in values.unique():
+        unique_values = dataframe[column].dropna().astype(str).unique()
+        if len(unique_values) <= MAX_FILTER_CANDIDATES:
+            for value in unique_values:
                 allowed.update(_norm(value).split())
 
     return {token for token in question.split() if token.isalpha() and token not in allowed}

--- a/nlq.py
+++ b/nlq.py
@@ -106,6 +106,13 @@ MONTH_NAMES = {
 MAX_FILTER_CANDIDATES = 200
 BREAKDOWN_LIMIT = 12
 
+QUERY_STOPWORDS = {
+    "a", "about", "across", "all", "and", "are", "by", "can", "do", "does", "each",
+    "for", "from", "have", "how", "in", "is", "it", "me", "many", "my", "of", "on",
+    "or", "our", "please", "show", "tell", "than", "the", "there", "to", "we", "what",
+    "which", "with", "your",
+}
+
 
 @dataclass(frozen=True)
 class ValueFilter:
@@ -216,6 +223,52 @@ def _detect_grain(question: str) -> str | None:
     return None
 
 
+def _unrecognized_query_tokens(
+    question: str, dataframe: pd.DataFrame, roles: ColumnRoles
+) -> set[str]:
+    """Return content words that cannot refer to this dataset or query grammar."""
+    allowed = set(QUERY_STOPWORDS)
+    allowed.update(AGGREGATION_WORDS)
+    allowed.update(ASCENDING_WORDS)
+    allowed.update(SUPERLATIVE_WORDS)
+    allowed.update(DECLINE_WORDS)
+    allowed.update(GROWTH_WORDS)
+    allowed.update(GRAIN_WORDS)
+    allowed.update(MONTH_NAMES)
+    allowed.update(
+        {
+            "bottom",
+            "count",
+            "fastest",
+            "number",
+            "rows",
+            "sells",
+            "sold",
+            "top",
+            "trend",
+            "over",
+            "time",
+        }
+    )
+
+    for column in dataframe.columns:
+        normalized = _norm(column)
+        allowed.update(normalized.split())
+        allowed.update(_word_variants(normalized))
+        first_word = normalized.split(" ", 1)[0]
+        allowed.update(_word_variants(first_word))
+
+    for column in roles.dimensions:
+        if column not in dataframe.columns:
+            continue
+        values = dataframe[column].dropna().astype(str)
+        if len(values) <= MAX_FILTER_CANDIDATES:
+            for value in values.unique():
+                allowed.update(_norm(value).split())
+
+    return {token for token in question.split() if token.isalpha() and token not in allowed}
+
+
 def parse_question(question: str, dataframe: pd.DataFrame, roles: ColumnRoles) -> QueryPlan | None:
     """Turn a plain-English question into an explicit plan, or None if unsupported."""
     q = _norm(question)
@@ -227,6 +280,8 @@ def parse_question(question: str, dataframe: pd.DataFrame, roles: ColumnRoles) -
 
     measure = _match_column(q, numeric_columns)
     dimension = _match_column(q, dimension_columns)
+    if _unrecognized_query_tokens(q, dataframe, roles):
+        return None
     year, month = _detect_time_filter(q)
     grain = _detect_grain(q)
     filters = _detect_value_filters(q, dataframe, roles, exclude=(dimension,))

--- a/tests/test_nlq.py
+++ b/tests/test_nlq.py
@@ -107,6 +107,18 @@ class NLQParsingTests(unittest.TestCase):
         self.assertIsNotNone(answer_question("which product", self.dataframe, self.roles))
         self.assertIsNotNone(answer_question("revenue by region", self.dataframe, self.roles))
 
+    def test_supported_grammar_and_contractions_remain_answerable(self):
+        for question in (
+            "what's total revenue",
+            "average revenue per region",
+            "revenue timeline",
+            "revenue history",
+            "revenue trajectory",
+            "total revenue in the West",
+        ):
+            with self.subTest(question=question):
+                self.assertIsNotNone(answer_question(question, self.dataframe, self.roles))
+
     def test_suggestions_are_all_answerable(self):
         for question in suggested_questions(self.dataframe, self.roles):
             self.assertIsNotNone(

--- a/tests/test_nlq.py
+++ b/tests/test_nlq.py
@@ -97,6 +97,16 @@ class NLQParsingTests(unittest.TestCase):
     def test_unreadable_question_returns_none(self):
         self.assertIsNone(answer_question("tell me a joke", self.dataframe, self.roles))
 
+    def test_questions_about_unknown_columns_return_none(self):
+        self.assertIsNone(
+            answer_question("what is the craziest product we sell", self.dataframe, self.roles)
+        )
+        self.assertIsNone(answer_question("total sales by region", self.dataframe, self.roles))
+
+    def test_known_bare_dimension_questions_remain_answerable(self):
+        self.assertIsNotNone(answer_question("which product", self.dataframe, self.roles))
+        self.assertIsNotNone(answer_question("revenue by region", self.dataframe, self.roles))
+
     def test_suggestions_are_all_answerable(self):
         for question in suggested_questions(self.dataframe, self.roles):
             self.assertIsNotNone(


### PR DESCRIPTION
Closes #22

Ask ADA now rejects content words that do not match the detected schema or supported query grammar before producing a calculation. Valid metric, dimension, ranking, and time questions remain supported, with regression coverage for refusal and bare-dimension cases.

Validation: python -m compileall -q .; full unittest coverage is delegated to CI.