### PR TITLE
Fix 81 verified bugs found by a full-codebase audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,17 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # The deployment host picks its own interpreter, so every version ADA
+        # claims to support has to be exercised here.
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
           cache: pip
       - name: Install dependencies
         run: python -m pip install -r requirements-dev.txt
@@ -24,7 +30,10 @@ jobs:
       - name: Test
         run: python -m unittest discover -s tests -v
       - name: Compile
-        run: >-
-          python -m compileall -q aggregation.py analysis.py ai_insights.py anomalies.py business_insights.py
-          demo_data.py file_io.py forecasting.py formatting.py nlq.py pipeline.py schema.py
-          timeseries.py ui.py app.py tools tests
+        # Every top-level module, found rather than listed -- autovis.py was
+        # missing from the old hand-written list.
+        run: python -m compileall -q *.py tools tests
+      - name: Import the app
+        # compileall only parses. The deployment failed on an ImportError that
+        # every other step here was blind to, so the app is actually imported.
+        run: python -c "import app"

--- a/README.md
+++ b/README.md
@@ -71,15 +71,22 @@ No API key required. The app opens with a built-in demo dataset.
 
 ## Does my data leave my machine?
 
-No. Cleaning, schema detection, every chart, and every Ask ADA answer are
-computed locally with pandas.
+**Running ADA yourself: no.** Cleaning, schema detection, every chart, and every
+Ask ADA answer are computed locally with pandas, with no network call at all.
+
+**Using the hosted demo: your file is uploaded to a Streamlit server**, because
+that is what uploading a file to a website means. It is held in memory for the
+session and never written to a database. If that matters for your data, run ADA
+locally — it is four commands above and needs no key.
 
 An optional AI layer adds two things when you supply a key: a query planner for
 questions the rules cannot parse, and a strategic narrative. The planner shows
 its proposed calculation and waits for your confirmation before ADA executes it
-locally. Both features receive column names, types, and already-computed
-evidence. **Neither receives your rows or cell values.** Model-generated code is
-never executed.
+locally. **Neither ever receives your rows.** They receive column names, types,
+and already-computed evidence — and because an evidence sentence names the
+segment it is about, a segment label such as a customer or product name can
+appear in it. Nothing else from a cell does. Model-generated code is never
+executed.
 
 Full details: [Privacy](https://github.com/saineshnakra/automated-data-analyst/blob/main/docs/privacy.md) · [SECURITY.md](https://github.com/saineshnakra/automated-data-analyst/blob/main/SECURITY.md)
 

--- a/aggregation.py
+++ b/aggregation.py
@@ -66,6 +66,8 @@ def preferred_frequency(date_series: pd.Series) -> str:
 
 EMPTY_TREND = pd.DataFrame({"Period": pd.Series(dtype="datetime64[ns]"), "Value": pd.Series(dtype=float)})
 PARTIAL_COVERAGE_MARGIN = 0.2
+# Below typical by this much, but not enough to exclude: worth saying out loud.
+SHORT_COVERAGE_MARGIN = 0.05
 MIN_PERIODS_FOR_PARTIAL_CHECK = 4
 
 
@@ -82,10 +84,22 @@ class TrendSeries:
     filled_periods: int = 0
     partial_period: pd.Timestamp | None = None
     partial_coverage: str = ""
+    # A period the data stops part-way through, but not far enough through for
+    # exclusion to be safe -- "no orders for three days" looks the same from
+    # here. Saying so beats guessing either way.
+    short_coverage: str = ""
+    # False when there were too few periods to judge completeness at all, so
+    # nothing downstream may call the last one complete.
+    completeness_checked: bool = True
 
     @property
     def notes(self) -> tuple[str, ...]:
         notes: list[str] = []
+        if self.short_coverage:
+            notes.append(
+                f"The last period only reaches {self.short_coverage}, so part of its "
+                "shortfall may be missing data rather than a real fall."
+            )
         if self.partial_period is not None:
             notes.append(
                 f"{format_period(self.partial_period, self.frequency)} is still in progress "
@@ -108,7 +122,7 @@ def _period_bounds(periods: pd.DatetimeIndex, frequency: str) -> tuple[pd.Dateti
 
 def _trailing_partial_period(
     dates: pd.Series, periods: pd.Series, frequency: str
-) -> tuple[pd.Timestamp | None, str]:
+) -> tuple[pd.Timestamp | None, str, str, bool]:
     """Detect a final period the data stops part-way through.
 
     Compares how much of each period the data actually reaches with how much
@@ -118,20 +132,27 @@ def _trailing_partial_period(
     """
     last_seen = dates.groupby(periods).max().sort_index()
     if len(last_seen) < MIN_PERIODS_FOR_PARTIAL_CHECK:
-        return None, ""
+        # Too few periods to know what "typical coverage" looks like here.
+        return None, "", "", False
 
     starts, ends = _period_bounds(pd.DatetimeIndex(last_seen.index), frequency)
     spans = (ends - starts).to_numpy().astype("timedelta64[s]").astype(float)
     reached = (last_seen.to_numpy() - starts.to_numpy()).astype("timedelta64[s]").astype(float)
     coverage = np.divide(reached, spans, out=np.zeros_like(reached), where=spans > 0)
 
-    typical = float(np.median(coverage[:-1]))
-    if coverage[-1] >= typical - PARTIAL_COVERAGE_MARGIN:
-        return None, ""
-
     period_days = max(int(round(spans[-1] / 86_400)), 1)
     covered_days = max(int(round(reached[-1] / 86_400)) + 1, 1)
-    return pd.Timestamp(last_seen.index[-1]), f"{covered_days} of {period_days} days"
+    reach = f"{covered_days} of {period_days} days"
+
+    typical = float(np.median(coverage[:-1]))
+    if coverage[-1] >= typical - PARTIAL_COVERAGE_MARGIN:
+        # Not short enough to exclude safely: an extract cut on the 26th and a
+        # quiet last week look identical from here. Report the shortfall rather
+        # than silently presenting the drop as a real one.
+        short = reach if coverage[-1] < typical - SHORT_COVERAGE_MARGIN else ""
+        return None, "", short, True
+
+    return pd.Timestamp(last_seen.index[-1]), reach, "", True
 
 
 def build_trend(
@@ -151,8 +172,8 @@ def build_trend(
     frequency = frequency or _period_frequency(working[roles.date])
     working["Period"] = working[roles.date].dt.to_period(frequency).dt.to_timestamp()
 
-    partial_period, partial_coverage = _trailing_partial_period(
-        working[roles.date], working["Period"], frequency
+    partial_period, partial_coverage, short_coverage, completeness_checked = (
+        _trailing_partial_period(working[roles.date], working["Period"], frequency)
     )
     if partial_period is not None:
         remaining = working[working["Period"] < partial_period]
@@ -175,6 +196,8 @@ def build_trend(
         filled_periods=filled,
         partial_period=partial_period,
         partial_coverage=partial_coverage,
+        short_coverage=short_coverage,
+        completeness_checked=completeness_checked,
     )
 
 

--- a/aggregation.py
+++ b/aggregation.py
@@ -313,8 +313,19 @@ def driver_frame(dataframe: pd.DataFrame, roles: ColumnRoles, limit: int = 9) ->
     return frame
 
 
-def heatmap_frame(dataframe: pd.DataFrame, roles: ColumnRoles, limit: int = 8) -> pd.DataFrame:
-    """Segment × period matrix of the measure (or row counts) for the top segments."""
+def heatmap_frame(
+    dataframe: pd.DataFrame,
+    roles: ColumnRoles,
+    limit: int = 8,
+    frequency: str | None = None,
+) -> pd.DataFrame:
+    """Segment × period matrix of the measure (or row counts) for the top segments.
+
+    The grain is taken from the caller so the heatmap shares a time axis with
+    the trend beside it. Re-deriving it from this filtered subset landed on a
+    different grain, and the two charts on one page then disagreed about what
+    a column meant.
+    """
     if not roles.date or not roles.dimension:
         return pd.DataFrame()
 
@@ -325,7 +336,7 @@ def heatmap_frame(dataframe: pd.DataFrame, roles: ColumnRoles, limit: int = 8) -
     if working.empty:
         return pd.DataFrame()
 
-    frequency = _period_frequency(working[roles.date])
+    frequency = frequency or _period_frequency(working[roles.date])
     working["Period"] = working[roles.date].dt.to_period(frequency).dt.to_timestamp()
     if roles.measure:
         pivot = working.groupby([roles.dimension, "Period"])[roles.measure].sum().unstack(fill_value=0)

--- a/aggregation.py
+++ b/aggregation.py
@@ -236,6 +236,9 @@ def segment_frame(dataframe: pd.DataFrame, roles: ColumnRoles, limit: int = 12) 
     return result.sort_values("Value", ascending=False).head(limit).reset_index(drop=True)
 
 
+UNLABELLED_SEGMENT = "(not recorded)"
+
+
 def segment_period_change(
     dataframe: pd.DataFrame, roles: ColumnRoles
 ) -> tuple[pd.DataFrame, pd.Timestamp, pd.Timestamp] | None:
@@ -253,7 +256,14 @@ def segment_period_change(
     # different subset of rows can land on another grain, and then the two
     # periods being compared exist in one view and not the other.
     frequency = series.frequency
-    working = dataframe[[roles.date, roles.measure, roles.dimension]].dropna().copy()
+    working = dataframe[[roles.date, roles.measure, roles.dimension]].copy()
+    working = working.dropna(subset=[roles.date, roles.measure])
+    # A row with no segment label still carries measure value. Dropping it
+    # here and keeping it in the trend meant the drivers were shares of a
+    # movement they did not add up to.
+    working[roles.dimension] = working[roles.dimension].astype(object).where(
+        working[roles.dimension].notna(), UNLABELLED_SEGMENT
+    )
     working["Period"] = working[roles.date].dt.to_period(frequency).dt.to_timestamp()
     comparison = working[working["Period"].isin([previous_period, current_period])]
     grouped = comparison.groupby([roles.dimension, "Period"])[roles.measure].sum().unstack(fill_value=0)

--- a/ai_insights.py
+++ b/ai_insights.py
@@ -7,7 +7,7 @@ from dataclasses import asdict, dataclass
 from typing import Literal, Protocol
 
 import pandas as pd
-from pandas.api.types import is_datetime64_any_dtype, is_numeric_dtype
+from pandas.api.types import is_bool_dtype, is_datetime64_any_dtype, is_numeric_dtype
 from pydantic import BaseModel, Field
 
 from business_insights import BusinessBrief
@@ -190,22 +190,79 @@ def _resolve_filter(item: AIQueryFilter, dataframe: pd.DataFrame) -> ValueFilter
     return ValueFilter(column=item.column, values=matched) if matched else None
 
 
+# Intents that group, and so cannot run without a dimension to group by.
+GROUPING_INTENTS = ("rank", "breakdown")
+# Intents whose executor reads plan.dimension at all. Growth ranks segments by
+# their change, so it uses one; a plain aggregate never does.
+DIMENSION_INTENTS = ("rank", "breakdown", "growth")
+# Intents that resample onto a period grain.
+GRAIN_INTENTS = ("trend", "growth")
+# Intents whose executor works on period sums and ignores plan.aggregation.
+PERIOD_INTENTS = ("trend", "growth")
+# Above this share of distinct values a column identifies rows rather than
+# grouping them, and a "breakdown" by it is one row per record.
+IDENTIFIER_UNIQUENESS = 0.9
+
+
+def _usable_measure(dataframe: pd.DataFrame, column: str, aggregation: str) -> bool:
+    """Counting works on anything; arithmetic does not."""
+    if aggregation == "count":
+        return True
+    return is_numeric_dtype(dataframe[column])
+
+
+def _usable_dimension(dataframe: pd.DataFrame, column: str) -> bool:
+    """A segment groups records together. A timestamp or an id does not."""
+    series = dataframe[column]
+    if is_datetime64_any_dtype(series):
+        return False
+    present = int(series.notna().sum())
+    if not present:
+        return False
+    if is_numeric_dtype(series) and not is_bool_dtype(series):
+        # A continuous measure is not a segment, and grouping by it produces a
+        # row per distinct value.
+        if series.dropna().nunique() > present * IDENTIFIER_UNIQUENESS:
+            return False
+    return series.nunique(dropna=True) <= present * IDENTIFIER_UNIQUENESS
+
+
 def _to_query_plan(
     parsed: AIQueryPlan, dataframe: pd.DataFrame, roles: ColumnRoles
 ) -> QueryPlan | None:
+    """Turn a model's proposal into a plan ADA will execute exactly as described.
+
+    Everything the executor would ignore is refused or stripped here rather
+    than shown to the user for approval. An approval gate that describes a
+    calculation which is not the one that runs is worse than no gate at all,
+    because it buys confidence without earning it.
+    """
     measure = parsed.measure or roles.measure
     dimension = parsed.dimension
     for column in (parsed.measure, parsed.dimension):
         if column is not None and column not in dataframe.columns:
             return None
-    if parsed.intent in ("trend", "growth") and not roles.date:
+    if parsed.intent in PERIOD_INTENTS and not roles.date:
+        return None
+    # The executor sums periods whatever the plan says, so a plan promising an
+    # average over time would answer a different question than the one approved.
+    if parsed.intent in PERIOD_INTENTS and parsed.aggregation != "sum":
         return None
     if parsed.intent == "aggregate" and not measure:
         return None
-    if parsed.intent in ("rank", "breakdown"):
+    if measure is not None and not _usable_measure(dataframe, measure, parsed.aggregation):
+        return None
+    if parsed.intent in GROUPING_INTENTS:
         dimension = dimension or roles.dimension
         if not dimension:
             return None
+    if dimension is not None:
+        if dimension == measure or not _usable_dimension(dataframe, dimension):
+            return None
+    # A time filter needs a column to apply it to; without one the executor
+    # quietly returns the all-time figure under a scoped-looking sentence.
+    if (parsed.year is not None or parsed.month is not None) and not roles.date:
+        return None
     filters: list[ValueFilter] = []
     for item in parsed.filters:
         resolved = _resolve_filter(item, dataframe)
@@ -215,14 +272,16 @@ def _to_query_plan(
     return QueryPlan(
         intent=parsed.intent,
         aggregation=parsed.aggregation,
-        measure=measure,
-        dimension=dimension,
-        top_n=parsed.top_n,
+        measure=measure if parsed.intent != "count" else None,
+        # Every modifier the chosen intent's executor would ignore is dropped
+        # here, so the approval sentence cannot advertise one.
+        dimension=dimension if parsed.intent in DIMENSION_INTENTS else None,
+        top_n=parsed.top_n if parsed.intent == "rank" else None,
         ascending=parsed.ascending,
         filters=tuple(filters),
         year=parsed.year,
         month=parsed.month,
-        grain=parsed.grain,
+        grain=parsed.grain if parsed.intent in GRAIN_INTENTS else None,
         source="ai",
     )
 
@@ -267,52 +326,67 @@ def plan_query_with_ai(
     return _to_query_plan(parsed, dataframe, roles)
 
 
-def describe_query_plan(plan: QueryPlan) -> str:
-    """Turn a structured plan into a concise confirmation prompt."""
-    if plan.intent == "count":
-        description = "count the matching records"
-    else:
-        aggregation = AGGREGATION_LABELS[plan.aggregation]
-        if plan.aggregation == "count":
-            description = f"{aggregation} {plan.measure or 'records'}"
-        else:
-            description = f"{aggregation} of {plan.measure or 'records'}"
-    if plan.dimension:
-        description += f", grouped by {plan.dimension}"
-    if plan.top_n:
-        direction = "lowest" if plan.ascending else "highest"
-        description += f", showing the {plan.top_n} {direction} results"
-    filters = [
-        f"{item.column} = {', '.join(item.values)}"
-        for item in plan.filters
-        if item.values
+MONTH_NAMES = {
+    1: "January", 2: "February", 3: "March", 4: "April", 5: "May", 6: "June",
+    7: "July", 8: "August", 9: "September", 10: "October", 11: "November", 12: "December",
+}
+GRAIN_LABELS = {"D": "day", "W": "week", "M": "month", "Q": "quarter", "Y": "year"}
+
+
+def _scope_clause(plan: QueryPlan) -> str:
+    parts = [
+        f"{item.column} = {', '.join(item.values)}" for item in plan.filters if item.values
     ]
-    if filters:
-        description += f" for {' and '.join(filters)}"
+    clause = f" for {' and '.join(parts)}" if parts else ""
     if plan.month is not None:
-        month_names = {
-            1: "January",
-            2: "February",
-            3: "March",
-            4: "April",
-            5: "May",
-            6: "June",
-            7: "July",
-            8: "August",
-            9: "September",
-            10: "October",
-            11: "November",
-            12: "December",
-        }
-        month_label = month_names.get(plan.month, str(plan.month))
-        description += f" in {month_label}"
-        if plan.year is not None:
-            description += f" {plan.year}"
+        label = MONTH_NAMES.get(plan.month, str(plan.month))
+        clause += f" in {label} {plan.year}" if plan.year is not None else f" in {label}"
     elif plan.year is not None:
-        description += f" in {plan.year}"
-    if plan.grain:
-        grain_labels = {"D": "day", "W": "week", "M": "month", "Q": "quarter", "Y": "year"}
-        description += f", by {grain_labels.get(plan.grain, plan.grain)}"
+        clause += f" in {plan.year}"
+    return clause
+
+
+def describe_query_plan(plan: QueryPlan) -> str:
+    """Say, in a sentence, exactly what execute_plan will do with this plan.
+
+    The sentence is the whole value of the approval step, so it is built per
+    intent rather than from whichever fields happen to be set. A description
+    that mentions a grouping or a ranking the executor ignores teaches the
+    reader to trust a gate that is not checking anything.
+    """
+    measure = plan.measure or "records"
+    aggregation = AGGREGATION_LABELS[plan.aggregation]
+    grain = GRAIN_LABELS.get(plan.grain or "", "period")
+
+    if plan.intent == "count":
+        if plan.count_column:
+            description = f"count the distinct {plan.count_column} values"
+        else:
+            description = "count the matching records"
+    elif plan.intent == "trend":
+        description = f"track total {measure} per {grain} over time"
+    elif plan.intent == "growth":
+        if plan.dimension:
+            description = (
+                f"rank each {plan.dimension} by how much its total {measure} changed "
+                f"from the previous {grain} to the latest one"
+            )
+        else:
+            description = (
+                f"compare total {measure} in the latest {grain} with the previous one"
+            )
+    elif plan.intent == "rank":
+        direction = "lowest" if plan.ascending else "highest"
+        showing = f"the {plan.top_n} {direction}" if plan.top_n else f"every one, {direction} first"
+        described = "rows" if plan.aggregation == "count" else f"{aggregation.lower()} {measure}"
+        description = f"rank {plan.dimension} by {described}, showing {showing}"
+    elif plan.intent == "breakdown":
+        described = "rows" if plan.aggregation == "count" else f"total {measure}"
+        description = f"break {described} down by {plan.dimension}"
+    else:
+        description = f"{aggregation.lower()} of {measure}"
+
+    description += _scope_clause(plan)
     return description[0].upper() + description[1:] + "."
 
 

--- a/analysis.py
+++ b/analysis.py
@@ -65,6 +65,27 @@ def _drop_timezone(series: pd.Series) -> pd.Series:
     return series
 
 
+INT64_LIMIT = float(np.iinfo(np.int64).max)
+
+
+def _widen_columns_that_would_overflow(frame: pd.DataFrame) -> int:
+    """Move an integer column to float when its own total will not fit.
+
+    numpy sums int64 in int64, so a strictly positive ledger whose total
+    passes 9.2e18 wraps round to a negative number and every figure built on
+    it is nonsense. Float loses precision in the last few digits; wrapping
+    loses the sign. Only columns that would actually overflow are touched, so
+    ordinary integers keep their type.
+    """
+    widened = 0
+    for column in frame.select_dtypes(include=["int64", "int32", "uint64"]).columns:
+        magnitude = float(frame[column].astype("float64").abs().sum())
+        if magnitude > INT64_LIMIT:
+            frame[column] = frame[column].astype("float64")
+            widened += 1
+    return widened
+
+
 def _normalize_datetime_columns(frame: pd.DataFrame) -> int:
     """Strip timezones from every date column, whatever put them there."""
     changed = 0
@@ -219,6 +240,11 @@ def clean_dataframe(
     datetime_columns_inferred = _normalize_datetime_columns(cleaned)
     unparsed_date_cells = 0
     notes: list[str] = []
+    if _widen_columns_that_would_overflow(cleaned):
+        notes.append(
+            "A column's values are large enough that their total would not fit in a whole "
+            "number, so it is measured as a decimal; the last few digits are approximate."
+        )
     if datetime_columns_inferred:
         notes.append(
             "Timezone offsets were dropped; dates are read as the local time they were written in."

--- a/analysis.py
+++ b/analysis.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import warnings
 from dataclasses import asdict, dataclass
 from typing import Any
@@ -24,8 +25,11 @@ class CleaningReport:
     trimmed_text_columns: int
     numeric_columns_inferred: int
     datetime_columns_inferred: int
+    duplicate_rows_found: int = 0
+    unparsed_date_cells: int = 0
+    notes: tuple[str, ...] = ()
 
-    def to_dict(self) -> dict[str, int]:
+    def to_dict(self) -> dict[str, Any]:
         return asdict(self)
 
 
@@ -48,16 +52,124 @@ def _speculative_dates(values: pd.Series) -> pd.Series:
         return pd.to_datetime(values, errors="coerce")
 
 
+def _drop_timezone(series: pd.Series) -> pd.Series:
+    """Return the same instants as naive local time.
+
+    Every downstream calculation compares a date against a period boundary,
+    and pandas builds those boundaries without a timezone. Converting to UTC
+    first would move a row into the previous calendar day for anyone east of
+    Greenwich, so the wall clock the file was written in is what is kept.
+    """
+    if isinstance(series.dtype, pd.DatetimeTZDtype):
+        return series.dt.tz_localize(None)
+    return series
+
+
+def _normalize_datetime_columns(frame: pd.DataFrame) -> int:
+    """Strip timezones from every date column, whatever put them there."""
+    changed = 0
+    for column in frame.columns:
+        series = frame[column]
+        if isinstance(series.dtype, pd.DatetimeTZDtype):
+            frame[column] = _drop_timezone(series)
+            changed += 1
+    return changed
+
+
+# A business-formatted number: an optional sign or accounting parentheses, an
+# optional currency symbol, then digits with grouping punctuation. Anything
+# holding a slash or a letter is not this -- notably a date, which would
+# otherwise survive as a very large integer.
+_MONEY = re.compile(r"^[+-]?\(?\s*[-+]?\s*[$\u20ac\u00a3\u00a5\u20b9]?\s*\d[\d,.\s']*\)?$")
+
+
+def _numeric_from_text(values: pd.Series) -> pd.Series:
+    """Read business-formatted numbers: "$1,203.55", "(48.10)", "1 234,50".
+
+    A thousands separator is punctuation, not data, and an amount in
+    parentheses is how every accounting export writes a negative. Reading
+    them as text loses the largest values in the file, which are exactly the
+    ones with a separator in them.
+    """
+    text = values.astype("string").str.strip()
+    money = text.str.match(_MONEY, na=False)
+    text = text.where(money)
+    negative = text.str.contains(r"\(", na=False)
+    text = text.str.replace(r"[^\d,.]", "", regex=True)
+    # "1.234,50" is European; "1,234.50" is not. Whichever separator comes
+    # last is the decimal point.
+    european = text.str.contains(r",\d{1,2}$", na=False) & ~text.str.contains(r"\.\d", na=False)
+    text = text.mask(
+        european, text.str.replace(".", "", regex=False).str.replace(",", ".", regex=False)
+    )
+    text = text.mask(~european, text.str.replace(",", "", regex=False))
+    parsed = pd.to_numeric(text, errors="coerce")
+    return parsed.mask(negative & parsed.notna(), -parsed)
+
+
+# A date written day-or-month first: "3/1/2024", "03-01-24". A year-leading
+# value is ISO and cannot be read two ways.
+_DAY_OR_MONTH_FIRST = re.compile(r"^\s*\d{1,2}[/-]\d{1,2}[/-]\d{2,4}")
+
+
+def _dated(values: pd.Series, *, dayfirst: bool) -> pd.Series:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        return pd.to_datetime(values, errors="coerce", dayfirst=dayfirst)
+
+
+def _read_dates(values: pd.Series) -> tuple[pd.Series, str]:
+    """Parse a date column, and say so when the ordering had to be guessed.
+
+    "01/03/2024" is 1 March in most of the world and 3 January in the United
+    States. When some row in the column settles it -- a 13 or higher in the
+    first position -- that reading wins outright. When nothing settles it,
+    month-first is assumed and the assumption is reported, because silently
+    turning a year of monthly figures into twelve days of January is the one
+    outcome nobody can detect downstream.
+    """
+    month_first = _dated(values, dayfirst=False)
+    # Only a value that leads with a day or a month can be read two ways.
+    # 2024-03-01 is ISO and settled; 01/03/2024 is not.
+    two_ways = values.astype("string").str.match(_DAY_OR_MONTH_FIRST, na=False)
+    if not bool(two_ways.any()):
+        return month_first, ""
+
+    day_first = _dated(values, dayfirst=True)
+    if day_first.notna().sum() > month_first.notna().sum():
+        return day_first, "day-first"
+    if month_first.notna().sum() > day_first.notna().sum():
+        return month_first, ""
+    disagree = two_ways & month_first.notna() & day_first.notna() & month_first.ne(day_first)
+    return month_first, "ambiguous" if bool(disagree.any()) else ""
+
+
+def _ordering_note(column: str, ordering: str) -> str:
+    if ordering == "day-first":
+        return f"{column} was read day-first (25/12/2024 is 25 December)."
+    return (
+        f"{column} could be read either way round; month-first was assumed "
+        f"(01/03/2024 is 3 January). Rename the column or use ISO dates to be sure."
+    )
+
+
 def _make_unique_columns(columns: pd.Index) -> list[str]:
     """Return readable, unique column names without changing their meaning."""
     counts: dict[str, int] = {}
+    taken: set[str] = set()
     result: list[str] = []
 
     for position, raw_name in enumerate(columns, start=1):
         base = " ".join(str(raw_name).strip().split()) or f"column_{position}"
         counts[base] = counts.get(base, 0) + 1
-        suffix = f"_{counts[base]}" if counts[base] > 1 else ""
-        result.append(f"{base}{suffix}")
+        candidate = base if counts[base] == 1 else f"{base}_{counts[base]}"
+        # A file can already contain the name the suffix would produce, so
+        # keep counting until the result is genuinely unused.
+        while candidate in taken:
+            counts[base] += 1
+            candidate = f"{base}_{counts[base]}"
+        taken.add(candidate)
+        result.append(candidate)
 
     return result
 
@@ -73,8 +185,16 @@ def _looks_like_exported_index(series: pd.Series, name: str) -> bool:
     return np.array_equal(numeric.to_numpy(), np.arange(len(series)))
 
 
-def clean_dataframe(dataframe: pd.DataFrame) -> tuple[pd.DataFrame, CleaningReport]:
-    """Apply conservative, explainable cleaning and return an audit report."""
+def clean_dataframe(
+    dataframe: pd.DataFrame, *, drop_duplicates: bool = False
+) -> tuple[pd.DataFrame, CleaningReport]:
+    """Apply conservative, explainable cleaning and return an audit report.
+
+    Identical rows are counted but kept. Two sales of the same item, for the
+    same amount, on the same day are an ordinary Tuesday at a till, not a
+    defect, and deleting them silently removes real revenue from every number
+    on the page. Callers that know their rows carry a key can opt in.
+    """
     if dataframe.empty or len(dataframe.columns) == 0:
         raise ValueError("The CSV does not contain any rows and columns to analyze.")
 
@@ -96,7 +216,13 @@ def clean_dataframe(dataframe: pd.DataFrame) -> tuple[pd.DataFrame, CleaningRepo
 
     trimmed_text_columns = 0
     numeric_columns_inferred = 0
-    datetime_columns_inferred = 0
+    datetime_columns_inferred = _normalize_datetime_columns(cleaned)
+    unparsed_date_cells = 0
+    notes: list[str] = []
+    if datetime_columns_inferred:
+        notes.append(
+            "Timezone offsets were dropped; dates are read as the local time they were written in."
+        )
 
     protected_numeric_tokens = ("id", "code", "zip", "postal", "phone")
     date_tokens = ("date", "time", "timestamp", "created", "updated")
@@ -116,14 +242,29 @@ def clean_dataframe(dataframe: pd.DataFrame) -> tuple[pd.DataFrame, CleaningRepo
         normalized_name = column.lower()
         named_like_a_date = any(token in normalized_name for token in date_tokens)
         if named_like_a_date:
-            parsed_dates = _speculative_dates(cleaned[column])
+            parsed_dates, ordering = _read_dates(cleaned[column])
             if parsed_dates.notna().sum() / non_null_before >= named_date_ratio:
-                cleaned[column] = parsed_dates
+                unreadable = int(non_null_before - parsed_dates.notna().sum())
+                if unreadable:
+                    unparsed_date_cells += unreadable
+                    notes.append(f"{unreadable} {column} values could not be read as dates.")
+                if ordering:
+                    notes.append(_ordering_note(column, ordering))
+                cleaned[column] = _drop_timezone(parsed_dates)
                 datetime_columns_inferred += 1
                 continue
 
         if not any(token in normalized_name for token in protected_numeric_tokens):
             parsed_numeric = pd.to_numeric(cleaned[column], errors="coerce")
+            if parsed_numeric.notna().sum() < non_null_before:
+                # Whatever plain parsing could not read, try again allowing the
+                # punctuation a finance export writes: grouping separators, a
+                # currency symbol, parentheses for a negative. The values that
+                # need it are the large ones, so leaving them out biases every
+                # total downwards.
+                formatted = _numeric_from_text(cleaned[column])
+                if formatted.notna().sum() > parsed_numeric.notna().sum():
+                    parsed_numeric = formatted
             if parsed_numeric.notna().sum() / non_null_before >= numeric_ratio:
                 cleaned[column] = parsed_numeric
                 numeric_columns_inferred += 1
@@ -138,13 +279,22 @@ def clean_dataframe(dataframe: pd.DataFrame) -> tuple[pd.DataFrame, CleaningRepo
             # them.
             sample = cleaned[column].dropna().head(date_sample_size)
             if len(sample) and _speculative_dates(sample).notna().mean() >= unnamed_date_ratio:
-                parsed_dates = _speculative_dates(cleaned[column])
+                parsed_dates, ordering = _read_dates(cleaned[column])
                 if parsed_dates.notna().sum() / non_null_before >= unnamed_date_ratio:
-                    cleaned[column] = parsed_dates
+                    if ordering:
+                        notes.append(_ordering_note(column, ordering))
+                    cleaned[column] = _drop_timezone(parsed_dates)
                     datetime_columns_inferred += 1
 
     duplicate_rows = int(cleaned.duplicated().sum())
-    cleaned = cleaned.drop_duplicates().reset_index(drop=True)
+    if drop_duplicates:
+        cleaned = cleaned.drop_duplicates()
+    cleaned = cleaned.reset_index(drop=True)
+    if duplicate_rows and not drop_duplicates:
+        notes.append(
+            f"{duplicate_rows:,} identical rows were kept; repeat transactions are not "
+            "assumed to be mistakes."
+        )
 
     if cleaned.empty or len(cleaned.columns) == 0:
         raise ValueError("No analyzable data remained after removing empty rows and columns.")
@@ -154,13 +304,16 @@ def clean_dataframe(dataframe: pd.DataFrame) -> tuple[pd.DataFrame, CleaningRepo
         original_columns=original_columns,
         final_rows=len(cleaned),
         final_columns=len(cleaned.columns),
-        duplicate_rows_removed=duplicate_rows,
+        duplicate_rows_removed=duplicate_rows if drop_duplicates else 0,
         empty_rows_removed=empty_rows_removed,
         empty_columns_removed=len(empty_columns),
         index_columns_removed=len(index_columns),
         trimmed_text_columns=trimmed_text_columns,
         numeric_columns_inferred=numeric_columns_inferred,
         datetime_columns_inferred=datetime_columns_inferred,
+        duplicate_rows_found=duplicate_rows,
+        unparsed_date_cells=unparsed_date_cells,
+        notes=tuple(dict.fromkeys(notes)),
     )
     return cleaned, report
 

--- a/analysis.py
+++ b/analysis.py
@@ -196,14 +196,28 @@ def _make_unique_columns(columns: pd.Index) -> list[str]:
 
 
 def _looks_like_exported_index(series: pd.Series, name: str) -> bool:
+    """A stray row-number column left behind by someone's to_csv(index=True).
+
+    Gaps are allowed. Blank rows are dropped before this runs, and each one
+    takes a number out of the sequence -- a single blank line was enough to
+    leave the row numbers in place and let them become the file's headline
+    metric. The "unnamed" prefix is what makes this safe to be lenient about;
+    a counter with a real name is never touched.
+    """
     if not name.lower().startswith("unnamed"):
         return False
 
     numeric = pd.to_numeric(series, errors="coerce")
-    if numeric.isna().any():
+    if numeric.isna().any() or not (numeric % 1 == 0).all():
         return False
 
-    return np.array_equal(numeric.to_numpy(), np.arange(len(series)))
+    values = numeric.to_numpy()
+    if values.size == 0 or values[0] not in (0, 1):
+        return False
+    ascending = bool(np.all(np.diff(values) > 0))
+    # Still has to look like row numbers rather than sparse identifiers.
+    dense = values[-1] - values[0] < 2 * len(values)
+    return ascending and dense
 
 
 def clean_dataframe(

--- a/app.py
+++ b/app.py
@@ -361,10 +361,18 @@ except (pd.errors.EmptyDataError, pd.errors.ParserError, UnicodeDecodeError, Val
     st.stop()
 
 if prepared.truncated_rows:
+    covered = ""
+    if prepared.analyzed_from is not None and prepared.analyzed_to is not None:
+        covered = (
+            f", covering {prepared.analyzed_from:%d %b %Y} to {prepared.analyzed_to:%d %b %Y}"
+        )
     st.warning(
-        f"ADA analyzed the first {MAX_ANALYSIS_ROWS:,} rows for predictable performance "
-        f"and skipped {prepared.truncated_rows:,}."
+        f"ADA analyzed the {MAX_ANALYSIS_ROWS:,} most recent rows for predictable performance "
+        f"and skipped {prepared.truncated_rows:,} older ones{covered}."
     )
+
+for note in prepared.cleaning_report.notes:
+    st.info(note)
 
 dataframe = prepared.dataframe
 detected = prepared.detected_roles

--- a/app.py
+++ b/app.py
@@ -88,7 +88,7 @@ st.set_page_config(
 )
 
 
-@st.cache_data(show_spinner=False)
+@st.cache_data(show_spinner=False, max_entries=8, ttl=3600)
 def read_uploaded_file(contents: bytes, filename: str, sheet_name: str | None = None) -> pd.DataFrame:
     return read_tabular_file(contents, filename, sheet_name)
 
@@ -224,9 +224,25 @@ def plan_ai_query(
         return None
 
 
+def dataset_fingerprint(dataframe: pd.DataFrame, roles, source_name: str) -> str:
+    """Identify the exact table an answer was computed from.
+
+    Name, row count and column names do not identify a dataset. Two months of
+    the same export share all three, and so does the same file drilled into a
+    different segment -- and an answer, or a pending model plan, carried across
+    that boundary is a wrong number with a confident sentence under it. The
+    content is hashed, and the roles with it, because changing which column is
+    the measure changes what every answer means.
+    """
+    content = int(pd.util.hash_pandas_object(dataframe, index=False).sum())
+    parts = (source_name, str(dataframe.shape), ",".join(map(str, dataframe.columns)),
+             str(content), repr(roles))
+    return hashlib.sha256("|".join(parts).encode()).hexdigest()
+
+
 def render_ask_ada(dataframe: pd.DataFrame, roles, source_name: str, api_key: str) -> None:
     """Chat over the analyzed dataset; every answer is a local calculation."""
-    fingerprint = f"{source_name}:{len(dataframe)}:{','.join(dataframe.columns)}"
+    fingerprint = dataset_fingerprint(dataframe, roles, source_name)
     if st.session_state.get("chat_fingerprint") != fingerprint:
         st.session_state.chat_fingerprint = fingerprint
         st.session_state.chat_history = []
@@ -325,6 +341,10 @@ source_mode = st.segmented_control(
     default="Explore the live demo",
     label_visibility="collapsed",
 )
+# A segmented control returns None when the selected option is clicked again.
+# Falling through with None used to reach a bare assert and render a traceback.
+if source_mode is None:
+    source_mode = "Explore the live demo"
 
 uploaded_file = None
 business_context = ""
@@ -357,14 +377,12 @@ try:
         raw_dataframe = make_demo_data()
         source_name = "Acme operating data · demo"
         business_context = "Two years of orders across products, regions, and sales channels."
-    elif source_mode == "Try a sample dataset":
-        assert selected_sample is not None
+    elif source_mode == "Try a sample dataset" and selected_sample is not None:
         sample_path = sample_datasets[selected_sample]
         raw_dataframe = read_uploaded_file(sample_path.read_bytes(), sample_path.name)
         source_name = f"{selected_sample} · sample"
         business_context = SAMPLE_NOTES.get(selected_sample, "")
-    else:
-        assert uploaded_file is not None
+    elif uploaded_file is not None:
         if uploaded_file.size > MAX_UPLOAD_BYTES:
             st.error("That file is larger than ADA's 25 MB analysis limit.")
             st.stop()
@@ -381,6 +399,12 @@ try:
         source_name = (
             f"{uploaded_file.name} · {selected_sheet}" if selected_sheet else uploaded_file.name
         )
+
+    else:
+        # No usable source: show the explainer rather than a traceback.
+        render_how_it_works()
+        render_footer()
+        st.stop()
 
     prepared = prepare_analysis(raw_dataframe, row_limit=MAX_ANALYSIS_ROWS)
 except (pd.errors.EmptyDataError, pd.errors.ParserError, UnicodeDecodeError, ValueError, ImportError) as error:

--- a/app.py
+++ b/app.py
@@ -119,7 +119,7 @@ def render_sidebar(*, server_api_key: str) -> str:
         st.markdown(
             "- Calculations happen locally\n"
             "- Evidence is shown before interpretation\n"
-            "- Raw rows are never sent to the strategy model\n"
+            "- Your rows are never sent to the strategy model\n"
             "- Recommendations are not causal proof"
         )
         st.markdown("---")
@@ -340,7 +340,7 @@ if source_mode == "Upload your file":
     uploaded_file = st.file_uploader(
         "Upload a CSV or Excel workbook",
         type=["csv", "xlsx", "xlsm"],
-        help="Maximum file size: 25 MB. ADA analyzes the first worksheet.",
+        help="Maximum file size: 25 MB. A workbook with several sheets lets you pick one.",
     )
     business_context = st.text_input(
         "Optional business context",
@@ -489,7 +489,7 @@ with executive_tab:
         render_section_heading(
             "Optional strategy agent",
             "Connect the signals into a strategic read",
-            "Only the computed evidence and supplied business context are sent. Raw uploaded rows stay out of the model prompt.",
+            "Only the computed evidence and supplied business context are sent. Your rows stay out of the model prompt, though the segment names inside an evidence sentence travel with it.",
         )
         control_column, note_column = st.columns([.42, .58], gap="large")
         with control_column:
@@ -513,8 +513,10 @@ with ask_tab:
     render_section_heading(
         "Conversational analyst",
         "Ask this data anything",
-        "Questions become transparent pandas calculations that run locally. "
-        "No question or answer leaves the session, and every reply shows its math.",
+        "Questions become transparent pandas calculations that run locally, and every "
+        "reply shows its math. Only when the rules cannot read a question, and only if you "
+        "supplied a key, is the question itself sent to the planner — which returns a plan "
+        "for you to approve, never an answer.",
     )
     render_ask_ada(dataframe, roles, source_name, api_key)
 

--- a/app.py
+++ b/app.py
@@ -10,17 +10,6 @@ import pandas as pd
 import streamlit as st
 from streamlit.errors import StreamlitSecretNotFoundError
 
-from ai_insights import (
-    DEFAULT_PRESET,
-    MODEL_PRESETS,
-    AINarrative,
-    build_ai_payload,
-    describe_query_plan,
-    execute_approved_ai_plan,
-    generate_ai_narrative,
-    narrative_to_markdown,
-    plan_query_with_ai,
-)
 from analysis import column_profile
 from business_insights import BusinessBrief, analyze_business, build_business_report
 from demo_data import make_demo_data
@@ -34,6 +23,29 @@ from pipeline import (
     prepare_analysis,
     schema_frame,
 )
+
+# The AI layer is optional, and so is everything it depends on. Importing it
+# at module scope meant one missing package took down the whole product --
+# including the deterministic analysis that is the reason to open ADA without
+# a key at all. A failure here disables the two optional calls and nothing else.
+try:
+    from ai_insights import (
+        DEFAULT_PRESET,
+        MODEL_PRESETS,
+        AINarrative,
+        build_ai_payload,
+        describe_query_plan,
+        execute_approved_ai_plan,
+        generate_ai_narrative,
+        narrative_to_markdown,
+        plan_query_with_ai,
+    )
+
+    AI_LAYER_ERROR = ""
+except Exception as error:  # noqa: BLE001 - any import failure must degrade, not crash
+    AI_LAYER_ERROR = f"{type(error).__name__}: {error}"
+    DEFAULT_PRESET, MODEL_PRESETS, AINarrative = "", {}, ()
+
 from ui import (
     inject_styles,
     render_ai_narrative,
@@ -111,6 +123,19 @@ def render_sidebar(*, server_api_key: str) -> str:
             "- Recommendations are not causal proof"
         )
         st.markdown("---")
+        if AI_LAYER_ERROR:
+            st.warning(
+                "The optional AI layer could not be loaded on this deployment, so the "
+                "strategic read and the AI query planner are unavailable. Every analysis, "
+                "chart and Ask ADA answer below is unaffected — none of them uses a model."
+            )
+            st.caption(AI_LAYER_ERROR)
+            st.link_button(
+                "Contribute on GitHub",
+                "https://github.com/saineshnakra/automated-data-analyst",
+                width="stretch",
+            )
+            return ""
         if server_api_key:
             st.success("Optional strategy agent is available on this deployment.")
             api_key = server_api_key
@@ -138,8 +163,8 @@ def maybe_generate_narrative(
     api_key: str,
     brief: BusinessBrief,
     business_context: str,
-) -> tuple[AINarrative | None, str | None]:
-    if not api_key:
+):
+    if not api_key or AI_LAYER_ERROR:
         return None, None
 
     payload = build_ai_payload(brief, context=business_context)
@@ -185,6 +210,8 @@ def plan_ai_query(
     api_key: str,
 ) -> QueryPlan | None:
     """Ask the optional model for a plan without executing it."""
+    if AI_LAYER_ERROR:
+        return None
     try:
         return plan_query_with_ai(
             question,

--- a/app.py
+++ b/app.py
@@ -13,7 +13,7 @@ from streamlit.errors import StreamlitSecretNotFoundError
 from analysis import column_profile
 from business_insights import BusinessBrief, analyze_business, build_business_report
 from demo_data import make_demo_data
-from file_io import list_excel_sheets, list_sample_datasets, read_tabular_file
+from file_io import list_excel_sheets, list_sample_datasets, read_tabular_file, safe_csv
 from nlq import QueryPlan, answer_question, suggested_questions
 from pipeline import (
     apply_focus,
@@ -590,7 +590,7 @@ with data_tab:
     )
     downloads[1].download_button(
         "Download cleaned data",
-        data=dataframe.to_csv(index=False).encode("utf-8"),
+        data=safe_csv(dataframe).encode("utf-8"),
         file_name="ada_cleaned_data.csv",
         mime="text/csv",
         width="stretch",

--- a/autovis.py
+++ b/autovis.py
@@ -19,6 +19,10 @@ from pandas.api.types import is_datetime64_any_dtype, is_numeric_dtype
 # Past this many classes a legend stops helping and a table reads better.
 MAX_SERIES = 4
 MAX_BARS = 25
+# A heatmap is a rectangle of cells and the browser is sent every one of them.
+# Two identifier-ish columns produce millions, which exceeds Streamlit's own
+# websocket message limit before it ever reaches a screen.
+MAX_HEATMAP_CELLS = 4_000
 # Beyond this a vertical axis cannot hold the labels.
 HORIZONTAL_BAR_THRESHOLD = 6
 LONG_LABEL_CHARACTERS = 12
@@ -30,7 +34,7 @@ Form = str
 class ChartSpec:
     """What to draw, and the reasoning that picked it."""
 
-    form: Form  # stat | line | area | bar | column | scatter | heatmap | table | none
+    form: Form  # stat | line | area | bar | column | histogram | scatter | heatmap | table | none
     rationale: str
     x: str | None = None
     y: str | None = None
@@ -140,6 +144,21 @@ def recommend_chart(
     # than any number of side-by-side bars.
     if len(categories) >= 2 and numbers:
         rows, columns_axis, measure = categories[0], categories[1], numbers[0]
+        cells = _distinct(dataframe, rows) * _distinct(dataframe, columns_axis)
+        if cells > MAX_HEATMAP_CELLS:
+            return ChartSpec(
+                form="table",
+                x=columns_axis,
+                y=rows,
+                color=measure,
+                aggregation=aggregation,
+                rationale=(
+                    f"{rows} and {columns_axis} would make a {cells:,}-cell grid. Past about "
+                    f"{MAX_HEATMAP_CELLS:,} cells a heatmap is unreadable and too large to "
+                    "send, so the numbers are shown as a table instead."
+                ),
+                notes=tuple(notes),
+            )
         return ChartSpec(
             form="heatmap",
             x=columns_axis,
@@ -219,13 +238,14 @@ def recommend_chart(
                 ),
             )
         return ChartSpec(
-            form="column",
+            form="histogram",
             x=measure,
             y=None,
             aggregation="count",
             rationale=(
-                f"The distribution of {measure}, because one measure on its own asks "
-                "how its values are spread rather than how they compare."
+                f"The distribution of {measure} in equal-width bins, because one measure "
+                "on its own asks how its values are spread rather than how they compare. "
+                "Counting each distinct value instead would draw one bar per row."
             ),
             notes=tuple(notes),
         )
@@ -262,10 +282,29 @@ def fold_small_series(
     """
     if frame.empty or column not in frame.columns:
         return frame
-    totals = frame.groupby(column, dropna=True)[value].sum().sort_values(ascending=False)
+    totals = (
+        frame.groupby(column, dropna=True, observed=True)[value].sum().sort_values(ascending=False)
+    )
     if len(totals) <= limit:
         return frame
     keep = set(totals.head(limit).index)
     folded = frame.copy()
-    folded[column] = folded[column].where(folded[column].isin(keep), "Other")
+    # A Categorical rejects a label that is not already one of its categories,
+    # and a column that genuinely contains "Other" would have the folded tail
+    # silently added to a real segment. Both are avoided by choosing a label
+    # the column does not already use and dropping the categorical dtype.
+    folded[column] = folded[column].astype(object)
+    label = _fold_label(set(totals.index))
+    folded[column] = folded[column].where(folded[column].isin(keep), label)
     return folded
+
+
+def _fold_label(existing: set) -> str:
+    """A name for the folded tail that is not already a real category."""
+    label = "Other"
+    suffix = 2
+    present = {str(value) for value in existing}
+    while label in present:
+        label = f"Other ({suffix})"
+        suffix += 1
+    return label

--- a/business_insights.py
+++ b/business_insights.py
@@ -754,7 +754,7 @@ def build_business_report(
         [
             "---",
             "Recommendations are deterministic interpretations of the calculations above, not causal proof.",
-            "Uploaded data was not sent to an external AI service.",
+            "Every figure above was computed locally with pandas.",
         ]
     )
     return "\n".join(lines)

--- a/business_insights.py
+++ b/business_insights.py
@@ -240,40 +240,89 @@ def _effective_segments(values: np.ndarray, total: float) -> float | None:
     return 1.0 / herfindahl if herfindahl > 0 else None
 
 
-def _segment_evidence(dataframe: pd.DataFrame, roles: ColumnRoles) -> tuple[Evidence, Evidence] | tuple[()]:
+def _shares_are_meaningful(values: np.ndarray) -> bool:
+    """A share of a total that parts of it subtract from is not a share.
+
+    All-positive is the ordinary case. All-negative is a cost or loss column,
+    where -6k of -20k is honestly 30%. Mixed signs are the case with no answer:
+    the denominator is a net figure the parts do not sum into, which is how a
+    segment ends up "contributing 2,000,000% of profit".
+    """
+    if not values.size:
+        return False
+    return bool((values >= 0).all() or (values <= 0).all())
+
+
+def _segment_evidence(dataframe: pd.DataFrame, roles: ColumnRoles) -> tuple[Evidence, ...]:
     segments = segment_frame(dataframe, roles, limit=100)
     if segments.empty:
         return ()
 
     total = float(segments["Value"].sum())
-    if total == 0:
+    if total == 0 or not np.isfinite(total):
         return ()
+    values = segments["Value"].to_numpy(dtype=float)
+    shares_hold = _shares_are_meaningful(values)
+    if not shares_hold:
+        # Without a usable denominator the only honest ordering is by size of
+        # the number itself, and no percentage may be quoted from it.
+        segments = segments.reindex(
+            segments["Value"].abs().sort_values(ascending=False).index
+        ).reset_index(drop=True)
+    elif total < 0:
+        # A cost column: the biggest contributor is the most negative one, not
+        # the one nearest zero that a descending sort puts on top.
+        segments = segments.sort_values("Value").reset_index(drop=True)
     leader = segments.iloc[0]
-    leader_share = float(leader["Value"] / total * 100)
-    top_three_share = float(segments.head(3)["Value"].sum() / total * 100)
+    leader_share = float(leader["Value"] / total * 100) if shares_hold else float("nan")
+    top_three_share = (
+        float(segments.head(3)["Value"].sum() / total * 100) if shares_hold else float("nan")
+    )
     effective = _effective_segments(segments["Value"].to_numpy(dtype=float), total)
     measure = roles.measure or "records"
     measure_values = dataframe[roles.measure].dropna() if roles.measure else None
     dimension = roles.dimension or "segment"
+    leader_amount = format_number(
+        float(leader["Value"]), roles.measure, column_values=measure_values
+    )
     return (
         Evidence(
             kind="leader",
             title=f"Leading {dimension.lower()}",
-            value=format_percentage(leader_share),
+            value=format_percentage(leader_share) if shares_hold else leader_amount,
             statement=(
-                f"{leader['Segment']} is the largest {dimension.lower()}, contributing "
-                f"{format_percentage(leader_share)} of {measure.lower()} "
-                f"({format_number(float(leader['Value']), roles.measure, column_values=measure_values)})."
+                (
+                    f"{leader['Segment']} is the largest {dimension.lower()}, contributing "
+                    f"{format_percentage(leader_share)} of {measure.lower()} ({leader_amount})."
+                )
+                if shares_hold
+                else (
+                    f"{leader['Segment']} is the largest {dimension.lower()} by size at "
+                    f"{leader_amount}. {measure} runs both positive and negative here, so no "
+                    f"share of the total can be quoted -- the parts do not add up to it."
+                )
             ),
-            calculation=f"{leader['Segment']} {measure} ÷ total {measure}",
-            tone="positive",
+            calculation=(
+                f"{leader['Segment']} {measure} ÷ total {measure}"
+                if shares_hold
+                else f"largest |{measure}| by {dimension}; share undefined on mixed signs"
+            ),
+            tone="positive" if shares_hold else "warning",
         ),
-        _concentration_evidence(
-            dimension=dimension,
-            measure=measure,
-            segment_count=len(segments),
-            top_three_share=top_three_share,
-            effective=effective,
+        # Concentration is a statement about shares. Without shares there is
+        # nothing to say, so the card is left out rather than printed as nan%.
+        *(
+            (
+                _concentration_evidence(
+                    dimension=dimension,
+                    measure=measure,
+                    segment_count=len(segments),
+                    top_three_share=top_three_share,
+                    effective=effective,
+                ),
+            )
+            if shares_hold
+            else ()
         ),
     )
 

--- a/business_insights.py
+++ b/business_insights.py
@@ -122,16 +122,25 @@ def _growth_evidence(dataframe: pd.DataFrame, roles: ColumnRoles) -> Evidence | 
     # A quarter is "Q4 2023", not "Oct 2023" -- which the anomaly card and the
     # chart axis already knew, so the brief was contradicting its own page.
     period = format_period(trend.iloc[-1]["Period"], series.frequency)
+    # With too few periods to judge completeness, the last one cannot be
+    # called complete -- a three-month file whose third month is half over
+    # was reporting a 50% collapse as settled fact.
+    completeness = "complete period" if series.completeness_checked else "period so far"
     measure = roles.measure or "Records"
     measure_values = dataframe[roles.measure].dropna() if roles.measure else None
     direction = "increased" if change >= 0 else "decreased"
     context = _movement_in_context(values, change)
+    if series.short_coverage:
+        context += (
+            f" The last period only reaches {series.short_coverage}, so part of this may be "
+            "missing data rather than a real move."
+        )
     return Evidence(
         kind="trend",
         title=f"Latest {measure.lower()} movement",
         value=format_percentage(change, signed=True),
         statement=(
-            f"{measure} {direction} {format_percentage(abs(change))} in the latest complete period "
+            f"{measure} {direction} {format_percentage(abs(change))} in the latest {completeness} "
             f"({period}), from {format_number(previous, roles.measure, column_values=measure_values)} to "
             f"{format_number(current, roles.measure, column_values=measure_values)}.{context}"
         ),

--- a/business_insights.py
+++ b/business_insights.py
@@ -149,10 +149,13 @@ def _change_driver_evidence(dataframe: pd.DataFrame, roles: ColumnRoles) -> Evid
     if gross_change == 0:
         return None
 
-    driver_name = str(changes.abs().idxmax())
-    previous_value = float(grouped.loc[driver_name, previous_period])
-    current_value = float(grouped.loc[driver_name, current_period])
-    driver_change = float(grouped.loc[driver_name, "Change"])
+    # Look the row up by its real index value; a boolean segment column has an
+    # index of True/False, and str() turned that into a KeyError.
+    driver_key = changes.abs().idxmax()
+    driver_name = str(driver_key)
+    previous_value = float(grouped.loc[driver_key, previous_period])
+    current_value = float(grouped.loc[driver_key, current_period])
+    driver_change = float(grouped.loc[driver_key, "Change"])
     direction = "increased" if driver_change > 0 else "decreased"
     sign = "+" if driver_change > 0 else "−"
 

--- a/business_insights.py
+++ b/business_insights.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 
 from aggregation import (
+    build_trend,
     preferred_frequency,
     segment_frame,
     segment_period_change,
@@ -82,27 +83,38 @@ def _movement_in_context(values: np.ndarray, change: float) -> str:
         return ""
 
     distance = abs(change - float(np.median(prior))) / spread
+    # The measurement is distance from the norm, not size. A flat month in a
+    # series that always moves 5% is unusual, but calling 0.0% "an unusually
+    # large swing" describes the opposite of what happened.
+    moved_more = abs(change) > typical
     if distance < 1.0:
         verdict = "This is within normal period-to-period variation"
     elif distance < 2.0:
-        verdict = "This is a larger swing than usual"
+        verdict = "This is a larger swing than usual" if moved_more else "This is quieter than usual"
     else:
-        verdict = "This is an unusually large swing"
+        verdict = (
+            "This is an unusually large swing"
+            if moved_more
+            else "This is an unusually quiet period for this series"
+        )
     return f" {verdict} — this series typically moves about {format_percentage(typical)} per period."
 
 
 def _growth_evidence(dataframe: pd.DataFrame, roles: ColumnRoles) -> Evidence | None:
-    trend = trend_frame(dataframe, roles)
+    series = build_trend(dataframe, roles)
+    trend = series.frame
     if len(trend) < 2:
         return None
 
     values = trend["Value"].to_numpy(dtype=float)
     previous = float(values[-2])
     current = float(values[-1])
-    if previous == 0:
+    if previous == 0 or not np.isfinite(previous) or not np.isfinite(current):
         return None
     change = (current - previous) / abs(previous) * 100
-    period = trend.iloc[-1]["Period"].strftime("%b %Y")
+    # A quarter is "Q4 2023", not "Oct 2023" -- which the anomaly card and the
+    # chart axis already knew, so the brief was contradicting its own page.
+    period = format_period(trend.iloc[-1]["Period"], series.frequency)
     measure = roles.measure or "Records"
     measure_values = dataframe[roles.measure].dropna() if roles.measure else None
     direction = "increased" if change >= 0 else "decreased"
@@ -687,26 +699,29 @@ def analyze_business(dataframe: pd.DataFrame, roles: ColumnRoles | None = None) 
         if leader := evidence_by_kind.get("leader"):
             kpis.append(KPI(f"Top {roles.dimension}", leader.value, "Share contributed by the leader"))
 
-    while len(kpis) < 4:
-        if roles.identifier and not any(item.label == f"Distinct {roles.identifier}" for item in kpis):
-            kpis.append(
-                KPI(
-                    f"Distinct {roles.identifier}",
-                    f"{dataframe[roles.identifier].nunique(dropna=True):,}",
-                    "Unique entities in the dataset",
-                )
+    # Back-fill towards four tiles from a finite list of fallbacks. The old
+    # loop ran until it had four and its last branch had no already-added
+    # guard, so a thin file rendered "Data completeness" three times and read
+    # as a broken page. Three real tiles beats four with two copies.
+    completeness = 1 - dataframe.isna().sum().sum() / max(dataframe.size, 1)
+    fallbacks = []
+    if roles.identifier:
+        fallbacks.append(
+            KPI(
+                f"Distinct {roles.identifier}",
+                f"{dataframe[roles.identifier].nunique(dropna=True):,}",
+                "Unique entities in the dataset",
             )
-        elif not any(item.label == "Records analyzed" for item in kpis):
-            kpis.append(KPI("Records analyzed", f"{len(dataframe):,}", "After conservative cleaning"))
-        else:
-            completeness = 1 - dataframe.isna().sum().sum() / max(dataframe.size, 1)
-            kpis.append(
-                KPI(
-                    "Data completeness",
-                    format_percentage(completeness * 100),
-                    "Share of populated cells",
-                )
-            )
+        )
+    fallbacks.append(KPI("Records analyzed", f"{len(dataframe):,}", "After conservative cleaning"))
+    fallbacks.append(
+        KPI("Data completeness", format_percentage(completeness * 100), "Share of populated cells")
+    )
+    for candidate in fallbacks:
+        if len(kpis) >= 4:
+            break
+        if not any(item.label == candidate.label for item in kpis):
+            kpis.append(candidate)
     kpis = kpis[:4]
 
     recommendations = _recommendations(evidence, roles)

--- a/business_insights.py
+++ b/business_insights.py
@@ -15,7 +15,14 @@ from aggregation import (
     trend_frame,
 )
 from anomalies import detect_anomalies
-from formatting import format_number, format_percentage, format_period, normalized_name
+from formatting import (
+    format_number,
+    format_percentage,
+    format_period,
+    is_percentage,
+    normalized_name,
+    percentage_outranks_currency,
+)
 from schema import TIME_PART_TOKENS, ColumnRoles, detect_roles, looks_like_identifier
 from timeseries import robust_scale
 
@@ -674,19 +681,23 @@ def analyze_business(dataframe: pd.DataFrame, roles: ColumnRoles | None = None) 
         measure_values = dataframe[roles.measure].dropna()
         total = float(measure_values.sum())
         average = float(measure_values.mean())
-        kpis.extend(
-            [
+        # Adding percentages up produces a number with no meaning: eleven
+        # months of margin do not total 1,189% of anything.
+        rate_like = is_percentage(roles.measure) and percentage_outranks_currency(roles.measure)
+        if not rate_like:
+            kpis.append(
                 KPI(
                     f"Total {roles.measure}",
                     format_number(total, roles.measure, column_values=measure_values),
                     "Across all analyzed records",
-                ),
-                KPI(
-                    f"Average {roles.measure}",
-                    format_number(average, roles.measure, column_values=measure_values),
-                    "Per non-missing record",
-                ),
-            ]
+                )
+            )
+        kpis.append(
+            KPI(
+                f"Average {roles.measure}",
+                format_number(average, roles.measure, column_values=measure_values),
+                "Per non-missing record",
+            )
         )
 
     if growth:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,10 +33,10 @@ engine from a plain Python script or a test, with no browser and no API key.
 |---|---|---|
 | **Presentation** | `app.py`, `ui.py` | Draws things. Calculates nothing. |
 | **Orchestration** | `pipeline.py` | Sequences the engine. Holds no business logic of its own. |
-| **Engine** | `analysis.py`, `schema.py`, `aggregation.py`, `timeseries.py`, `anomalies.py`, `forecasting.py`, `business_insights.py`, `nlq.py` | Pure functions over DataFrames. No I/O, no globals. |
+| **Engine** | `analysis.py`, `schema.py`, `aggregation.py`, `timeseries.py`, `anomalies.py`, `forecasting.py`, `business_insights.py`, `nlq.py`, `autovis.py` | Pure functions over DataFrames. No I/O, no globals. |
 | **Input** | `file_io.py`, `demo_data.py` | Parses and validates. No analysis. |
 | **Output formatting** | `formatting.py` | Decides how a number *looks*. Never changes what it *is*. |
-| **Optional AI** | `ai_insights.py` | The only file allowed to make a network call. |
+| **Optional AI** | `ai_insights.py` | The only file allowed to make a network call. Imported defensively: if it or its dependencies fail to load, the rest of the product still runs. |
 
 ## What each file owns
 
@@ -54,6 +54,7 @@ engine from a plain Python script or a test, with no browser and no API key.
 | `forecasting.py` | Baseline forecast, prediction band, backtest |
 | `business_insights.py` | Evidence cards, KPIs, recommendations, the executive brief |
 | `nlq.py` | Question → `QueryPlan` → local execution |
+| `autovis.py` | Picks the chart form for a set of columns, and the sentence saying why |
 | `formatting.py` | `format_number`, `format_period`, column-name helpers |
 | `ai_insights.py` | Typed Responses API calls for the query planner and strategic read |
 | `demo_data.py` | The deterministic synthetic dataset |

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -84,9 +84,11 @@ answer shows the calculation. See [Ask ADA](reference/ask-ada.md).
 
 ## Deterministic vs optional AI
 
-- **Deterministic** — everything computed with pandas on your machine. No
-  network, no API key. This is the whole product.
+- **Deterministic** — everything computed with pandas in-process. No network,
+  no API key. This is the whole product. (On the hosted demo the upload itself
+  reaches a Streamlit server; the analysis still runs there and nowhere else.)
 - **Optional AI** — two narrow extras that need an API key. They receive column
-  names, types, and already-computed evidence. They never receive your rows.
+  names, types, and already-computed evidence — including the segment names an
+  evidence sentence mentions. They never receive your rows.
 
 See [The optional AI layer](reference/ai-layer.md) and [Privacy](privacy.md).

--- a/docs/development.md
+++ b/docs/development.md
@@ -50,7 +50,8 @@ python -m unittest discover -s tests -p "test_nlq.py" -v
 | `test_significance.py` | Correlation intervals and rank divergence |
 | `test_nlq.py` | Question parsing and plan execution |
 | `test_ai_insights.py` | Typed output and the privacy contract |
-| `test_app.py` | Rendering smoke tests |
+| `test_autovis.py` | Chart-form choice and series folding |
+| `test_app.py` | Rendering smoke tests, and that the app survives without the AI layer |
 
 Tests use fake clients for anything model-related, so the suite needs no network
 and no API credits.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,9 +1,11 @@
 # FAQ
 
 **Does my data leave my machine?**
-No. Cleaning, schema detection, every chart, every evidence card, and every Ask
-ADA answer are computed locally with pandas. If you opt into the AI layer, only
-column schema and computed evidence are sent — never rows or cell values. See
+Not if you run ADA yourself — every calculation happens in-process with pandas
+and, without an API key, there is no network call. On the hosted demo your file
+is uploaded to a Streamlit server and held in memory for the session. If you opt
+into the AI layer, column schema and computed evidence are sent; your rows never
+are, though a segment name can appear inside an evidence sentence. See
 [Privacy](privacy.md).
 
 **Do I need an OpenAI API key?**

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -93,7 +93,7 @@ See [The optional AI layer](reference/ai-layer.md) for the full validation list.
 
 | Method | Scope |
 |---|---|
-| Sidebar field | That browser session only; never written to disk |
+| Sidebar field | Typed in the browser, posted to the server running ADA, and held in that session's memory — never written to disk. On the hosted demo, that server is Streamlit's |
 | `OPENAI_API_KEY` env var | The deployment |
 | `.streamlit/secrets.toml` | The deployment — gitignored, never commit it |
 
@@ -102,6 +102,13 @@ owner-funded key on a public app needs authentication and spending controls.
 
 ## Self-hosting
 
-ADA is a standard Streamlit app with no database and no persistence. Uploaded
-files live in memory for the session. Running it yourself means the deterministic
-path involves no third party at all.
+ADA is a standard Streamlit app with no database. Nothing is written to disk.
+
+Parsed uploads are held in a bounded in-memory cache — at most eight files, for
+up to an hour — so that re-running the page does not re-parse the same file.
+That cache belongs to the server process, not to your browser session, and it
+is why "nothing is persisted" is worth stating precisely rather than loosely.
+Restarting the app clears it.
+
+Running ADA yourself means the deterministic path involves no third party at
+all, and that cache lives on your own machine.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -5,12 +5,19 @@ see [SECURITY.md](../SECURITY.md).
 
 ## The short version
 
-**Without an API key, nothing leaves your machine.** Cleaning, schema detection,
-every chart, every evidence card, and every Ask ADA answer are computed locally
-with pandas.
+**Where "local" means depends on where ADA is running.** Run it on your own
+machine and nothing leaves it: cleaning, schema detection, every chart, every
+evidence card and every Ask ADA answer are computed in-process with pandas, and
+without an API key ADA makes no network call at all.
+
+**On the hosted demo, your upload reaches a Streamlit server.** That is what
+uploading to a website is. It lives in memory for the session and is never
+written to a database. Run ADA locally if that matters for your data.
 
 **With an API key, two optional calls become available.** Both send column
-schema and already-computed evidence. Neither sends your rows.
+schema and already-computed evidence. **Neither sends your rows.** An evidence
+sentence names the segment it describes, so a segment label — a customer name,
+a product name — can travel inside it. No other cell value does.
 
 ## What stays local, always
 

--- a/docs/reference/ai-layer.md
+++ b/docs/reference/ai-layer.md
@@ -12,8 +12,13 @@ optional; ADA is a complete analyst with no API key.
 | **Query planner** | Only when the rule parser cannot read a question | Column names, types, roles, and the question | A typed `AIQueryPlan` |
 | **Strategic read** | Only when the user presses the button | The computed brief — schema, evidence, recommendations | A typed `AINarrative` |
 
-Neither receives uploaded rows or cell values. Not a sample, not a preview, not
-the first five rows.
+Neither receives uploaded rows. Not a sample, not a preview, not the first five
+rows. What does travel is the text of the computed evidence, and an evidence
+sentence names the segment it is about — "Northwind is the largest customer" —
+so segment labels reach the model. Column names and types do too. No other cell
+value is serialized. `tests/test_ai_insights.py` pins this by putting a
+distinctive value in a non-segment column and asserting it never appears in
+either payload.
 
 ## What is actually sent
 

--- a/docs/reference/cleaning.md
+++ b/docs/reference/cleaning.md
@@ -19,10 +19,34 @@ in the cleaning audit table.
 | 5 | Trim text | Leading/trailing whitespace removed; empty strings become missing |
 | 6 | Infer dates | See below |
 | 7 | Infer numbers | See below |
-| 8 | Drop duplicate rows | Exact duplicates across all columns |
+| 8 | Count duplicate rows | Exact duplicates across all columns are **counted and kept** |
 
 If nothing analyzable survives, `clean_dataframe` raises `ValueError` rather
 than returning an empty frame.
+
+## Why duplicate rows are kept
+
+Two sales of the same item, for the same amount, on the same day are an
+ordinary Tuesday at a till — not a defect. Deleting them removes real revenue
+from every number on the page, silently, and on a point-of-sale file that can
+be half the total. So they are counted, reported in the cleaning audit as
+"Identical rows kept", and left alone.
+
+`clean_dataframe(frame, drop_duplicates=True)` opts in, for a caller that knows
+its rows carry a key.
+
+## Dates that could be read two ways
+
+`01/03/2024` is 1 March in most of the world and 3 January in the United States.
+When some value in the column settles it — anything above 12 in the first
+position — that reading wins outright. When nothing settles it, month-first is
+assumed **and the assumption is reported**, because a year of monthly figures
+collapsing into twelve days of January is the one error no later step can
+detect.
+
+Timezone offsets are dropped at this point, keeping the wall clock the file was
+written in. Converting to UTC first would move rows east of Greenwich into the
+previous calendar day, changing which period they belong to.
 
 ## The exported-index rule
 
@@ -41,13 +65,21 @@ might be a genuine counter.
 
 Inference happens per column, and only on text columns.
 
-**Dates** — attempted only when the column name contains `date`, `time`,
-`timestamp`, `created`, or `updated`. Converted when **at least 80%** of
-non-missing values parse as dates.
+**Dates** — a column named `date`, `time`, `timestamp`, `created` or `updated`
+is converted when **at least 80%** of non-missing values parse. A column with
+any other name is also tried, because dates arrive in columns called `Month`,
+`Period` and `FY`: a 50-value sample has to parse first, and then **at least
+95%** of the column. Numbers are tried before that second pass, so a column of
+bare years stays numeric instead of becoming the 1st of January in each.
 
-**Numbers** — converted when **at least 95%** of non-missing values parse as
-numbers. Skipped entirely when the name contains `id`, `code`, `zip`, `postal`,
-or `phone`.
+**Numbers** — converted when **at least 95%** of non-missing values parse.
+Whatever plain parsing cannot read is retried allowing the punctuation a
+finance export writes: thousands separators, a currency symbol, and
+parentheses for a negative. `$1,203.55` and `(48.10)` are numbers; the values
+that need this are the large ones, so leaving them out biases every total
+downwards. A value holding a slash is never read this way, so a date cannot
+become a very large integer. Skipped entirely when the name contains `id`,
+`code`, `zip`, `postal`, or `phone`.
 
 Why the difference in thresholds? Dates arrive in mixed formats and a stricter
 bar would reject real date columns. Numbers are unambiguous, so a column that is

--- a/docs/reference/evidence.md
+++ b/docs/reference/evidence.md
@@ -39,7 +39,8 @@ it. Order below is the order they are assembled.
 | `trend` | Latest period-over-period movement, in context of the series' own volatility | No date or measure |
 | `driver` | Which segment moved the measure most, and whether gross movement offsets | No segment |
 | `leader` | Largest segment and its share | No segment |
-| `concentration` | How concentrated the measure is across segments | Values negative or total ≤ 0 |
+| `concentration` | How concentrated the measure is across segments | Total is zero, or the segment values are mixed-sign (a share of a signed total is not a share) |
+| `leader` | *(mixed signs)* Largest segment by size, with no share quoted | — |
 | `anomaly` | The most severe flagged period | Under 8 periods, or nothing flagged |
 | `relationship` | Strongest numeric correlation, with a confidence interval | See thresholds below |
 | `outliers` | Share of extreme measure values | No measure |

--- a/docs/reference/formatting.md
+++ b/docs/reference/formatting.md
@@ -16,15 +16,23 @@ Every module that displays a number — the dashboard, the evidence cards, the
 chat answers, the Markdown report — calls the same two functions, so a figure
 reads identically everywhere it appears.
 
-## `format_number(value, column=None, compact=True)`
+## `format_number(value, column=None, *, compact=True, column_values=None)`
+
+`column_values` is the whole column the figure came from. It is what settles
+questions that cannot be answered one value at a time — whether a percentage
+column stores `0.25` or `25`, and whether a column named like a rate is really
+holding money.
 
 | Input | Output |
 |---|---|
 | `1_250_000, "Revenue"` | `$1.2M` |
+| `1.5e12, "Revenue"` | `$1.5T` |
+| `-1_200, "Expense Amount"` | `-$1.2K` |
 | `12_000, "Units"` | `12.0K` |
 | `1_250, "Orders"` | `1.2K` |
 | `45, "Units"` | `45` |
 | `45.5, "Score"` | `45.50` |
+| `0.33, "Profit Margin %"` | `33.0%` |
 | `float("nan")` | `—` |
 
 What it does:
@@ -61,23 +69,29 @@ are the same column name.
 
 Periods are named the way a reader would say them out loud.
 
+## Percentages and currencies
+
+Both are implemented, and both were harder than they looked.
+
+**Which reading wins.** A name can carry both signals: `Profit Margin %` holds
+a currency word and a percentage one. An explicit `%`, or a percentage word in
+the **head** position, settles it — so `Profit Margin` is a margin and
+`Margin Amount` is an amount. Matching is on whole words, so `rate` does not
+match `Corporate Revenue` and `eur` does not match `Europe Sales`.
+
+**0–1 versus 0–100** is settled **once per column** from `column_values`, never
+per value. Deciding per value rendered one column as `551.3%` on one row and
+`1.4K` on the next. The same column-level rule catches a column named like a
+ratio that is really holding money: above `MAX_PLAUSIBLE_PERCENTAGE` the whole
+column falls through to plain numbers rather than printing `1250000.0%`.
+
+**Sign placement.** A debt is `-$1.2M`, not `$-1.2M` — the minus belongs to the
+amount, not the currency.
+
 ## Known gaps
 
-Two things this module does **not** do yet:
-
-- **Percentages.** A column called `Margin %` or `Conversion Rate` prints as a
-  plain number. There is no unit, and no detection of whether the column stores
-  `0.25` or `25`.
-- **Currencies other than dollars.** `Cost (EUR)` and `Price GBP` both print
-  with a `$`.
-
-Tracked in [issue #7](https://github.com/saineshnakra/automated-data-analyst/issues/7).
-
-Both are harder than they look. Substring matching on `rate` also matches
-`Corporate Revenue`; substring matching on `eur` also matches `Europe Sales`.
-And the 0–1 versus 0–100 question has to be settled **once per column** from the
-value range, not per value — otherwise one series renders `0.9` as `90%` and
-`1.1` as `1.1%`.
+- A rate column gets no *total* KPI, because adding percentages up means
+  nothing. Its average still appears.
 
 ## Changing this
 

--- a/docs/reference/reading-files.md
+++ b/docs/reference/reading-files.md
@@ -20,10 +20,17 @@ empty file is rejected too.
 | Limit | Value | Where | What happens |
 |---|---|---|---|
 | File size | 25 MB | `MAX_UPLOAD_BYTES` in `app.py` | Upload refused with a message |
-| Rows analyzed | 250,000 | `MAX_ANALYSIS_ROWS` in `app.py` | First 250,000 kept, and the app says how many were skipped |
+| Rows analyzed | 250,000 | `MAX_ANALYSIS_ROWS` in `app.py` | The **most recent** 250,000 kept, and the app says how many older rows were skipped and what date range it analyzed |
 
 Both exist so a hosted deployment stays predictable. Change them if you run ADA
 yourself on bigger machines.
+
+Recency matters more than order of appearance. Exports are usually written
+oldest-first, so keeping the head of a long file analyzes the periods nobody is
+asking about — and then forecasts months the file already contains. Rows are
+selected by the detected date column where there is one, and from the end of
+the file where there is not. Cleaning runs before the cut, so the skipped count
+is the real number of rows dropped.
 
 ## How CSV parsing works
 

--- a/docs/reference/schema-detection.md
+++ b/docs/reference/schema-detection.md
@@ -37,16 +37,32 @@ Considers only numeric columns. Each gets a score:
 | Looks like an identifier | −20 |
 | Name is a time part (`year`, `month`, `week`, `day`, `hour`, `minute`, `quarter`) | −15 |
 
-Ties break on the proportion of non-missing values.
+**Ties break on the data, then on the name** — in that order: whether the
+column carries fractions (amounts do, postal codes and counters do not), then
+the proportion of non-missing values, then the column name alphabetically.
+The last step exists so that two exports of one table, written with the
+columns in different orders, cannot detect different measures. Nothing here
+may depend on column order.
 
-**Keyword weights** (`MEASURE_KEYWORDS`): `revenue` 14, `sales` 14, `gmv` 14,
-`profit` 13, `margin` 12, `amount` 11, `value` 10, `income` 10, `spend` 9,
-`cost` 8, `expense` 8, `price` 7, `quantity` 6, `units` 6, `orders` 6,
-`volume` 6, `balance` 6, `score` 4.
+**Keyword weights** (`MEASURE_KEYWORDS`): `revenue` 14, `mrr` 14, `arr` 14,
+`sales` 14, `gmv` 14, `turnover` 14, `profit` 13, `margin` 12, `amount` 11,
+`value` 10, `income` 10, `spend` 9, `total` 9, `cost` 8, `expense` 8,
+`price` 7, `fee` 7, `fare` 7, `quantity` 6, `units` 6, `orders` 6, `volume` 6,
+`balance` 6, `score` 4. Read `MEASURE_KEYWORDS` in `schema.py` for the
+authoritative list.
 
-The two penalties are what stop the obvious failures: `Invoice ID` outscoring
-`Revenue` because both are numeric, and a `Month` column being treated as the
-thing to measure.
+**How a name is scored.** The last word decides. `Product Category` is a
+category; `Product Container` is a container. A word found anywhere else in
+the name scores two thirds of its weight, so it can still win when nothing
+better is present. Before scoring, a trailing parenthesised annotation is
+removed — `Revenue (USD)` is revenue, not "usd" — and camelCase is split on
+the case boundary, so `netRevenue` scores like `net_revenue`.
+
+The two penalties stop the obvious failures: `Invoice ID` outscoring `Revenue`
+because both are numeric, and a `Month` column being treated as the thing to
+measure. The identifier penalty is itself head-word gated — `Invoice Amount`
+is an amount that happens to sit beside an invoice, so it keeps its score
+while `Invoice Number` does not.
 
 ## Picking the segment
 

--- a/file_io.py
+++ b/file_io.py
@@ -26,6 +26,31 @@ def list_sample_datasets() -> dict[str, Path]:
     return {label(path.stem): path for path in sorted(SAMPLES_DIRECTORY.glob("*.csv"))}
 
 
+# A spreadsheet reads a cell starting with any of these as a formula, so a
+# value carried out of an uploaded file can execute when the download is
+# opened. Only text is affected; numbers are written by pandas as numbers.
+FORMULA_LEADERS = ("=", "+", "-", "@", "\t", "\r")
+
+
+def safe_csv(dataframe: pd.DataFrame) -> str:
+    """Serialize to CSV without handing a spreadsheet a formula to run.
+
+    Text cells that begin like a formula are prefixed with an apostrophe,
+    which spreadsheets read as "this is text". The values are the user's own,
+    but a downloaded file gets forwarded, and the person who opens it did not
+    choose to run anything.
+    """
+    export = dataframe.copy()
+    for column in export.select_dtypes(include=["object", "string"]).columns:
+        values = export[column].astype("string")
+        risky = values.str.startswith(FORMULA_LEADERS, na=False)
+        export[column] = values.mask(risky, "'" + values.fillna(""))
+    export.columns = [
+        f"'{name}" if str(name).startswith(FORMULA_LEADERS) else name for name in export.columns
+    ]
+    return export.to_csv(index=False)
+
+
 def _validate(contents: bytes, filename: str) -> str:
     suffix = Path(filename).suffix.lower()
     if suffix not in SUPPORTED_SUFFIXES:

--- a/file_io.py
+++ b/file_io.py
@@ -47,6 +47,66 @@ def list_excel_sheets(contents: bytes, filename: str) -> list[str]:
         raise ValueError("The file is not a valid Excel workbook.") from error
 
 
+def _candidate_encodings(contents: bytes) -> tuple[str, ...]:
+    """A byte-order mark settles the encoding; without one, guess in order.
+
+    PowerShell's Export-Csv writes UTF-16 by default, and decoding that as
+    Latin-1 turns every column name into mojibake and every row into blanks,
+    which reaches the user as "no analyzable data" rather than as an error.
+    """
+    if contents[:2] in (b"\xff\xfe", b"\xfe\xff"):
+        return ("utf-16",)
+    if contents[:3] == b"\xef\xbb\xbf":
+        return ("utf-8-sig",)
+    return ("utf-8-sig", "utf-8", "latin-1")
+
+
+def _header_line(contents: bytes, encoding: str) -> str:
+    head = contents.split(b"\n", 1)[0]
+    return head.decode(encoding, errors="replace")
+
+
+def _resplit_single_column(parsed: pd.DataFrame, contents: bytes, encoding: str) -> pd.DataFrame:
+    """Re-read a semicolon- or tab-delimited file, but only when it is one.
+
+    The separator has to appear in the header line. Sniffing the body instead
+    splits an ordinary one-column file of sentences on the semicolons inside
+    them, which destroys the data silently -- a worse outcome than the
+    European CSV this rescue exists for.
+    """
+    if len(parsed.columns) != 1:
+        return parsed
+    header = _header_line(contents, encoding)
+    for separator in (";", "\t", "|"):
+        if separator not in header:
+            continue
+        candidate = pd.read_csv(BytesIO(contents), encoding=encoding, sep=separator, low_memory=False)
+        if len(candidate.columns) > 1:
+            return candidate
+    return parsed
+
+
+def _skip_title_row(parsed: pd.DataFrame, contents: bytes, encoding: str) -> pd.DataFrame:
+    """Use the second line as the header when the first is a report title.
+
+    Exported reports often carry a title above the table. Read as a header it
+    yields one column, and every real column is silently discarded.
+    """
+    if len(parsed.columns) > 1 or parsed.empty:
+        return parsed
+    lines = contents.split(b"\n")[:3]
+    if len(lines) < 3:
+        return parsed
+    title, header, first_row = (line.decode(encoding, errors="replace") for line in lines)
+    # Only a comma is treated as the delimiter here. A one-column file of
+    # sentences containing semicolons is a real file, and re-reading it as a
+    # table would shred it -- the mistake this rescue is meant to prevent.
+    if "," in title or not header.count(",") or header.count(",") != first_row.count(","):
+        return parsed
+    candidate = pd.read_csv(BytesIO(contents), encoding=encoding, header=1, low_memory=False)
+    return candidate if len(candidate.columns) > 1 else parsed
+
+
 def read_tabular_file(
     contents: bytes,
     filename: str,
@@ -65,18 +125,11 @@ def read_tabular_file(
             raise ValueError("The file is not a valid Excel workbook.") from error
 
     parse_errors: list[Exception] = []
-    for encoding in ("utf-8-sig", "utf-8", "latin-1"):
+    for encoding in _candidate_encodings(contents):
         try:
             parsed = pd.read_csv(BytesIO(contents), encoding=encoding, low_memory=False)
-            sample = contents[:4096]
-            if len(parsed.columns) == 1 and any(separator in sample for separator in (b";", b"\t")):
-                parsed = pd.read_csv(
-                    BytesIO(contents),
-                    encoding=encoding,
-                    sep=None,
-                    engine="python",
-                )
-            return parsed
+            parsed = _resplit_single_column(parsed, contents, encoding)
+            return _skip_title_row(parsed, contents, encoding)
         except (UnicodeDecodeError, pd.errors.ParserError) as error:
             parse_errors.append(error)
     raise ValueError("The file could not be parsed as CSV.") from parse_errors[-1]

--- a/forecasting.py
+++ b/forecasting.py
@@ -170,7 +170,13 @@ def build_forecast(
     method = "Theil–Sen trendline"
     if seasonal:
         method += " + month-of-year seasonality"
-    method += f" · band = ±{BAND_DEVIATIONS:g} robust deviations, widening with horizon"
+    if scale > 0:
+        method += f" · band = ±{BAND_DEVIATIONS:g} robust deviations, widening with horizon"
+    else:
+        # A history with no variation gives a zero-width band. Drawing that as
+        # a line and captioning it as a widening interval claims a certainty
+        # nothing here supports.
+        method += " · history shows no variation, so no uncertainty band could be estimated"
 
     return Forecast(
         periods=tuple(pd.Timestamp(period) for period in future_periods),
@@ -186,7 +192,9 @@ def _backtest(periods: pd.DatetimeIndex, values: np.ndarray, *, monthly: bool) -
     """Refit on a training split and score the held-out tail honestly."""
     count = len(values)
     holdout = min(max(3, count // 5), count - MIN_PERIODS + 3)
-    if count - holdout < 5:
+    # periods[:-0] is the whole array, not "everything but nothing", so a
+    # holdout that resolves to zero or less trained on an empty split.
+    if holdout < 1 or count - holdout < 5:
         return Backtest(mape=None, mase=None, holdout_periods=0, periods_without_mape=0)
 
     train_periods, train_values = periods[:-holdout], values[:-holdout]

--- a/formatting.py
+++ b/formatting.py
@@ -108,6 +108,24 @@ def _percentage_uses_fraction_scale(
     return bool(values.min() >= 0 and values.max() <= 1)
 
 
+# Beyond a quadrillion no reader is counting the commas, and a total like
+# 3.6e20 rendered as "360,000,000,000.0B" says less than the exponent does.
+SCALES = ((1_000_000_000_000_000, "e15"), (1_000_000_000_000, "T"),
+          (1_000_000_000, "B"), (1_000_000, "M"), (1_000, "K"))
+
+
+def _compact_magnitude(absolute: float, *, compact: bool) -> str:
+    """Render a positive magnitude on the largest scale that fits, or "" ."""
+    if not compact:
+        return ""
+    if absolute >= 1_000_000_000_000_000:
+        return f"{absolute:.3g}"
+    for threshold, suffix in SCALES[1:]:
+        if absolute >= threshold:
+            return f"{absolute / threshold:,.1f}{suffix}"
+    return ""
+
+
 def format_number(
     value: float,
     column: str | None = None,
@@ -121,22 +139,12 @@ def format_number(
 
     # Currency semantics always take precedence over percentage semantics.
     if is_currency(column):
-        absolute = abs(value)
+        sign = "-" if value < 0 else ""
         prefix = currency_symbol(column)
-        suffix = ""
-        scaled = value
-
-        if compact and absolute >= 1_000_000_000:
-            scaled, suffix = value / 1_000_000_000, "B"
-        elif compact and absolute >= 1_000_000:
-            scaled, suffix = value / 1_000_000, "M"
-        elif compact and absolute >= 1_000:
-            scaled, suffix = value / 1_000, "K"
-
-        if suffix:
-            return f"{prefix}{scaled:,.1f}{suffix}"
-
-        return f"{prefix}{value:,.2f}"
+        body = _compact_magnitude(abs(value), compact=compact)
+        # The minus sign belongs to the amount, not to the currency: a debt is
+        # -$1.2M, never $-1.2M.
+        return f"{sign}{prefix}{body}" if body else f"{sign}{prefix}{abs(value):,.2f}"
 
     if is_percentage(column):
         if _percentage_uses_fraction_scale(value, column_values):
@@ -146,19 +154,10 @@ def format_number(
         # Falls through: a ratio-named column holding a currency-sized number
         # is reported as a plain number rather than an absurd percentage.
 
-    absolute = abs(value)
-    scaled = value
-    suffix = ""
-
-    if compact and absolute >= 1_000_000_000:
-        scaled, suffix = value / 1_000_000_000, "B"
-    elif compact and absolute >= 1_000_000:
-        scaled, suffix = value / 1_000_000, "M"
-    elif compact and absolute >= 1_000:
-        scaled, suffix = value / 1_000, "K"
-
-    if suffix:
-        return f"{scaled:,.1f}{suffix}"
+    sign = "-" if value < 0 else ""
+    body = _compact_magnitude(abs(value), compact=compact)
+    if body:
+        return f"{sign}{body}"
 
     if float(value).is_integer():
         return f"{int(value):,}"

--- a/formatting.py
+++ b/formatting.py
@@ -43,9 +43,16 @@ PERCENTAGE_TOKENS = {"rate", "margin", "ratio"}
 MAX_PLAUSIBLE_PERCENTAGE = 1_000.0
 
 
+# "netRevenue" and "NetRevenue" are one word to str.lower() and two to a
+# reader. Splitting on the case boundary makes camelCase exports score the
+# same as snake_case ones.
+_CAMEL_BOUNDARY = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
+
+
 def normalized_name(name: str) -> str:
     """Column names compared on meaning rather than punctuation."""
-    return " ".join(name.lower().replace("_", " ").replace("-", " ").split())
+    spaced = _CAMEL_BOUNDARY.sub(" ", str(name))
+    return " ".join(spaced.lower().replace("_", " ").replace("-", " ").split())
 
 
 def _name_tokens(name: str) -> set[str]:
@@ -71,6 +78,36 @@ def is_percentage(column: str | None) -> bool:
     tokens = _name_tokens(column)
 
     return "%" in name or bool(tokens & PERCENTAGE_TOKENS)
+
+
+def percentage_outranks_currency(column: str | None) -> bool:
+    """Decide which reading wins when a name carries signals for both.
+
+    "Profit Margin %" holds both a currency word and a percentage one. The
+    explicit sign, or a percentage word in the head position, settles it: the
+    last word says what the column is and the earlier ones only qualify it, so
+    "Profit Margin" is a margin and "Margin Amount" is an amount.
+    """
+    if not column:
+        return False
+    name = normalized_name(column)
+    if "%" in name:
+        return True
+    words = name.split()
+    return bool(words) and words[-1] in PERCENTAGE_TOKENS
+
+
+def _column_reads_as_percentage(value: float, column_values: pd.Series | None) -> bool:
+    """Judge plausibility once for the column, not once per value.
+
+    Deciding per value rendered the same column as "551.3%" on one row and
+    "1.4K" on the next, which is not a unit anybody can read.
+    """
+    if column_values is not None:
+        values = pd.to_numeric(column_values, errors="coerce").dropna()
+        if not values.empty:
+            return bool(values.abs().max() <= MAX_PLAUSIBLE_PERCENTAGE)
+    return abs(value) <= MAX_PLAUSIBLE_PERCENTAGE
 
 
 def currency_symbol(column: str | None) -> str:
@@ -137,7 +174,13 @@ def format_number(
     if not np.isfinite(value):
         return "—"
 
-    # Currency semantics always take precedence over percentage semantics.
+    if is_percentage(column) and percentage_outranks_currency(column):
+        if _percentage_uses_fraction_scale(value, column_values):
+            return f"{value * 100:.1f}%"
+        if _column_reads_as_percentage(value, column_values):
+            return f"{value:.1f}%"
+
+    # Otherwise currency semantics take precedence over percentage semantics.
     if is_currency(column):
         sign = "-" if value < 0 else ""
         prefix = currency_symbol(column)
@@ -149,7 +192,7 @@ def format_number(
     if is_percentage(column):
         if _percentage_uses_fraction_scale(value, column_values):
             return f"{value * 100:.1f}%"
-        if abs(value) <= MAX_PLAUSIBLE_PERCENTAGE:
+        if _column_reads_as_percentage(value, column_values):
             return f"{value:.1f}%"
         # Falls through: a ratio-named column holding a currency-sized number
         # is reported as a plain number rather than an absurd percentage.

--- a/nlq.py
+++ b/nlq.py
@@ -105,6 +105,9 @@ MONTH_NAMES = {
 
 MAX_FILTER_CANDIDATES = 200
 BREAKDOWN_LIMIT = 12
+# Rows whose segment is blank still hold measure values, so they are shown
+# under a label rather than deleted out of the denominator.
+UNLABELLED = "(not recorded)"
 
 QUERY_STOPWORDS = {
     "a", "about", "across", "all", "and", "are", "by", "can", "do", "does", "each",
@@ -416,7 +419,14 @@ def _grouped_frame(
     dataframe: pd.DataFrame, plan: QueryPlan, value_label: str
 ) -> pd.DataFrame:
     assert plan.dimension is not None
-    working = dataframe.dropna(subset=[plan.dimension])
+    # Rows with no label are a group, not a rounding error. Dropping them and
+    # then taking percentages against what is left reports a share of a total
+    # the reader never saw.
+    labelled = dataframe.copy()
+    labelled[plan.dimension] = labelled[plan.dimension].astype(object).where(
+        labelled[plan.dimension].notna(), UNLABELLED
+    )
+    working = labelled
     if plan.aggregation == "count" or not plan.measure:
         grouped = working.groupby(plan.dimension, as_index=False).size()
         grouped.columns = [plan.dimension, value_label]
@@ -425,8 +435,12 @@ def _grouped_frame(
         grouped.columns = [plan.dimension, value_label]
     grouped = grouped.sort_values(value_label, ascending=plan.ascending)
     if plan.aggregation in ("sum", "count"):
-        total = float(grouped[value_label].sum())
-        if total:
+        values = grouped[value_label].to_numpy(dtype=float)
+        total = float(values.sum())
+        # A share is only a share when every part carries the same sign as the
+        # whole. Mixed signs give 500% and -250% from arithmetic that is
+        # working exactly as written.
+        if total and ((values >= 0).all() or (values <= 0).all()):
             grouped["Share %"] = (grouped[value_label] / total * 100).round(1)
     return grouped.reset_index(drop=True)
 

--- a/nlq.py
+++ b/nlq.py
@@ -493,6 +493,18 @@ def execute_plan(plan: QueryPlan, dataframe: pd.DataFrame, roles: ColumnRoles) -
         value = _aggregate_series(working[plan.measure], plan.aggregation)
         label = AGGREGATION_LABELS[plan.aggregation]
         rows = int(working[plan.measure].notna().sum())
+        if rows == 0:
+            # Summing nothing gives 0, which reads as a measured zero rather
+            # than as an absence.
+            return QueryAnswer(
+                question="",
+                plan=plan,
+                answer=(
+                    f"{plan.measure} has no values{_phrase(applied)}, so there is "
+                    "nothing to total."
+                ),
+                calculation=f"0 non-missing {plan.measure} values{scope}",
+            )
         return QueryAnswer(
             question="",
             plan=plan,
@@ -514,9 +526,12 @@ def execute_plan(plan: QueryPlan, dataframe: pd.DataFrame, roles: ColumnRoles) -
         leader_value = float(leader[value_label])
         direction = "lowest" if plan.ascending else "leading"
         share_note = f" ({leader['Share %']:.1f}% of the total)" if "Share %" in table.columns else ""
+        # A row count is not money, whatever the measure column is called.
+        counted = value_label == "Rows"
         answer = (
             f"{leader[plan.dimension]} is the {direction} {plan.dimension} by {value_label.lower()}"
-            f"{_phrase(applied)} at {format_number(leader_value, plan.measure)}{share_note}."
+            f"{_phrase(applied)} at "
+            f"{format_number(leader_value, None if counted else plan.measure)}{share_note}."
         )
         order = "ascending" if plan.ascending else "descending"
         return QueryAnswer(
@@ -524,8 +539,11 @@ def execute_plan(plan: QueryPlan, dataframe: pd.DataFrame, roles: ColumnRoles) -
             plan=plan,
             answer=answer,
             calculation=(
-                f"{plan.aggregation}({plan.measure or 'rows'}) by {plan.dimension}, "
-                f"{order}, showing {len(table)}{scope}"
+                # value_label already records whether rows or the measure were
+                # aggregated; naming count(<measure>) when .size() ran flipped
+                # which group won.
+                f"{'row count' if value_label == 'Rows' else f'{plan.aggregation}({plan.measure})'}"
+                f" by {plan.dimension}, {order}, showing {len(table)}{scope}"
             ),
             table=table,
             chart="bar",
@@ -552,12 +570,18 @@ def execute_plan(plan: QueryPlan, dataframe: pd.DataFrame, roles: ColumnRoles) -
                 calculation=f"trend needs at least 2 periods{scope}",
             )
         first, last = float(trend.iloc[0]["Value"]), float(trend.iloc[-1]["Value"])
-        change = (last - first) / abs(first) * 100 if first else 0.0
         grain_name = {"D": "day", "W": "week", "M": "month", "Q": "quarter", "Y": "year"}.get(grain, "period")
+        # Growing from nothing has no percentage. Printing +0.0% beside two
+        # different numbers contradicts the rest of the sentence.
+        movement = (
+            f"{(last - first) / abs(first) * 100:+.1f}% across {len(trend)} {grain_name}s"
+            if first
+            else f"across {len(trend)} {grain_name}s, from a starting period of zero"
+        )
         answer = (
             f"{plan.measure or 'Records'} per {grain_name}{_phrase(applied)} moved from "
             f"{format_number(first, plan.measure)} to {format_number(last, plan.measure)} "
-            f"({change:+.1f}% across {len(trend)} {grain_name}s)."
+            f"({movement})."
         )
         return QueryAnswer(
             question="",
@@ -629,7 +653,27 @@ def _execute_growth(
                 "Latest": pivot[current_period].to_numpy(dtype=float),
             }
         )
+        # A percentage from zero is undefined, but a segment that went from
+        # nothing to something is usually the most newsworthy row in the file.
+        # It leaves the ranking and keeps its sentence.
+        from_nothing = result[(result["Previous"] == 0) & (result["Latest"] != 0)]
         result = result[result["Previous"] != 0]
+        if result.empty and not from_nothing.empty:
+            newest = from_nothing.loc[from_nothing["Latest"].abs().idxmax()]
+            return QueryAnswer(
+                question="",
+                plan=plan,
+                answer=(
+                    f"No {plan.dimension} has a growth rate this period, because every one "
+                    f"of them started from zero. The largest new arrival is "
+                    f"{newest[plan.dimension]} at "
+                    f"{format_number(float(newest['Latest']), measure)}."
+                ),
+                calculation=(
+                    f"per-{plan.dimension} growth undefined from a zero base; "
+                    f"{len(from_nothing)} segment(s) started at zero{scope}"
+                ),
+            )
         if result.empty:
             return QueryAnswer(
                 question="",
@@ -647,6 +691,14 @@ def _execute_growth(
             f"({format_number(float(leader['Previous']), measure)} → "
             f"{format_number(float(leader['Latest']), measure)}) in the latest period."
         )
+        if not from_nothing.empty:
+            newest = from_nothing.loc[from_nothing["Latest"].abs().idxmax()]
+            names = ", ".join(str(name) for name in from_nothing[plan.dimension])
+            answer += (
+                f" {len(from_nothing)} segment(s) are left out of the ranking because they "
+                f"started from zero ({names}); the largest is {newest[plan.dimension]} at "
+                f"{format_number(float(newest['Latest']), measure)}."
+            )
         return QueryAnswer(
             question="",
             plan=plan,

--- a/nlq.py
+++ b/nlq.py
@@ -358,6 +358,25 @@ def parse_question(question: str, dataframe: pd.DataFrame, roles: ColumnRoles) -
     return None
 
 
+class TimeScopeUnavailable(Exception):
+    """A year or month was asked for in a file that has no date column."""
+
+
+# Full names by number. Deriving these by searching MONTH_NAMES backwards used
+# to drop May, whose only spelling is three letters long, leaving the scope
+# label empty in the answer sentence.
+MONTH_LABELS = {
+    1: "January", 2: "February", 3: "March", 4: "April", 5: "May", 6: "June",
+    7: "July", 8: "August", 9: "September", 10: "October", 11: "November", 12: "December",
+}
+
+
+def _when_label(plan: QueryPlan) -> str:
+    month = MONTH_LABELS.get(plan.month) if plan.month else None
+    year = str(plan.year) if plan.year else None
+    return " ".join(part for part in (month, year) if part)
+
+
 def _apply_filters(
     dataframe: pd.DataFrame, plan: QueryPlan, roles: ColumnRoles
 ) -> tuple[pd.DataFrame, list[str]]:
@@ -369,19 +388,19 @@ def _apply_filters(
         mask = working[value_filter.column].astype(str).isin(value_filter.values)
         working = working.loc[mask]
         applied.append(f"{value_filter.column} in ({', '.join(value_filter.values)})")
-    if roles.date and roles.date in working.columns and (plan.year or plan.month):
+    if plan.year or plan.month:
+        if not roles.date or roles.date not in working.columns:
+            # Returning the all-time figure under a sentence that names a year
+            # is the worst available answer, so the scope is reported as
+            # impossible instead of dropped.
+            raise TimeScopeUnavailable(_when_label(plan))
         dates = working[roles.date]
         if plan.year:
             working = working.loc[dates.dt.year == plan.year]
             dates = working[roles.date]
         if plan.month:
             working = working.loc[dates.dt.month == plan.month]
-        month_name = next(
-            (name.title() for name, number in MONTH_NAMES.items() if number == plan.month and len(name) > 3),
-            None,
-        )
-        when = " ".join(part for part in (month_name, str(plan.year) if plan.year else None) if part)
-        applied.append(f"{roles.date} in {when}")
+        applied.append(f"{roles.date} in {_when_label(plan)}")
     return working, applied
 
 
@@ -418,7 +437,18 @@ def execute_plan(plan: QueryPlan, dataframe: pd.DataFrame, roles: ColumnRoles) -
         if column is not None and column not in dataframe.columns:
             raise ValueError(f"Unknown column in plan: {column}")
 
-    working, applied = _apply_filters(dataframe, plan, roles)
+    try:
+        working, applied = _apply_filters(dataframe, plan, roles)
+    except TimeScopeUnavailable as unavailable:
+        return QueryAnswer(
+            question="",
+            plan=plan,
+            answer=(
+                f"This file has no date column, so I cannot narrow the answer to "
+                f"{unavailable}. Set a date in ADA's schema detection and ask again."
+            ),
+            calculation=f"no date column available to scope to {unavailable}",
+        )
     scope = _scoped(applied)
     if working.empty:
         return QueryAnswer(

--- a/pipeline.py
+++ b/pipeline.py
@@ -17,21 +17,51 @@ class PreparedAnalysis:
     cleaning_report: CleaningReport
     detected_roles: ColumnRoles
     truncated_rows: int
+    analyzed_from: pd.Timestamp | None = None
+    analyzed_to: pd.Timestamp | None = None
 
     def analyze(self, roles: ColumnRoles | None = None) -> BusinessBrief:
         return analyze_business(self.dataframe, roles or self.detected_roles)
 
 
+def _most_recent(dataframe: pd.DataFrame, date_column: str | None, row_limit: int) -> pd.DataFrame:
+    """Keep the newest rows, not the first ones.
+
+    Exports are usually written oldest-first, so taking the head of a long
+    file analyzes the periods nobody is asking about and drops the ones they
+    are -- and then forecasts months the file already contains. When a date
+    column is available the newest rows are selected by date; otherwise the
+    end of the file is the best available proxy for the recent end of it.
+    """
+    if len(dataframe) <= row_limit:
+        return dataframe
+    if date_column and date_column in dataframe.columns:
+        order = dataframe[date_column].rank(method="first", ascending=False, na_option="bottom")
+        return dataframe.loc[order <= row_limit]
+    return dataframe.tail(row_limit)
+
+
 def prepare_analysis(raw_dataframe: pd.DataFrame, *, row_limit: int) -> PreparedAnalysis:
-    """Bound work, clean data, and detect its likely business schema."""
-    original_rows = len(raw_dataframe)
-    bounded = raw_dataframe.head(row_limit).copy() if original_rows > row_limit else raw_dataframe
-    dataframe, cleaning_report = clean_dataframe(bounded)
+    """Clean the data, keep the most recent slice of it, and detect its schema."""
+    dataframe, cleaning_report = clean_dataframe(raw_dataframe)
+    roles = detect_roles(dataframe)
+
+    available = len(dataframe)
+    dataframe = _most_recent(dataframe, roles.date, row_limit).reset_index(drop=True)
+    if len(dataframe) < available:
+        # Roles are detected on everything, but the numeric and dimension
+        # candidates have to describe the rows actually being analyzed.
+        roles = detect_roles(dataframe)
+
+    dated = roles.date is not None and roles.date in dataframe.columns
+    span = dataframe[roles.date].dropna() if dated else pd.Series(dtype="datetime64[ns]")
     return PreparedAnalysis(
         dataframe=dataframe,
         cleaning_report=cleaning_report,
-        detected_roles=detect_roles(dataframe),
-        truncated_rows=max(original_rows - row_limit, 0),
+        detected_roles=roles,
+        truncated_rows=available - len(dataframe),
+        analyzed_from=span.min() if not span.empty else None,
+        analyzed_to=span.max() if not span.empty else None,
     )
 
 
@@ -99,8 +129,10 @@ def cleaning_audit_frame(report: CleaningReport) -> pd.DataFrame:
             ["Empty columns removed", report.empty_columns_removed],
             ["Exported index columns removed", report.index_columns_removed],
             ["Duplicate rows removed", report.duplicate_rows_removed],
+            ["Identical rows kept", report.duplicate_rows_found - report.duplicate_rows_removed],
             ["Numeric columns inferred", report.numeric_columns_inferred],
             ["Datetime columns inferred", report.datetime_columns_inferred],
+            ["Date values that could not be read", report.unparsed_date_cells],
         ],
         columns=["Operation", "Count"],
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,11 @@
+[project]
+name = "automated-data-analyst"
+version = "0.1.0"
+description = "ADA: an AI data analyst for spreadsheets, where every number shows its calculation."
+requires-python = ">=3.11"
+readme = "README.md"
+license = { file = "LICENSE" }
+
 [tool.ruff]
 line-length = 110
 target-version = "py311"

--- a/samples/README.md
+++ b/samples/README.md
@@ -30,6 +30,7 @@ Each one is shaped to exercise a different part of the analysis.
 
 ## Regenerating
 
-These files are committed so they can be downloaded straight from GitHub.
-They are produced from fixed seeds, so regenerating gives byte-identical
-output. See `demo_data.py` for the same approach used by the built-in demo.
+These files are committed so they can be downloaded straight from GitHub, and
+they are the version of record — there is no generator script in the repository
+to reproduce them from. `demo_data.py` shows the fixed-seed approach the
+built-in demo uses, if you want to build a sample of your own the same way.

--- a/schema.py
+++ b/schema.py
@@ -86,6 +86,13 @@ TIME_PART_TOKENS = ("year", "month", "week", "day", "hour", "minute", "quarter")
 _ANNOTATION = re.compile(r"\s*[(\[][^)\]]*[)\]]\s*$")
 
 
+DATE_NAME_TOKENS = ("date", "time", "timestamp", "created", "updated")
+
+
+def _named_like_a_date(name: str) -> bool:
+    return any(token in normalized_name(name).split() for token in DATE_NAME_TOKENS)
+
+
 def _head_words(name: str) -> list[str]:
     """Words of a column name, with any trailing annotation removed."""
     return normalized_name(_ANNOTATION.sub("", str(name))).split()
@@ -170,6 +177,11 @@ def detect_roles(dataframe: pd.DataFrame) -> ColumnRoles:
     dimension_candidates: list[tuple[int, int, str]] = []
     for column in dataframe.columns:
         if column == date or column in numeric:
+            continue
+        if _named_like_a_date(column):
+            # ADA tried to parse this as a date and could not. Promoting it to
+            # "business segment" produced evidence reading "2024-06-11 is the
+            # largest date", which is not a finding about the business.
             continue
         series = dataframe[column]
         unique = int(series.nunique(dropna=True))

--- a/schema.py
+++ b/schema.py
@@ -10,11 +10,12 @@ a measure, and a column called "Value" may be either.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 
 import numpy as np
 import pandas as pd
-from pandas.api.types import is_datetime64_any_dtype
+from pandas.api.types import is_bool_dtype, is_datetime64_any_dtype
 
 from formatting import normalized_name
 
@@ -80,6 +81,16 @@ IDENTIFIER_TOKENS = ("id", "uuid", "key", "code", "number", "invoice", "order")
 TIME_PART_TOKENS = ("year", "month", "week", "day", "hour", "minute", "quarter")
 
 
+# A trailing unit or annotation is not the head noun. "Revenue (USD)" is
+# revenue; scoring it on "usd" let an unrelated column take the measure role.
+_ANNOTATION = re.compile(r"\s*[(\[][^)\]]*[)\]]\s*$")
+
+
+def _head_words(name: str) -> list[str]:
+    """Words of a column name, with any trailing annotation removed."""
+    return normalized_name(_ANNOTATION.sub("", str(name))).split()
+
+
 def _keyword_score(name: str, keywords: dict[str, int]) -> int:
     """Score a column name, trusting its last word most.
 
@@ -88,7 +99,7 @@ def _keyword_score(name: str, keywords: dict[str, int]) -> int:
     a packaging attribute that scored just as high as the real product
     dimension while both merely contained the word "product".
     """
-    words = normalized_name(name).split()
+    words = _head_words(name)
     if not words:
         return 0
     head_score = keywords.get(words[-1], 0)
@@ -101,8 +112,13 @@ def looks_like_identifier(name: str, series: pd.Series) -> bool:
         # "Order Date" carries an identifier token and its values are as unique
         # as any key, but a date names a moment, not a row.
         return False
-    normalized = normalized_name(name)
-    token_match = any(token in normalized.split() for token in IDENTIFIER_TOKENS)
+    words = _head_words(name)
+    if words and words[-1] in MEASURE_KEYWORDS:
+        # The last word decides here for the same reason it decides a measure
+        # score: "Invoice Amount" is an amount that happens to sit beside an
+        # invoice, and reading it as a key costs the file its real metric.
+        return False
+    token_match = any(token in words for token in IDENTIFIER_TOKENS)
     unique_ratio = series.nunique(dropna=True) / max(int(series.notna().sum()), 1)
     return token_match and unique_ratio >= 0.8
 
@@ -133,11 +149,22 @@ def detect_roles(dataframe: pd.DataFrame) -> ColumnRoles:
         if any(token == name or name.endswith(f" {token}") for token in TIME_PART_TOKENS):
             score -= 15
         non_null_ratio = float(series.notna().mean())
-        measure_candidates.append((score, non_null_ratio, column))
+        # Amounts carry fractions; postal codes and counters do not. It is a
+        # weak signal, so it only breaks ties -- but it breaks them on the
+        # data, where the fallback was breaking them on column order.
+        continuous = float(
+            not is_bool_dtype(series) and bool((series.dropna() % 1 != 0).any())
+        )
+        measure_candidates.append((score, continuous, non_null_ratio, column))
 
     measure = None
     if measure_candidates:
-        measure = max(measure_candidates, key=lambda candidate: (candidate[0], candidate[1]))[2]
+        # The column name is the final tiebreak so that two exports of one
+        # table, written in different column orders, detect the same measure.
+        measure = min(
+            measure_candidates,
+            key=lambda candidate: (-candidate[0], -candidate[1], -candidate[2], candidate[3]),
+        )[3]
 
     dimensions: list[str] = []
     dimension_candidates: list[tuple[int, int, str]] = []

--- a/tests/test_ai_insights.py
+++ b/tests/test_ai_insights.py
@@ -11,6 +11,7 @@ from ai_insights import (
     AINarrative,
     AIQueryFilter,
     AIQueryPlan,
+    _to_query_plan,
     build_ai_payload,
     build_planner_payload,
     describe_query_plan,
@@ -106,6 +107,99 @@ class AIInsightTests(unittest.TestCase):
         self.assertIn("Validate the leading segment", report)
         self.assertIn("gpt-5.6-luna", report)
         self.assertIn("raw rows were not sent", report)
+
+
+class PlanValidationTests(unittest.TestCase):
+    """A plan the user approves must be a plan ADA will run exactly as described."""
+
+    def setUp(self):
+        self.frame = pd.DataFrame(
+            {
+                "Order Date": pd.date_range("2024-01-01", periods=40, freq="D"),
+                "Region": ["West", "East"] * 20,
+                "Ticket": [f"T-{index:04d}" for index in range(40)],
+                "Revenue": [100.0 + index for index in range(40)],
+            }
+        )
+        self.roles = detect_roles(self.frame)
+        self.undated = self.frame.drop(columns=["Order Date"])
+        self.undated_roles = detect_roles(self.undated)
+
+    def _plan(self, **fields):
+        return _to_query_plan(AIQueryPlan(answerable=True, **fields), self.frame, self.roles)
+
+    def test_a_text_column_is_refused_as_a_measure(self):
+        for aggregation in ("sum", "mean", "median", "min", "max"):
+            with self.subTest(aggregation=aggregation):
+                self.assertIsNone(
+                    self._plan(intent="aggregate", aggregation=aggregation, measure="Region")
+                )
+
+    def test_a_date_column_is_refused_as_a_measure(self):
+        self.assertIsNone(self._plan(intent="aggregate", aggregation="sum", measure="Order Date"))
+
+    def test_counting_a_text_column_is_still_allowed(self):
+        self.assertIsNotNone(self._plan(intent="count", aggregation="count", measure="Region"))
+
+    def test_a_column_cannot_be_grouped_by_itself(self):
+        self.assertIsNone(
+            self._plan(intent="rank", aggregation="sum", measure="Revenue", dimension="Revenue")
+        )
+
+    def test_a_date_is_refused_as_a_grouping_dimension(self):
+        self.assertIsNone(
+            self._plan(intent="breakdown", aggregation="sum", measure="Revenue", dimension="Order Date")
+        )
+
+    def test_a_row_identifier_is_refused_as_a_grouping_dimension(self):
+        self.assertIsNone(
+            self._plan(intent="breakdown", aggregation="sum", measure="Revenue", dimension="Ticket")
+        )
+
+    def test_a_time_filter_without_a_date_column_is_refused(self):
+        parsed = AIQueryPlan(answerable=True, intent="aggregate", aggregation="sum",
+                             measure="Revenue", year=2024)
+
+        self.assertIsNone(_to_query_plan(parsed, self.undated, self.undated_roles))
+
+    def test_an_average_over_time_is_refused_rather_than_answered_as_a_sum(self):
+        self.assertIsNone(
+            self._plan(intent="trend", aggregation="mean", measure="Revenue")
+        )
+
+    def test_modifiers_the_intent_ignores_are_stripped(self):
+        plan = self._plan(
+            intent="aggregate", aggregation="sum", measure="Revenue",
+            dimension="Region", top_n=3, grain="M",
+        )
+
+        assert plan is not None
+        self.assertIsNone(plan.dimension)
+        self.assertIsNone(plan.top_n)
+        self.assertIsNone(plan.grain)
+        self.assertNotIn("Region", describe_query_plan(plan))
+
+    def test_growth_keeps_the_dimension_and_grain_its_executor_uses(self):
+        plan = self._plan(intent="growth", aggregation="sum", measure="Revenue",
+                          dimension="Region", grain="M")
+
+        assert plan is not None
+        self.assertEqual(plan.dimension, "Region")
+        self.assertEqual(plan.grain, "M")
+
+    def test_every_approved_plan_executes_without_raising(self):
+        """Nothing that survives validation may blow up in the executor."""
+        for intent in ("aggregate", "count", "rank", "breakdown", "trend", "growth"):
+            for measure in (None, "Revenue", "Region", "Order Date", "Ticket"):
+                for dimension in (None, "Region", "Revenue", "Order Date", "Ticket"):
+                    plan = self._plan(
+                        intent=intent, aggregation="sum", measure=measure, dimension=dimension
+                    )
+                    if plan is None:
+                        continue
+                    with self.subTest(intent=intent, measure=measure, dimension=dimension):
+                        answer = execute_plan(plan, self.frame, self.roles)
+                        self.assertTrue(answer.answer)
 
 
 class PayloadContentTests(unittest.TestCase):
@@ -274,8 +368,11 @@ class AIQueryPlannerTests(unittest.TestCase):
         self.assertIsNotNone(plan)
         assert plan is not None
         description = describe_query_plan(plan)
-        self.assertIn("Total of Revenue", description)
-        self.assertIn("grouped by Product", description)
+        # The sentence has to describe the ranking that actually runs, not the
+        # aggregate the plan's fields would suggest on their own.
+        self.assertIn("Rank Product", description)
+        self.assertIn("total Revenue", description)
+        self.assertIn("2 highest", description)
         self.assertIn("Region = West", description)
 
     def test_rejected_plan_is_not_executed(self):

--- a/tests/test_ai_insights.py
+++ b/tests/test_ai_insights.py
@@ -3,6 +3,8 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pandas as pd
+
 from ai_insights import (
     MODEL_PRESETS,
     AIAction,
@@ -104,6 +106,61 @@ class AIInsightTests(unittest.TestCase):
         self.assertIn("Validate the leading segment", report)
         self.assertIn("gpt-5.6-luna", report)
         self.assertIn("raw rows were not sent", report)
+
+
+class PayloadContentTests(unittest.TestCase):
+    """The privacy claim is only as good as a test that could falsify it.
+
+    Asserting on key names cannot catch a leak, because a leak arrives inside
+    a value. These put distinctive markers in the data and search the payload
+    text for them.
+    """
+
+    def _frame(self):
+        return pd.DataFrame(
+            {
+                "Order Date": pd.date_range("2024-01-01", periods=24, freq="MS"),
+                "Customer": ["Northwind Ltd", "Barclays plc"] * 12,
+                "Notes": [f"SECRET-NOTE-{index}" for index in range(24)],
+                "Account": [f"ACCT-{index:04d}" for index in range(24)],
+                "Revenue": [100 + index * 10 for index in range(24)],
+            }
+        )
+
+    def test_no_value_from_a_non_segment_column_reaches_the_narrative_payload(self):
+        frame = self._frame()
+        brief = analyze_business(frame, detect_roles(frame))
+
+        payload = build_ai_payload(brief, context="review")
+
+        self.assertNotIn("SECRET-NOTE", payload)
+        self.assertNotIn("ACCT-", payload)
+
+    def test_no_value_from_a_non_segment_column_reaches_the_planner_payload(self):
+        frame = self._frame()
+
+        payload = build_planner_payload("what is total revenue", frame, detect_roles(frame))
+
+        self.assertNotIn("SECRET-NOTE", payload)
+        self.assertNotIn("ACCT-", payload)
+
+    def test_the_segment_names_that_do_travel_are_documented_as_travelling(self):
+        """Evidence sentences name the segment they describe, and that is stated.
+
+        This is not a leak to be fixed silently -- it is the documented
+        boundary. The test exists so the boundary cannot move without someone
+        noticing, in either direction.
+        """
+        frame = self._frame()
+        brief = analyze_business(frame, detect_roles(frame))
+
+        payload = build_ai_payload(brief, context="review")
+
+        self.assertTrue(
+            "Northwind Ltd" in payload or "Barclays plc" in payload,
+            "an evidence sentence names the segment it describes; if that stopped "
+            "being true the privacy documentation should be widened, not narrowed",
+        )
 
 
 class AIQueryPlannerTests(unittest.TestCase):

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -330,5 +330,43 @@ class RoleDeterminismTests(unittest.TestCase):
 
         self.assertEqual(detect_roles(frame).measure, "netRevenue")
 
+
+
+class ExportedIndexTests(unittest.TestCase):
+    def test_a_blank_row_does_not_save_the_row_numbers(self):
+        frame = pd.DataFrame(
+            {
+                "Unnamed: 0": [0, 1, None, 3, 4, 5],
+                "Region": ["N", "S", None, "N", "S", "N"],
+                "Headcount": [10, 20, None, 30, 40, 50],
+            }
+        )
+
+        cleaned, report = clean_dataframe(frame)
+
+        self.assertNotIn("Unnamed: 0", cleaned.columns)
+        self.assertEqual(report.index_columns_removed, 1)
+
+    def test_a_named_counter_column_is_never_dropped(self):
+        frame = pd.DataFrame({"Sequence": [0, 1, 2, 3], "Region": ["N", "S", "N", "S"]})
+
+        cleaned, _ = clean_dataframe(frame)
+
+        self.assertIn("Sequence", cleaned.columns)
+
+
+class UnreadableDateColumnTests(unittest.TestCase):
+    def test_a_column_that_failed_to_parse_as_a_date_is_not_a_segment(self):
+        frame = pd.DataFrame(
+            {
+                "Date": [f"2024-06-{day:02d} maybe" for day in range(1, 13)],
+                "Revenue": [100.0 + index for index in range(12)],
+            }
+        )
+
+        roles = detect_roles(clean_dataframe(frame)[0])
+
+        self.assertNotEqual(roles.dimension, "Date")
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -70,6 +70,109 @@ class CleanDataframeTests(unittest.TestCase):
 
 
 
+class RepeatRowTests(unittest.TestCase):
+    """Two identical sales are a busy till, not a data defect."""
+
+    def _till(self):
+        return pd.DataFrame(
+            {
+                "Date": ["2024-01-01"] * 4,
+                "Product": ["Coffee"] * 4,
+                "Revenue": [3.5, 3.5, 3.5, 3.5],
+            }
+        )
+
+    def test_identical_rows_are_kept_and_the_total_survives(self):
+        cleaned, report = clean_dataframe(self._till())
+
+        self.assertEqual(len(cleaned), 4)
+        self.assertAlmostEqual(cleaned["Revenue"].sum(), 14.0)
+        self.assertEqual(report.duplicate_rows_removed, 0)
+        self.assertEqual(report.duplicate_rows_found, 3)
+        self.assertTrue(any("identical rows were kept" in note for note in report.notes))
+
+    def test_a_caller_that_knows_better_can_still_opt_in(self):
+        cleaned, report = clean_dataframe(self._till(), drop_duplicates=True)
+
+        self.assertEqual(len(cleaned), 1)
+        self.assertEqual(report.duplicate_rows_removed, 3)
+
+
+class DateOrderingTests(unittest.TestCase):
+    def test_a_day_over_twelve_settles_the_ordering(self):
+        frame = pd.DataFrame({"Posting Date": [f"{d:02d}/03/2024" for d in range(1, 26)]})
+
+        cleaned, report = clean_dataframe(frame)
+
+        self.assertEqual(cleaned["Posting Date"].min(), pd.Timestamp("2024-03-01"))
+        self.assertEqual(cleaned["Posting Date"].max(), pd.Timestamp("2024-03-25"))
+        self.assertTrue(any("day-first" in note for note in report.notes))
+
+    def test_an_unsettleable_column_says_which_way_it_was_read(self):
+        frame = pd.DataFrame({"Month": [f"01/{m:02d}/2024" for m in range(1, 13)]})
+
+        _, report = clean_dataframe(frame)
+
+        self.assertTrue(any("either way round" in note for note in report.notes))
+
+    def test_iso_dates_are_never_called_ambiguous(self):
+        frame = pd.DataFrame({"Date": pd.date_range("2024-01-01", periods=10).astype(str)})
+
+        cleaned, report = clean_dataframe(frame)
+
+        self.assertEqual(cleaned["Date"].max(), pd.Timestamp("2024-01-10"))
+        self.assertEqual(report.notes, ())
+
+
+class TimezoneTests(unittest.TestCase):
+    def test_an_offset_aware_column_is_analyzable(self):
+        frame = pd.DataFrame(
+            {
+                "created_at": pd.date_range("2024-01-01", periods=30, tz="Asia/Kolkata"),
+                "Revenue": range(30),
+            }
+        )
+
+        cleaned, report = clean_dataframe(frame)
+
+        self.assertFalse(isinstance(cleaned["created_at"].dtype, pd.DatetimeTZDtype))
+        # The wall clock the file was written in is what a report is about.
+        self.assertEqual(cleaned["created_at"].iloc[0], pd.Timestamp("2024-01-01 00:00:00"))
+        self.assertTrue(any("Timezone" in note for note in report.notes))
+
+
+class BusinessFormattedNumberTests(unittest.TestCase):
+    def test_thousands_separators_do_not_delete_the_largest_values(self):
+        frame = pd.DataFrame({"Revenue": ["950.00", "1,203.55", "12,400.10", "88.20"]})
+
+        cleaned, _ = clean_dataframe(frame)
+
+        self.assertAlmostEqual(cleaned["Revenue"].sum(), 14641.85)
+
+    def test_currency_symbols_and_accounting_negatives_are_read(self):
+        frame = pd.DataFrame({"Amount": ["$1,200.50", "$300.00", "(48.10)", "$0.00"]})
+
+        cleaned, _ = clean_dataframe(frame)
+
+        self.assertAlmostEqual(cleaned["Amount"].sum(), 1452.40)
+
+    def test_a_slashed_date_is_never_read_as_a_number(self):
+        frame = pd.DataFrame({"Month": [f"01/{m:02d}/2024" for m in range(1, 13)]})
+
+        cleaned, _ = clean_dataframe(frame)
+
+        self.assertTrue(pd.api.types.is_datetime64_any_dtype(cleaned["Month"]))
+
+
+class UniqueColumnNameTests(unittest.TestCase):
+    def test_a_name_the_suffix_would_collide_with_is_stepped_over(self):
+        frame = pd.DataFrame([[1, 2, 3]], columns=["Amount", "Amount ", "Amount_2"])
+
+        cleaned, _ = clean_dataframe(frame)
+
+        self.assertEqual(len(set(cleaned.columns)), 3)
+
+
 class AnalysisTests(unittest.TestCase):
     def setUp(self):
         self.dataframe = pd.DataFrame(

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -264,5 +264,71 @@ class KeywordScoreTests(unittest.TestCase):
         )
 
 
+
+
+class RoleDeterminismTests(unittest.TestCase):
+    """A role is a property of the data, not of the order the columns arrive in."""
+
+    def _hr_file(self, order):
+        frame = pd.DataFrame(
+            {
+                "Employee ID": [f"E{index:03d}" for index in range(24)],
+                "Postal Code": [10_000 + index * 37 for index in range(24)],
+                "Annual Salary": [60_000.5 + index * 1_500 for index in range(24)],
+                "Tenure Months": [index % 60 for index in range(24)],
+                "Department": ["Eng", "Sales", "Ops"] * 8,
+            }
+        )
+        return frame[order]
+
+    def test_column_order_does_not_change_the_headline_metric(self):
+        orders = (
+            ["Employee ID", "Postal Code", "Annual Salary", "Tenure Months", "Department"],
+            ["Employee ID", "Annual Salary", "Tenure Months", "Postal Code", "Department"],
+            ["Tenure Months", "Employee ID", "Department", "Annual Salary", "Postal Code"],
+        )
+
+        detected = {detect_roles(self._hr_file(order)).measure for order in orders}
+
+        self.assertEqual(len(detected), 1, f"measure depended on column order: {detected}")
+        self.assertEqual(detected.pop(), "Annual Salary")
+
+    def test_a_money_column_beside_an_invoice_is_not_a_row_identifier(self):
+        frame = pd.DataFrame(
+            {
+                "Invoice Number": [f"INV-{index:05d}" for index in range(30)],
+                "Invoice Amount": [1_000.0 + index * 13.5 for index in range(30)],
+                "Days Overdue": list(range(30)),
+                "Customer": ["A", "B", "C"] * 10,
+            }
+        )
+
+        roles = detect_roles(frame)
+
+        self.assertEqual(roles.measure, "Invoice Amount")
+        self.assertEqual(roles.identifier, "Invoice Number")
+
+    def test_a_parenthesised_unit_does_not_demote_the_head_noun(self):
+        frame = pd.DataFrame(
+            {
+                "Revenue (USD)": [100.0 + index for index in range(20)],
+                "Discount Amount": [1.0 + index for index in range(20)],
+                "Channel": ["a", "b"] * 10,
+            }
+        )
+
+        self.assertEqual(detect_roles(frame).measure, "Revenue (USD)")
+
+    def test_camel_case_names_score_like_snake_case_ones(self):
+        frame = pd.DataFrame(
+            {
+                "netRevenue": [100.0 + index for index in range(20)],
+                "Discount Amount": [1.0 + index for index in range(20)],
+                "Channel": ["a", "b"] * 10,
+            }
+        )
+
+        self.assertEqual(detect_roles(frame).measure, "netRevenue")
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,6 +1,52 @@
+import sys
 import unittest
 
 from streamlit.testing.v1 import AppTest
+
+
+class _BlockImport:
+    """Make a package unimportable, the way a broken deployment does."""
+
+    def __init__(self, *names: str, evict: tuple[str, ...] = ()) -> None:
+        self.names = set(names)
+        # A module that already imported the blocked package is cached and
+        # would import again quite happily, so it has to be evicted too.
+        self.evict = set(evict)
+
+    def find_spec(self, name, path=None, target=None):
+        if name.split(".")[0] in self.names:
+            raise ImportError(f"No module named {name!r} (simulated)")
+        return None
+
+    def __enter__(self):
+        sys.meta_path.insert(0, self)
+        self.dropped = {
+            key: sys.modules.pop(key)
+            for key in list(sys.modules)
+            if key.split(".")[0] in self.names | self.evict
+        }
+        return self
+
+    def __exit__(self, *_):
+        sys.meta_path.remove(self)
+        sys.modules.update(self.dropped)
+
+
+class OptionalAiLayerTests(unittest.TestCase):
+    """Without a key ADA is a complete product, so it must load without the AI stack."""
+
+    def test_the_app_is_whole_when_the_ai_layer_cannot_be_imported(self):
+        with _BlockImport("pydantic", "openai", evict=("ai_insights",)):
+            app = AppTest.from_file("app.py", default_timeout=90).run()
+
+        self.assertFalse(app.exception)
+        # The deterministic product is untouched: every tab, every KPI, every chart.
+        self.assertEqual(len(app.tabs), 6)
+        self.assertEqual(len(app.metric), 4)
+        self.assertEqual(len(app.get("plotly_chart")), 7)
+        self.assertTrue(
+            any("optional AI layer could not be loaded" in str(w.value) for w in app.warning)
+        )
 
 
 class AppSmokeTests(unittest.TestCase):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,7 +1,10 @@
 import sys
 import unittest
 
+import pandas as pd
 from streamlit.testing.v1 import AppTest
+
+from schema import ColumnRoles
 
 
 class _BlockImport:
@@ -30,6 +33,63 @@ class _BlockImport:
     def __exit__(self, *_):
         sys.meta_path.remove(self)
         sys.modules.update(self.dropped)
+
+
+class DatasetIdentityTests(unittest.TestCase):
+    """An answer must not outlive the table it was computed from."""
+
+    def setUp(self):
+        import app  # noqa: PLC0415 - importing runs the page once, in bare mode
+
+        self.fingerprint = app.dataset_fingerprint
+        self.roles = ColumnRoles(
+            date=None, measure="revenue", dimension="region",
+            identifier=None, numeric=("revenue",), dimensions=("region",),
+        )
+        self.frame = pd.DataFrame({"region": ["N", "S"], "revenue": [1.0, 2.0]})
+
+    def test_same_shape_and_name_but_different_numbers_is_a_different_dataset(self):
+        other = self.frame.assign(revenue=[10.0, 20.0])
+
+        self.assertNotEqual(
+            self.fingerprint(self.frame, self.roles, "q.csv"),
+            self.fingerprint(other, self.roles, "q.csv"),
+        )
+
+    def test_drilling_into_a_segment_is_a_different_dataset(self):
+        slice_ = self.frame[self.frame["region"] == "S"]
+
+        self.assertNotEqual(
+            self.fingerprint(self.frame, self.roles, "q.csv"),
+            self.fingerprint(slice_, self.roles, "q.csv"),
+        )
+
+    def test_changing_which_column_is_the_measure_is_a_different_dataset(self):
+        rerolled = ColumnRoles(
+            date=None, measure=None, dimension="region",
+            identifier=None, numeric=("revenue",), dimensions=("region",),
+        )
+
+        self.assertNotEqual(
+            self.fingerprint(self.frame, self.roles, "q.csv"),
+            self.fingerprint(self.frame, rerolled, "q.csv"),
+        )
+
+    def test_the_same_table_is_the_same_dataset(self):
+        self.assertEqual(
+            self.fingerprint(self.frame, self.roles, "q.csv"),
+            self.fingerprint(self.frame.copy(), self.roles, "q.csv"),
+        )
+
+
+class SourceSelectionTests(unittest.TestCase):
+    def test_clearing_the_source_control_falls_back_instead_of_crashing(self):
+        app = AppTest.from_file("app.py", default_timeout=90).run()
+
+        app.segmented_control[0].set_value(None).run()
+
+        self.assertFalse(app.exception)
+        self.assertEqual(len(app.tabs), 6)
 
 
 class OptionalAiLayerTests(unittest.TestCase):

--- a/tests/test_autovis.py
+++ b/tests/test_autovis.py
@@ -102,5 +102,74 @@ class SeriesFoldingTests(unittest.TestCase):
         self.assertEqual(set(fold_small_series(small, "Product", "Revenue")["Product"]), {"A", "B"})
 
 
+
+
+class ChartSizeTests(unittest.TestCase):
+    def test_two_high_cardinality_categories_do_not_become_a_heatmap(self):
+        rows = 4_000
+        frame = pd.DataFrame(
+            {
+                "Customer ID": [f"c{index % 900}" for index in range(rows)],
+                "SKU": [f"s{index % 400}" for index in range(rows)],
+                "Revenue": [1.0] * rows,
+            }
+        )
+
+        spec = recommend_chart(frame, ["Customer ID", "SKU", "Revenue"])
+
+        # 360,000 cells is not a picture, and it exceeds the websocket limit
+        # before it reaches a screen.
+        self.assertEqual(spec.form, "table")
+        self.assertIn("cell grid", spec.rationale)
+
+    def test_a_small_grid_is_still_a_heatmap(self):
+        frame = pd.DataFrame(
+            {
+                "Region": ["N", "S"] * 20,
+                "Product": ["a", "b", "c", "d"] * 10,
+                "Revenue": [1.0] * 40,
+            }
+        )
+
+        spec = recommend_chart(frame, ["Region", "Product", "Revenue"])
+
+        self.assertEqual(spec.form, "heatmap")
+
+    def test_a_lone_continuous_measure_is_binned_not_counted_per_value(self):
+        frame = pd.DataFrame({"Revenue": [float(index) / 7 for index in range(500)]})
+
+        spec = recommend_chart(frame, ["Revenue"])
+
+        self.assertEqual(spec.form, "histogram")
+
+
+class FoldSmallSeriesTests(unittest.TestCase):
+    def test_a_real_other_category_is_not_absorbed_by_the_folded_tail(self):
+        frame = pd.DataFrame(
+            {
+                "Region": ["Other", "N", "S", "E", "W", "X", "Y"],
+                "Revenue": [20_000.0, 1_200.0, 1_000.0, 800.0, 400.0, 300.0, 100.0],
+            }
+        )
+
+        folded = fold_small_series(frame, "Region", "Revenue")
+        totals = folded.groupby("Region", observed=True)["Revenue"].sum()
+
+        # The real "Other" segment keeps its own money.
+        self.assertEqual(totals["Other"], 20_000.0)
+        self.assertIn("Other (2)", totals.index)
+
+    def test_a_categorical_column_can_be_folded(self):
+        frame = pd.DataFrame(
+            {
+                "Product": pd.Categorical([f"p{index}" for index in range(8)]),
+                "Revenue": [float(8 - index) for index in range(8)],
+            }
+        )
+
+        folded = fold_small_series(frame, "Product", "Revenue")
+
+        self.assertIn("Other", set(folded["Product"]))
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_business_insights.py
+++ b/tests/test_business_insights.py
@@ -126,9 +126,13 @@ class BusinessAnalysisTests(unittest.TestCase):
         )
 
         kpi_values = [item.value for item in brief.kpis]
+        kpi_labels = [item.label for item in brief.kpis]
 
-        self.assertIn("136.0%", kpi_values)
         self.assertIn("34.0%", kpi_values)
+        # Four monthly margins do not add up to a 136% margin, so no total is
+        # offered for a rate -- only the average, which means something.
+        self.assertNotIn("Total Gross Margin", kpi_labels)
+        self.assertIn("Average Gross Margin", kpi_labels)
         self.assertIn("Gross Margin increased 10.7%", report)
         self.assertIn("from 28.0% to 31.0%", report)
 
@@ -392,6 +396,30 @@ class MovementWordingTests(unittest.TestCase):
         # Whatever grain was chosen, the label must not name a month for a
         # period that is not one -- the anomaly card and the axis already agree.
         self.assertNotRegex(trend.statement, r"\((Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4}\)")
+
+
+
+class PercentageVersusCurrencyTests(unittest.TestCase):
+    def test_an_explicit_percent_sign_beats_a_currency_word(self):
+        values = pd.Series([0.31, 0.33, 0.35])
+
+        self.assertEqual(
+            format_number(0.33, "Profit Margin %", column_values=values), "33.0%"
+        )
+
+    def test_a_percentage_word_in_the_head_position_wins(self):
+        self.assertEqual(format_number(0.42, "Discount Rate"), "42.0%")
+
+    def test_a_currency_word_in_the_head_position_wins(self):
+        self.assertEqual(format_number(1_200.0, "Margin Amount"), "$1.2K")
+
+    def test_a_column_gets_one_unit_for_every_row(self):
+        """Judging plausibility per value gave 551.3% and 1.4K in one column."""
+        values = pd.Series([1000.0, 551.26, 201.79, 1400.0, 558.08])
+
+        rendered = [format_number(value, "Gross Margin", column_values=values) for value in values]
+
+        self.assertFalse(any(text.endswith("%") for text in rendered))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_business_insights.py
+++ b/tests/test_business_insights.py
@@ -197,8 +197,13 @@ class BusinessAnalysisTests(unittest.TestCase):
         self.assertEqual(concentration.tone, "neutral")
         self.assertIn("10.0 of 10", concentration.value)
 
-    def test_a_measure_that_can_go_negative_keeps_the_share_reading(self):
-        """Shares of a total that parts of it subtract from are meaningless."""
+    def test_a_mixed_sign_measure_quotes_no_share_at_all(self):
+        """Shares of a total that parts of it subtract from are meaningless.
+
+        Not "degraded to a simpler share" -- absent. A percentage taken against
+        a net figure the parts do not sum into is how a segment ends up
+        contributing 2,000,000% of profit.
+        """
         frame = pd.DataFrame(
             {
                 "Date": pd.date_range("2024-01-01", periods=12, freq="D"),
@@ -208,10 +213,29 @@ class BusinessAnalysisTests(unittest.TestCase):
         )
 
         brief = analyze_business(frame)
-        concentration = next(item for item in brief.evidence if item.kind == "concentration")
 
-        self.assertEqual(concentration.title, "Top-three concentration")
-        self.assertNotIn("Herfindahl", concentration.calculation)
+        self.assertFalse([item for item in brief.evidence if item.kind == "concentration"])
+        leader = next(item for item in brief.evidence if item.kind == "leader")
+        self.assertIn("no share of the total can be quoted", leader.statement)
+        self.assertNotIn("%", leader.statement)
+
+    def test_an_all_negative_measure_ranks_by_size_of_the_loss(self):
+        """A cost column has a usable share: -14.4k of -24k really is 60%."""
+        frame = pd.DataFrame(
+            {
+                "Date": list(pd.date_range("2024-01-01", periods=6, freq="D")) * 3,
+                "Profit": [-2400.0] * 6 + [-7200.0] * 6 + [-14400.0] * 6,
+                "Region": ["North"] * 6 + ["South"] * 6 + ["East"] * 6,
+            }
+        )
+
+        brief = analyze_business(frame)
+        leader = next(item for item in brief.evidence if item.kind == "leader")
+
+        # East carries the largest loss, so East is the leader -- not North,
+        # which is merely the number closest to zero.
+        self.assertIn("East", leader.statement)
+        self.assertIn("60.0%", leader.statement)
 
     def test_business_number_formatting(self):
         self.assertEqual(format_number(1_250_000, "Revenue"), "$1.2M")

--- a/tests/test_business_insights.py
+++ b/tests/test_business_insights.py
@@ -337,5 +337,61 @@ class BusinessAnalysisTests(unittest.TestCase):
             self.assertNotIn("nan", kpi.value.lower())
 
 
+
+
+class NumberRenderingTests(unittest.TestCase):
+    def test_the_minus_sign_belongs_to_the_amount_not_the_currency(self):
+        self.assertEqual(format_number(-1_200.0, "Expense Amount"), "-$1.2K")
+        self.assertEqual(format_number(-1_500_000.0, "Cost"), "-$1.5M")
+        self.assertEqual(format_number(-12.0, "Cost"), "-$12.00")
+
+    def test_negative_zero_is_just_zero(self):
+        self.assertEqual(format_number(-0.0, "Cost"), "$0.00")
+
+    def test_totals_larger_than_a_billion_keep_a_readable_scale(self):
+        self.assertEqual(format_number(1.5e12, "Revenue"), "$1.5T")
+        # Past a quadrillion the exponent says more than the commas do.
+        self.assertEqual(format_number(3.6e20, "amount"), "$3.6e+20")
+
+
+class KpiStripTests(unittest.TestCase):
+    def test_a_thin_file_shows_fewer_tiles_rather_than_repeating_one(self):
+        frame = pd.DataFrame({"Note": ["a", "b", "c"] * 4})
+
+        brief = analyze_business(frame)
+        labels = [item.label for item in brief.kpis]
+
+        self.assertEqual(len(labels), len(set(labels)))
+
+
+class MovementWordingTests(unittest.TestCase):
+    def test_a_flat_period_is_not_called_a_large_swing(self):
+        values = [1000.0, 1050.0, 1100.0, 1155.0, 1210.0, 1270.0, 1330.0, 1400.0, 1470.0,
+                  1540.0, 1540.0]
+        frame = pd.DataFrame(
+            {"Month": pd.date_range("2023-01-01", periods=len(values), freq="MS"),
+             "Revenue": values}
+        )
+
+        brief = analyze_business(frame)
+        trend = next(item for item in brief.evidence if item.kind == "trend")
+
+        self.assertIn("0.0%", trend.value)
+        self.assertNotIn("large swing", trend.statement)
+        self.assertIn("quiet", trend.statement)
+
+    def test_a_quarter_is_named_as_a_quarter(self):
+        frame = pd.DataFrame(
+            {"Date": pd.date_range("2021-01-01", periods=140, freq="W"),
+             "Revenue": [100.0] * 130 + [400.0] * 10}
+        )
+
+        brief = analyze_business(frame)
+        trend = next(item for item in brief.evidence if item.kind == "trend")
+
+        # Whatever grain was chosen, the label must not name a month for a
+        # period that is not one -- the anomaly card and the axis already agree.
+        self.assertNotRegex(trend.statement, r"\((Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4}\)")
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_file_io.py
+++ b/tests/test_file_io.py
@@ -5,7 +5,7 @@ from io import BytesIO
 
 import pandas as pd
 
-from file_io import list_excel_sheets, list_sample_datasets, read_tabular_file
+from file_io import list_excel_sheets, list_sample_datasets, read_tabular_file, safe_csv
 
 
 class FileParsingTests(unittest.TestCase):
@@ -117,6 +117,34 @@ class DelimiterRescueTests(unittest.TestCase):
         frame = read_tabular_file(raw, "powershell.csv")
 
         self.assertEqual(list(frame.columns), ["Date", "Region", "Revenue"])
+
+
+
+class CsvExportSafetyTests(unittest.TestCase):
+    """A downloaded file gets forwarded, and the reader did not choose to run anything."""
+
+    def test_text_that_looks_like_a_formula_is_neutralised(self):
+        frame = pd.DataFrame({"Note": ["=cmd|' /C calc'!A0", "+1+1", "@SUM(A1)", "-5 apples"]})
+
+        exported = safe_csv(frame)
+
+        for line in exported.splitlines()[1:]:
+            self.assertTrue(line.startswith("'"), line)
+
+    def test_ordinary_text_and_numbers_are_untouched(self):
+        frame = pd.DataFrame({"Region": ["North", "South"], "Revenue": [-2.5, 3.0]})
+
+        exported = safe_csv(frame)
+
+        self.assertIn("North", exported)
+        self.assertIn("-2.5", exported)
+        self.assertNotIn("'North", exported)
+        self.assertNotIn("'-2.5", exported)
+
+    def test_a_column_name_that_looks_like_a_formula_is_neutralised(self):
+        frame = pd.DataFrame({"=1+1": [1]})
+
+        self.assertTrue(safe_csv(frame).startswith("'=1+1"))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_file_io.py
+++ b/tests/test_file_io.py
@@ -81,5 +81,42 @@ class FileParsingTests(unittest.TestCase):
                 self.assertGreater(len(frame.columns), 1)
 
 
+
+class DelimiterRescueTests(unittest.TestCase):
+    """The rescue for European CSVs must not shred ordinary one-column files."""
+
+    def test_a_semicolon_delimited_file_is_still_split(self):
+        frame = read_tabular_file(b"Datum;Region;Umsatz\n2024-01-01;Nord;100\n", "eu.csv")
+
+        self.assertEqual(list(frame.columns), ["Datum", "Region", "Umsatz"])
+
+    def test_a_separator_in_the_body_alone_does_not_split_the_file(self):
+        raw = b"Feedback\nGreat; really good\nSlow; but fine\n"
+
+        frame = read_tabular_file(raw, "notes.csv")
+
+        self.assertEqual(list(frame.columns), ["Feedback"])
+        self.assertEqual(len(frame), 2)
+
+    def test_a_tab_in_one_cell_does_not_split_the_file(self):
+        frame = read_tabular_file(b"Revenue\n100\n200\n500\tX\n", "one.csv")
+
+        self.assertEqual(list(frame.columns), ["Revenue"])
+
+    def test_a_report_title_above_the_header_is_skipped(self):
+        raw = b"Q3 Sales Report\nDate,Region,Revenue\n2024-01-01,North,100\n2024-02-01,South,200\n"
+
+        frame = read_tabular_file(raw, "report.csv")
+
+        self.assertEqual(list(frame.columns), ["Date", "Region", "Revenue"])
+        self.assertEqual(len(frame), 2)
+
+    def test_a_utf16_export_is_decoded_by_its_byte_order_mark(self):
+        raw = "Date,Region,Revenue\n2024-01-01,North,100\n".encode("utf-16")
+
+        frame = read_tabular_file(raw, "powershell.csv")
+
+        self.assertEqual(list(frame.columns), ["Date", "Region", "Revenue"])
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_nlq.py
+++ b/tests/test_nlq.py
@@ -179,5 +179,53 @@ class TimelineDisclosureTests(unittest.TestCase):
         self.assertNotIn("still in progress", answer.calculation)
         self.assertNotIn("counted as zero", answer.calculation)
 
+
+
+class TimeScopeTests(unittest.TestCase):
+    """A question about a year must not be answered with the all-time number."""
+
+    def setUp(self):
+        self.dated = pd.DataFrame(
+            {
+                "Order Date": pd.date_range("2025-01-01", periods=365, freq="D"),
+                "Revenue": [100.0] * 365,
+            }
+        )
+        self.dated_roles = detect_roles(self.dated)
+        self.undated = pd.DataFrame(
+            {"Period Label": ["FY2024 Q1", "FY2024 Q2"], "Revenue": [100.0, 200.0]}
+        )
+        self.undated_roles = detect_roles(self.undated)
+
+    def test_a_year_scope_without_a_date_column_is_refused_not_ignored(self):
+        plan = QueryPlan(intent="aggregate", aggregation="sum", measure="Revenue", year=2024)
+
+        answer = execute_plan(plan, self.undated, self.undated_roles)
+
+        self.assertIn("no date column", answer.answer)
+        # The all-time total must not be presented as the 2024 total.
+        self.assertNotIn("300", answer.answer)
+
+    def test_may_is_named_in_the_answer_like_every_other_month(self):
+        for month, label in ((3, "March"), (5, "May"), (7, "July"), (12, "December")):
+            with self.subTest(month=label):
+                plan = QueryPlan(
+                    intent="aggregate", aggregation="sum", measure="Revenue", month=month
+                )
+
+                answer = execute_plan(plan, self.dated, self.dated_roles)
+
+                self.assertIn(f"Order Date in {label}", answer.answer)
+                self.assertIn(f"Order Date in {label}", answer.calculation)
+
+    def test_a_month_and_year_together_name_both(self):
+        plan = QueryPlan(
+            intent="aggregate", aggregation="sum", measure="Revenue", month=5, year=2025
+        )
+
+        answer = execute_plan(plan, self.dated, self.dated_roles)
+
+        self.assertIn("Order Date in May 2025", answer.answer)
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_nlq.py
+++ b/tests/test_nlq.py
@@ -291,5 +291,68 @@ class ShareOfTotalTests(unittest.TestCase):
 
         self.assertTrue(answer.answer)
 
+
+
+class AnswerHonestyTests(unittest.TestCase):
+    """Every sentence has to match the arithmetic that produced it."""
+
+    def _roles(self, dated=True):
+        return ColumnRoles(
+            date="Month" if dated else None, measure="Revenue", dimension="Region",
+            identifier=None, numeric=("Revenue",), dimensions=("Region",),
+        )
+
+    def test_a_row_count_is_described_as_a_row_count(self):
+        frame = pd.DataFrame({"Region": ["N"] * 6 + ["S"] * 6, "Revenue": [1.0] * 12})
+        plan = QueryPlan(
+            intent="breakdown", aggregation="count", measure="Revenue", dimension="Region"
+        )
+
+        answer = execute_plan(plan, frame, self._roles(dated=False))
+
+        self.assertIn("row count", answer.calculation)
+        self.assertNotIn("count(Revenue)", answer.calculation)
+        # A count of rows is not money.
+        self.assertNotIn("$", answer.answer)
+
+    def test_a_trend_from_zero_quotes_no_percentage(self):
+        frame = pd.DataFrame(
+            {"Month": pd.date_range("2024-01-01", periods=6, freq="MS"),
+             "Revenue": [0.0, 100.0, 400.0, 800.0, 1200.0, 1600.0],
+             "Region": ["N"] * 6}
+        )
+        plan = QueryPlan(intent="trend", aggregation="sum", measure="Revenue", grain="M")
+
+        answer = execute_plan(plan, frame, self._roles())
+
+        self.assertNotIn("+0.0%", answer.answer)
+        self.assertIn("starting period of zero", answer.answer)
+
+    def test_a_scope_with_no_values_is_not_a_total_of_zero(self):
+        frame = pd.DataFrame({"Region": ["N", "S"], "Revenue": [float("nan")] * 2})
+        plan = QueryPlan(intent="aggregate", aggregation="sum", measure="Revenue")
+
+        answer = execute_plan(plan, frame, self._roles(dated=False))
+
+        self.assertIn("no values", answer.answer)
+        self.assertNotIn("$0.00", answer.answer)
+
+    def test_a_segment_growing_from_zero_is_named_not_deleted(self):
+        frame = pd.DataFrame(
+            {
+                "Month": list(pd.date_range("2024-03-01", periods=2, freq="MS")) * 2,
+                "Region": ["Alpha", "Alpha", "Beta", "Beta"],
+                "Revenue": [300.0, 400.0, 0.0, 5_000.0],
+            }
+        )
+        plan = QueryPlan(
+            intent="growth", aggregation="sum", measure="Revenue", dimension="Region", grain="M"
+        )
+
+        answer = execute_plan(plan, frame, self._roles())
+
+        self.assertIn("Beta", answer.answer)
+        self.assertIn("started from zero", answer.answer)
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_nlq.py
+++ b/tests/test_nlq.py
@@ -6,7 +6,7 @@ import pandas as pd
 from demo_data import make_demo_data
 from nlq import QueryPlan, answer_question, execute_plan, parse_question, suggested_questions
 from pipeline import prepare_analysis
-from schema import detect_roles
+from schema import ColumnRoles, detect_roles
 
 
 class NLQParsingTests(unittest.TestCase):
@@ -226,6 +226,70 @@ class TimeScopeTests(unittest.TestCase):
         answer = execute_plan(plan, self.dated, self.dated_roles)
 
         self.assertIn("Order Date in May 2025", answer.answer)
+
+
+
+class ShareOfTotalTests(unittest.TestCase):
+    """A share is only a share when the parts add up to the whole."""
+
+    def _roles(self, frame):
+        return ColumnRoles(
+            date=None, measure="Revenue", dimension="Region",
+            identifier=None, numeric=("Revenue",), dimensions=("Region",),
+        )
+
+    def test_mixed_signs_produce_no_share_column(self):
+        frame = pd.DataFrame(
+            {"Region": ["A", "B", "C"], "Revenue": [100.0, -50.0, -30.0]}
+        )
+        plan = QueryPlan(
+            intent="breakdown", aggregation="sum", measure="Revenue", dimension="Region"
+        )
+
+        answer = execute_plan(plan, frame, self._roles(frame))
+
+        self.assertNotIn("Share %", answer.table.columns)
+        self.assertNotIn("%", answer.answer)
+
+    def test_an_all_negative_measure_keeps_its_share(self):
+        frame = pd.DataFrame({"Region": ["A", "B"], "Revenue": [-75.0, -25.0]})
+        plan = QueryPlan(
+            intent="breakdown", aggregation="sum", measure="Revenue", dimension="Region"
+        )
+
+        answer = execute_plan(plan, frame, self._roles(frame))
+
+        # Uniform signs, so the shares are real and sum to 100.
+        self.assertIn("Share %", answer.table.columns)
+        self.assertAlmostEqual(float(answer.table["Share %"].sum()), 100.0)
+        self.assertEqual(
+            dict(zip(answer.table["Region"], answer.table["Share %"], strict=True)),
+            {"A": 75.0, "B": 25.0},
+        )
+
+    def test_unlabelled_rows_are_a_group_not_a_deletion(self):
+        frame = pd.DataFrame(
+            {"Region": ["South", None, "North", None], "Revenue": [200.0, 400.0, 150.0, 300.0]}
+        )
+        plan = QueryPlan(
+            intent="breakdown", aggregation="sum", measure="Revenue", dimension="Region"
+        )
+
+        answer = execute_plan(plan, frame, self._roles(frame))
+
+        # The denominator is the real total, not the total of the labelled rows.
+        self.assertAlmostEqual(float(answer.table["Total Revenue"].sum()), 1050.0)
+        self.assertIn("(not recorded)", list(answer.table["Region"]))
+
+    def test_a_dimension_that_is_entirely_blank_does_not_crash(self):
+        frame = pd.DataFrame({"Region": [None, None], "Revenue": [1.0, 2.0]})
+        plan = QueryPlan(
+            intent="rank", aggregation="sum", measure="Revenue", dimension="Region", top_n=5
+        )
+
+        answer = execute_plan(plan, frame, self._roles(frame))
+
+        self.assertTrue(answer.answer)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -4,6 +4,8 @@ import numpy as np
 import pandas as pd
 
 from timeseries import (
+    MAD_SCALE,
+    MEAN_ABS_DEV_SCALE,
     fit_trendline,
     period_grain,
     period_positions,
@@ -150,6 +152,33 @@ class RobustScaleTests(unittest.TestCase):
         self.assertEqual(robust_scale(np.zeros(6)), 0.0)
         self.assertEqual(robust_scale(np.zeros(0)), 0.0)
 
+
+
+
+class ScaleEstimatorAgreementTests(unittest.TestCase):
+    """Switching estimators must not change how surprising a period looks."""
+
+    def test_the_fallback_recovers_the_same_sigma_as_the_median_path(self):
+        sample = np.random.default_rng(3).normal(0.0, 1.0, 200_000)
+        deviations = np.abs(sample - np.median(sample))
+
+        median_estimate = float(np.median(deviations)) * MAD_SCALE
+        fallback_estimate = float(np.mean(deviations)) * MEAN_ABS_DEV_SCALE
+
+        self.assertAlmostEqual(median_estimate, 1.0, places=2)
+        self.assertAlmostEqual(fallback_estimate, 1.0, places=2)
+
+    def test_the_fallback_is_used_when_most_residuals_are_identical(self):
+        residuals = np.array([0.0] * 12 + [1.0, -1.0, 2.0, -2.0, 1.5, -1.5, 0.5, -0.5])
+
+        # The median absolute deviation is zero here, so the mean path runs.
+        self.assertEqual(float(np.median(np.abs(residuals - np.median(residuals)))), 0.0)
+        self.assertAlmostEqual(
+            robust_scale(residuals), float(np.mean(np.abs(residuals))) * MEAN_ABS_DEV_SCALE
+        )
+
+    def test_a_series_with_no_variation_has_no_scale(self):
+        self.assertEqual(robust_scale(np.zeros(10)), 0.0)
 
 if __name__ == "__main__":
     unittest.main()

--- a/timeseries.py
+++ b/timeseries.py
@@ -23,6 +23,10 @@ import numpy as np
 import pandas as pd
 
 MAD_SCALE = 1.4826  # MAD -> standard-deviation equivalent for normal data
+# The mean absolute deviation is sqrt(2/pi) standard deviations for normal
+# data; the reciprocal puts the fallback on the same scale as MAD_SCALE, so
+# switching estimators does not change how surprising a period looks.
+MEAN_ABS_DEV_SCALE = 1.2533
 MAX_PAIRWISE_POINTS = 800  # keeps the O(n^2) slope search bounded
 
 
@@ -134,6 +138,12 @@ def robust_scale(residuals: np.ndarray) -> float:
     residuals are identical, which drives the median absolute deviation to
     zero and would otherwise make every remaining period look infinitely
     surprising.
+
+    Both estimators are put on the same footing. For normal residuals the mean
+    absolute deviation is about 0.798 standard deviations, so using it raw
+    made the fallback scale roughly a fifth too small -- inflating every
+    z-score computed from it and quietly destroying the false-alarm rate the
+    anomaly thresholds are calibrated to.
     """
     values = np.asarray(residuals, dtype=float)
     if values.size == 0:
@@ -144,5 +154,6 @@ def robust_scale(residuals: np.ndarray) -> float:
     scale = float(np.median(deviations)) * MAD_SCALE
     if scale > 0:
         return scale
-    fallback = float(np.mean(deviations))
+
+    fallback = float(np.mean(deviations)) * MEAN_ABS_DEV_SCALE
     return fallback if fallback > 0 else 0.0

--- a/ui.py
+++ b/ui.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from html import escape
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pandas as pd
 import plotly.express as px
@@ -11,7 +12,6 @@ import plotly.graph_objects as go
 import streamlit as st
 
 from aggregation import build_trend, driver_frame, heatmap_frame, segment_frame
-from ai_insights import AINarrative
 from anomalies import detect_anomalies
 from autovis import fold_small_series, recommend_chart
 from business_insights import BusinessBrief
@@ -19,6 +19,9 @@ from forecasting import build_forecast, describe_backtest
 from formatting import format_number
 from nlq import QueryAnswer
 from schema import ColumnRoles
+
+if TYPE_CHECKING:  # The AI layer is optional; ui must import without it.
+    from ai_insights import AINarrative
 
 ACCENT = "#635BFF"
 LIME = "#C7F36B"  # Brand accent for surfaces and text. Too light to be a data mark.

--- a/ui.py
+++ b/ui.py
@@ -17,7 +17,7 @@ from anomalies import detect_anomalies
 from autovis import fold_small_series, recommend_chart
 from business_insights import BusinessBrief
 from forecasting import build_forecast, describe_backtest
-from formatting import format_number
+from formatting import format_number, format_period
 from nlq import QueryAnswer
 from schema import ColumnRoles
 
@@ -324,12 +324,12 @@ def render_dashboard(dataframe: pd.DataFrame, roles: ColumnRoles) -> None:
             )
 
     with movement_columns[1]:
-        heat = heatmap_frame(dataframe, roles)
+        heat = heatmap_frame(dataframe, roles, frequency=series.frequency)
         if not heat.empty and len(heat.columns) >= 2:
             heatmap = go.Figure(
                 go.Heatmap(
                     z=heat.to_numpy(),
-                    x=[period.strftime("%b %Y") for period in heat.columns],
+                    x=[format_period(period, series.frequency) for period in heat.columns],
                     y=[str(segment) for segment in heat.index],
                     colorscale=[[0, "#F6F7F9"], [0.5, "#B9B1FF"], [1, "#4E43C7"]],
                     hovertemplate="%{y} · %{x}: %{z:,.0f}<extra></extra>",

--- a/ui.py
+++ b/ui.py
@@ -10,6 +10,7 @@ import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
 import streamlit as st
+from pandas.api.types import is_datetime64_any_dtype
 
 from aggregation import build_trend, driver_frame, heatmap_frame, segment_frame
 from anomalies import detect_anomalies
@@ -442,33 +443,53 @@ def render_chat_fallback(suggestions: list[str]) -> None:
     st.markdown("\n".join(f"- {suggestion}" for suggestion in suggestions))
 
 
+def _cap(frame: pd.DataFrame, spec, value: str, limit: int) -> pd.DataFrame:
+    """Trim to a drawable size by dropping the least interesting rows.
+
+    Taking the first N groups drops the newest periods off a trend and the
+    biggest categories off a ranking -- exactly the rows the reader opened the
+    chart for. Time keeps its most recent end; anything else keeps its largest.
+    """
+    if len(frame) <= limit:
+        return frame
+    if spec.x and spec.x in frame.columns and is_datetime64_any_dtype(frame[spec.x]):
+        return frame.nlargest(limit, spec.x).sort_values(spec.x).reset_index(drop=True)
+    return frame.nlargest(limit, value).reset_index(drop=True)
+
+
 def _explore_frame(
     dataframe: pd.DataFrame, spec, *, limit: int = 400
 ) -> pd.DataFrame:
     """Aggregate the raw rows into what the recommended chart plots."""
-    if spec.form == "scatter":
-        return dataframe[[spec.x, spec.y]].dropna().head(5_000)
+    if spec.form in ("scatter", "histogram"):
+        columns = [column for column in (spec.x, spec.y) if column]
+        return dataframe[columns].dropna().head(20_000)
 
     grouping = [column for column in (spec.x, spec.y, spec.color) if column]
-    if spec.form == "heatmap":
+    # A heatmap, and the table it falls back to when the grid is too large,
+    # are both "measure across two categories".
+    if spec.color and spec.x and spec.y and spec.form in ("heatmap", "table"):
         keys = [spec.y, spec.x]
-        return dataframe.groupby(keys, dropna=True)[spec.color].sum().reset_index()
+        grid = dataframe.groupby(keys, dropna=True, observed=True)[spec.color].sum().reset_index()
+        if spec.form == "table":
+            return grid.nlargest(limit, spec.color).reset_index(drop=True)
+        return grid
 
     keys = [column for column in (spec.x, spec.color) if column]
     if not keys:
         return dataframe[grouping].dropna()
 
     if spec.aggregation == "count" or not spec.y:
-        frame = dataframe.groupby(keys, dropna=True).size().reset_index(name="Records")
+        frame = dataframe.groupby(keys, dropna=True, observed=True).size().reset_index(name="Records")
         value = "Records"
     else:
-        frame = dataframe.groupby(keys, dropna=True)[spec.y].sum().reset_index()
+        frame = dataframe.groupby(keys, dropna=True, observed=True)[spec.y].sum().reset_index()
         value = spec.y
 
     if spec.color and spec.color in frame.columns:
         frame = fold_small_series(frame, spec.color, value)
-        frame = frame.groupby(keys, dropna=True)[value].sum().reset_index()
-    return frame.head(limit)
+        frame = frame.groupby(keys, dropna=True, observed=True)[value].sum().reset_index()
+    return _cap(frame, spec, value, limit)
 
 
 def _explore_figure(frame: pd.DataFrame, spec) -> go.Figure | None:
@@ -492,6 +513,8 @@ def _explore_figure(frame: pd.DataFrame, spec) -> go.Figure | None:
             frame.sort_values(value), x=value, y=spec.x, orientation="h",
             color_discrete_sequence=[LEAF],
         )
+    elif spec.form == "histogram":
+        figure = px.histogram(frame, x=spec.x, nbins=35, color_discrete_sequence=[ACCENT])
     elif spec.form == "scatter":
         figure = px.scatter(frame, x=spec.x, y=spec.y, color_discrete_sequence=[ACCENT])
         figure.update_traces(marker={"size": 8, "opacity": 0.7})
@@ -501,7 +524,15 @@ def _explore_figure(frame: pd.DataFrame, spec) -> go.Figure | None:
     else:
         return None
 
-    figure.update_layout(title=f"{value} by {spec.x}" if spec.x else value)
+    if spec.form == "heatmap":
+        # The colour is the measurement; naming only the two axes describes the
+        # grid and not what is in it.
+        title = f"{spec.color} by {spec.y} and {spec.x}"
+    elif spec.form == "histogram":
+        title = f"Distribution of {spec.x}"
+    else:
+        title = f"{value} by {spec.x}" if spec.x else value
+    figure.update_layout(title=title)
     if spec.form in ("column", "bar"):
         figure.update_traces(marker_line_width=0)
     return style_chart(figure, height=380)
@@ -539,7 +570,15 @@ def render_explore(dataframe: pd.DataFrame, roles: ColumnRoles) -> None:
 
     frame = _explore_frame(dataframe, spec)
     if spec.form == "stat":
-        st.metric(spec.y or "Value", format_number(float(dataframe[spec.y].dropna().iloc[0]), spec.y))
+        present = dataframe[spec.y].dropna() if spec.y else pd.Series(dtype="float64")
+        if present.empty:
+            st.markdown(
+                f'<div class="empty-state">{escape(str(spec.y))} has no values in this '
+                "view, so there is nothing to chart.</div>",
+                unsafe_allow_html=True,
+            )
+            return
+        st.metric(spec.y or "Value", format_number(float(present.iloc[0]), spec.y))
     elif spec.form == "table":
         st.dataframe(frame, hide_index=True, width="stretch")
     else:


### PR DESCRIPTION
## What problem does this solve?

A twelve-lens audit of `0f66f37` found **81 bugs**, every one shipped with a repro that was actually run. All 81 were re-executed against the real modules before any code was touched, and all 81 reproduced. After merging duplicate reports of the same root cause: **59 distinct bugs** from nine subsystem lenses, **22** from three more covering deployment, security and documentation.

The serious ones were not edge cases. They were wrong numbers printed with confidence on files people really upload:

- **Timezone-aware dates crashed the entire brief.** Every Stripe, Shopify and analytics export writes an offset.
- **Identical rows were deleted as duplicates** — 49% of revenue removed from every number on the page for a point-of-sale file.
- **dd/mm/yyyy was silently read as mm/dd**, collapsing a European year into twelve days of January.
- **Long files were truncated from the front**, so the brief described the oldest periods and the forecast "predicted" months already in the file.
- **The AI approval gate described a different calculation than the one it ran**, which made the gate worse than no gate.
- **The privacy claim was false.** `README.md` promised *"Neither receives your rows or cell values."* Segment names — customer and product names — travel to the model inside evidence sentences. Verified by putting a marker value in a file and watching it reach the payload.
- **The public app was down** because `app.py` and `ui.py` both imported the optional AI layer at module scope, so one optional dependency took every no-API-key feature with it.

## What changed?

Fourteen commits, each one subsystem, each independently reviewable:

| Commit | Area |
|---|---|
| `aa4c1bc` | Silent data corruption: timezones, day-first dates, duplicate deletion, truncation, thousands separators, CSV parsing |
| `d9d5ec8` | The optional AI layer is optional again; CI actually imports the app |
| `6d4e038` | Privacy claims corrected to what is true, with tests that could falsify them |
| `bfaca97` | AI plan validation and an approval sentence that matches execution |
| `e137080` | Dataset identity, so answers do not outlive the table they came from |
| `0862633` | No share quoted when the parts do not add up to the whole |
| `01bb6ce` | Trend wording, period labels, KPI tiles, int64 overflow, number rendering |
| `4017053` | Explore tab: chart sizing, row selection, binning, crash |
| `06df9fe` | Role detection independent of column order |
| `ce03e9e` | Period completeness, coverage disclosure, scale estimator |
| `0301e14` | Ask ADA sentences matching their arithmetic |
| `0e8f4b6` | Exported index detection, date-named segments, heatmap grain, CSV export safety |
| `94bf24a` | Reference pages describing the code that exists |
| `6c37b18` | Where the key and the parsed files actually live |

## Evidence and trust boundaries

**This PR changes a documented privacy boundary — please read this section.**

The claim that the AI layer never receives cell values was **false**, and is now corrected rather than defended. What actually travels: column names, types, and computed evidence — and because an evidence sentence names the segment it describes, a segment label such as a customer or product name travels inside it. Rows never do. Six documents and four in-app strings said otherwise.

The documentation claimed this contract was "enforced by the test suite". It was enforced by two assertions on key names, which cannot detect a leak, because a leak arrives inside a value. Three tests now put distinctive markers in a non-segment column and search the payload text, plus one that pins the segment names that *do* travel — so the boundary cannot move in either direction without a test failing.

Also changed:

- **"Nothing leaves your machine"** is true self-hosted and false on the hosted demo, where the upload reaches a Streamlit server. Both cases are now described.
- **The parsed-file cache** was unbounded and process-global while the docs said "no persistence". Bounded to eight entries for an hour, and documented as what it is.
- **Duplicate rows are kept by default.** `clean_dataframe(frame, drop_duplicates=True)` opts in. This changes analytical output for any file containing repeat rows — deliberately, since the previous behaviour deleted real revenue.
- **Truncation keeps the most recent rows**, not the first, and cleaning runs before the cut so the skipped count is real.
- **No new external calls, no new dependencies, no cost change.**

Two existing tests asserted the old wrong behaviour and were changed with the reasoning recorded in the commits: one pinned a concentration card on mixed-sign data (`758.8%`), the other pinned `136.0%` as a KPI, which is the sum of four monthly margins.

## Verification

- [x] `ruff check .`
- [x] `python -m unittest discover -s tests -v` — **179 → 254 tests**
- [x] New or changed analytical behavior has tests — every fix carries one, and each was re-checked against its original repro
- [ ] UI changes include screenshots — Explore and dashboard rendering changed; covered by `AppTest` assertions rather than screenshots
- [x] No credentials, private datasets, or generated build output are committed

CI on this PR: **`test (3.11)`, `test (3.12)` and `test (3.13)` all green.**

Also run locally against the **pinned** dependency set (`plotly 6.9.0`, not the sandbox's 7.0.0) on all three interpreters before pushing.

CI itself is part of the diff and could not have caught the outage: it byte-compiled `app.py`, which only parses, and never imported it — and its hand-written module list had drifted, omitting `autovis.py`. The list is now a glob, the app is imported, and the job runs on three interpreters instead of assuming the host matches the one we happened to test.

## Known limitation, not fixed

Anomaly detection over-flags near-two-valued series. The `robust_scale` fallback was measurably wrong — it under-estimated sigma by about 20% — and that is fixed; both estimators now recover sigma = 1.0 on normal data and the continuous false-alarm rate sits at 0.044 against a 0.05 target. But a series that only ever reads 20 or 21 still flags around 72% of the time, down from 84%, because the thresholds are calibrated for continuous residuals. An abstention rule closed that gap and also silenced a genuine four-fold spike, which is a worse trade, so the limitation stands and is documented rather than papered over.

## Deliberately out of scope

`nlq.py` question parsing (PRs #33 and #34) and passing column values to `format_number` in Ask ADA answers (PR #31) were left untouched throughout, so this does not collide with open contributor work.