### PR TITLE
fix(nlq): accept common query phrasing

### DIFF
--- a/docs/reference/ask-ada.md
+++ b/docs/reference/ask-ada.md
@@ -81,6 +81,12 @@ If none match, `parse_question` returns `None` — and returning `None` is the
 correct behavior, not a failure. It is what triggers the AI fallback or the
 suggestion list, rather than ADA guessing.
 
+Today, refusal also checks every word against a bounded allowlist of query
+terms, dataset names and values, and common conversational words. This protects
+against unsupported requests, but ordinary phrasing can expose gaps in the
+allowlist. It is a temporary guard until refusal can rely on the finite dataset
+schema and recognized query signals instead of the open-ended English language.
+
 ## Execution
 
 `execute_plan` applies filters, aggregates, and returns a `QueryAnswer`:

--- a/nlq.py
+++ b/nlq.py
@@ -111,6 +111,8 @@ QUERY_STOPWORDS = {
     "for", "from", "have", "he", "how", "i", "in", "is", "it", "me", "many", "my",
     "of", "on", "or", "our", "please", "re", "s", "she", "show", "tell", "than", "that",
     "the", "there", "this", "to", "they", "ve", "we", "what", "which", "with", "you", "your",
+    "also", "any", "been", "did", "done", "get", "give", "got", "hows", "just", "last",
+    "least", "made", "make", "most", "much", "next", "only", "then", "us", "was", "were", "whats",
 }
 
 

--- a/tests/test_nlq.py
+++ b/tests/test_nlq.py
@@ -119,6 +119,25 @@ class NLQParsingTests(unittest.TestCase):
             with self.subTest(question=question):
                 self.assertIsNotNone(answer_question(question, self.dataframe, self.roles))
 
+    def test_common_function_words_remain_answerable(self):
+        for question in (
+            "which region grew the most",
+            "how much revenue did we make",
+            "what were total revenue last quarter",
+            "give me revenue by channel",
+            "whats the total revenue",
+        ):
+            with self.subTest(question=question):
+                self.assertIsNotNone(answer_question(question, self.dataframe, self.roles))
+
+    def test_unsupported_phrasing_remains_refused(self):
+        for question in (
+            "what is the weather",
+            "show me the vibe of this data",
+        ):
+            with self.subTest(question=question):
+                self.assertIsNone(answer_question(question, self.dataframe, self.roles))
+
     def test_suggestions_are_all_answerable(self):
         for question in suggested_questions(self.dataframe, self.roles):
             self.assertIsNotNone(


### PR DESCRIPTION
Closes #32.

Ask ADA's bounded refusal vocabulary rejected ordinary questions such as `how much revenue did we make` before the parser could use their valid measure and intent signals. This adds the requested common function words while keeping unknown business concepts and unsupported requests refused.

The calculation and trust boundary is unchanged: queries still execute locally against detected dataset roles, and every non-dataset word must remain in the bounded query vocabulary. The reference documentation now records that temporary refusal design and its limits.

Validation:
- `ruff check .`
- `python -m unittest discover -s tests -v` (181 passed)
- required `compileall` command
- direct smoke check for five accepted phrases and five refusal cases
