### PR TITLE
fix: add missing function words to QUERY_STOPWORDS (#32)

### DIFF
--- a/docs/reference/ask-ada.md
+++ b/docs/reference/ask-ada.md
@@ -81,6 +81,22 @@ If none match, `parse_question` returns `None` — and returning `None` is the
 correct behavior, not a failure. It is what triggers the AI fallback or the
 suggestion list, rather than ADA guessing.
 
+### Refusing unreadable questions
+
+Before a plan is built, every word in the question must be either a known
+column/value, part of the query grammar (aggregation, ranking, growth, time,
+grain words), or one of `QUERY_STOPWORDS` — a fixed allowlist of function
+words ("the", "by", "how", "give", "were", ...). Any other word — a column
+that doesn't exist, a typo, an off-topic request — refuses the question
+(`None`) instead of guessing. This is why "tell me a joke" and "total sales by
+region" (no `sales` column) return `None`.
+
+`QUERY_STOPWORDS` is a temporary, allowlist-based approach: ordinary phrasing
+("how much revenue did we make") can fail until its function words are added
+to the list. The [long-term fix](https://github.com/saineshnakra/automated-data-analyst/issues/32)
+is schema-based validation — refuse only when a question names a column or
+measure that genuinely doesn't exist, rather than maintaining a word list.
+
 ## Execution
 
 `execute_plan` applies filters, aggregates, and returns a `QueryAnswer`:

--- a/nlq.py
+++ b/nlq.py
@@ -107,10 +107,13 @@ MAX_FILTER_CANDIDATES = 200
 BREAKDOWN_LIMIT = 12
 
 QUERY_STOPWORDS = {
-    "a", "about", "across", "all", "and", "are", "by", "can", "do", "does", "each",
-    "for", "from", "have", "he", "how", "i", "in", "is", "it", "me", "many", "my",
-    "of", "on", "or", "our", "please", "re", "s", "she", "show", "tell", "than", "that",
-    "the", "there", "this", "to", "they", "ve", "we", "what", "which", "with", "you", "your",
+    "a", "about", "across", "all", "also", "and", "any", "are", "been", "by", "can",
+    "did", "do", "does", "done", "each", "for", "from", "get", "give", "got", "have",
+    "he", "how", "hows", "i", "in", "is", "it", "just", "last", "least", "make", "made",
+    "many", "me", "most", "much", "my", "next", "of", "on", "only", "or", "our",
+    "please", "re", "s", "she", "show", "tell", "than", "that", "the", "then", "there",
+    "this", "to", "they", "us", "ve", "was", "we", "were", "what", "whats", "which",
+    "with", "you", "your",
 }
 
 

--- a/tests/test_nlq.py
+++ b/tests/test_nlq.py
@@ -119,6 +119,17 @@ class NLQParsingTests(unittest.TestCase):
             with self.subTest(question=question):
                 self.assertIsNotNone(answer_question(question, self.dataframe, self.roles))
 
+    def test_ordinary_phrasing_with_function_words_remains_answerable(self):
+        for question in (
+            "which region grew the most",
+            "how much revenue did we make",
+            "what were total revenue last quarter",
+            "give me revenue by channel",
+            "whats the total revenue",
+        ):
+            with self.subTest(question=question):
+                self.assertIsNotNone(answer_question(question, self.dataframe, self.roles))
+
     def test_suggestions_are_all_answerable(self):
         for question in suggested_questions(self.dataframe, self.roles):
             self.assertIsNotNone(


### PR DESCRIPTION
## What problem does this solve?

Plain English questions like "how much revenue did we make" were being 
rejected because common function words like `much`, `did`, `make`, `were` 
were missing from `QUERY_STOPWORDS` in nlq.py.

## What changed?

- `nlq.py` — added 23 missing function words to QUERY_STOPWORDS
- `tests/test_nlq.py` — added regression test covering all 5 example questions from issue #32
- `docs/reference/ask-ada.md` — documented the refusal mechanism (was undocumented before)
## Evidence and trust boundaries

Pure allowlist expansion — no changes to refusal logic (_unrecognized_query_tokens).
No external calls, no privacy boundary changes, no cost impact.

## Verification

- [x] python -m unittest discover -s tests -v → 23/23 passed in test_nlq.py, 171/171 full suite
- [x] New analytical behavior has tests (test_ordinary_phrasing_with_function_words_remains_answerable)
- [x] No credentials, private datasets, or generated build output committed