### PR TITLE
Fix the live outage's root cause and four regressions from #37

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -8,4 +8,7 @@ font = "sans serif"
 [server]
 maxUploadSize = 25
 headless = true
-fileWatcherType = "none"
+# The file watcher stays on. With it off, Streamlit re-runs app.py on each
+# deploy but never reloads a module it has already imported, so a symbol added
+# to file_io.py or ai_insights.py raises "cannot import name" from app.py for
+# the life of the server process. That is what took the public app down.

--- a/aggregation.py
+++ b/aggregation.py
@@ -262,6 +262,22 @@ def segment_frame(dataframe: pd.DataFrame, roles: ColumnRoles, limit: int = 12) 
 UNLABELLED_SEGMENT = "(not recorded)"
 
 
+def unlabelled_label(existing) -> str:
+    """The name shown for rows with no segment, chosen not to be a real one.
+
+    The file can already contain the literal "(not recorded)" -- some exports
+    write exactly that -- and folding genuinely blank rows into it merged two
+    different populations into one number. Step the label until it is unused.
+    """
+    present = {str(value) for value in existing if value is not None}
+    label = UNLABELLED_SEGMENT
+    suffix = 2
+    while label in present:
+        label = f"{UNLABELLED_SEGMENT[:-1]}, {suffix})"
+        suffix += 1
+    return label
+
+
 def segment_period_change(
     dataframe: pd.DataFrame, roles: ColumnRoles
 ) -> tuple[pd.DataFrame, pd.Timestamp, pd.Timestamp] | None:
@@ -285,7 +301,7 @@ def segment_period_change(
     # here and keeping it in the trend meant the drivers were shares of a
     # movement they did not add up to.
     working[roles.dimension] = working[roles.dimension].astype(object).where(
-        working[roles.dimension].notna(), UNLABELLED_SEGMENT
+        working[roles.dimension].notna(), unlabelled_label(working[roles.dimension].dropna().unique())
     )
     working["Period"] = working[roles.date].dt.to_period(frequency).dt.to_timestamp()
     comparison = working[working["Period"].isin([previous_period, current_period])]

--- a/ai_insights.py
+++ b/ai_insights.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel, Field
 
 from business_insights import BusinessBrief
 from nlq import AGGREGATION_LABELS, QueryAnswer, QueryPlan, ValueFilter, execute_plan
-from schema import ColumnRoles
+from schema import ColumnRoles, looks_like_identifier
 
 
 class AIAction(BaseModel):
@@ -211,20 +211,37 @@ def _usable_measure(dataframe: pd.DataFrame, column: str, aggregation: str) -> b
     return is_numeric_dtype(dataframe[column])
 
 
+# Below this many rows, every value being distinct says nothing: a two-row
+# regional summary has two distinct regions and is exactly what a breakdown
+# is for.
+IDENTIFIER_EVIDENCE_ROWS = 25
+
+
 def _usable_dimension(dataframe: pd.DataFrame, column: str) -> bool:
-    """A segment groups records together. A timestamp or an id does not."""
+    """A segment groups records together. A timestamp or an id does not.
+
+    Uniqueness on its own is not evidence of an identifier -- a pre-aggregated
+    table is unique by construction. So a column is refused when its name
+    says it is a key, when it is a timestamp, when it is a continuous number,
+    or when it is unique across enough rows for that to mean something.
+    """
     series = dataframe[column]
     if is_datetime64_any_dtype(series):
         return False
     present = int(series.notna().sum())
     if not present:
         return False
+    if looks_like_identifier(column, series):
+        return False
+    distinct = int(series.nunique(dropna=True))
     if is_numeric_dtype(series) and not is_bool_dtype(series):
         # A continuous measure is not a segment, and grouping by it produces a
         # row per distinct value.
-        if series.dropna().nunique() > present * IDENTIFIER_UNIQUENESS:
+        if (series.dropna() % 1 != 0).any() or distinct > present * IDENTIFIER_UNIQUENESS:
             return False
-    return series.nunique(dropna=True) <= present * IDENTIFIER_UNIQUENESS
+    if present >= IDENTIFIER_EVIDENCE_ROWS and distinct > present * IDENTIFIER_UNIQUENESS:
+        return False
+    return True
 
 
 def _to_query_plan(
@@ -381,7 +398,10 @@ def describe_query_plan(plan: QueryPlan) -> str:
         described = "rows" if plan.aggregation == "count" else f"{aggregation.lower()} {measure}"
         description = f"rank {plan.dimension} by {described}, showing {showing}"
     elif plan.intent == "breakdown":
-        described = "rows" if plan.aggregation == "count" else f"total {measure}"
+        # The executor honours every aggregation here, so the sentence must
+        # name the one chosen. Hard-coding "total" once described a mean as a
+        # sum, which is the exact lie the approval step exists to prevent.
+        described = "rows" if plan.aggregation == "count" else f"{aggregation.lower()} {measure}"
         description = f"break {described} down by {plan.dimension}"
     else:
         description = f"{aggregation.lower()} of {measure}"

--- a/analysis.py
+++ b/analysis.py
@@ -101,31 +101,83 @@ def _normalize_datetime_columns(frame: pd.DataFrame) -> int:
 # optional currency symbol, then digits with grouping punctuation. Anything
 # holding a slash or a letter is not this -- notably a date, which would
 # otherwise survive as a very large integer.
+# A business-formatted number: an optional sign or accounting parentheses, an
+# optional currency symbol, then digits with grouping punctuation. Anything
+# holding a slash or a letter is not this -- notably a date, which would
+# otherwise survive as a very large integer.
 _MONEY = re.compile(r"^[+-]?\(?\s*[-+]?\s*[$\u20ac\u00a3\u00a5\u20b9]?\s*\d[\d,.\s']*\)?$")
+_CURRENCY_CHARS = "$\u20ac\u00a3\u00a5\u20b9"
+
+
+def _read_formatted_number(text: str) -> float | None:
+    """Read one business-formatted number, or refuse it.
+
+    The sign is settled first and never touched again: a leading minus, a
+    leading plus, or accounting parentheses. An earlier version of this
+    stripped "everything that is not a digit" and took the minus sign with it,
+    so refunds became revenue. That is the one mistake this function must not
+    be able to make again, whatever else it gets wrong.
+
+    Then the separators. When both "," and "." appear, the one that comes
+    last is the decimal point and the other is grouping. When only one
+    appears, three digits after it is grouping ("1,000") and one or two is a
+    decimal ("1234,50"); "1,234" alone reads as a thousand, which is what
+    pandas and every US export mean by it.
+    """
+    raw = text.strip()
+    if not raw or not _MONEY.match(raw):
+        return None
+    negative = raw.startswith("-") or (raw.startswith("(") and raw.endswith(")"))
+    body = raw.strip("()+-").strip()
+    if body.startswith("-") or body.startswith("+"):
+        # A second sign after the currency symbol, "$-100", or a redundant one
+        # inside accounting parentheses, "-(100)": both say negative once more.
+        negative = negative or body.startswith("-")
+        body = body[1:].strip()
+    body = "".join(ch for ch in body if ch not in _CURRENCY_CHARS and not ch.isspace() and ch != "'")
+    if not body or not body[0].isdigit():
+        return None
+
+    last_comma, last_dot = body.rfind(","), body.rfind(".")
+    if last_comma >= 0 and last_dot >= 0:
+        decimal = "," if last_comma > last_dot else "."
+    elif last_comma >= 0:
+        digits_after = len(body) - last_comma - 1
+        decimal = "," if body.count(",") == 1 and digits_after in (1, 2) else None
+    elif last_dot >= 0:
+        digits_after = len(body) - last_dot - 1
+        # "1.234.567" is grouped; "1.234" is a decimal; "12.5" is a decimal.
+        decimal = None if body.count(".") > 1 else "."
+        if decimal == "." and body.count(".") == 1 and digits_after == 3 and len(body) > 4:
+            # "1.234" with nothing to disambiguate stays a decimal, matching
+            # pd.to_numeric; only the multi-dot form is treated as grouping.
+            decimal = "."
+    else:
+        decimal = None
+
+    grouping = {",", "."} - ({decimal} if decimal else set())
+    for mark in grouping:
+        body = body.replace(mark, "")
+    if decimal and decimal != ".":
+        body = body.replace(decimal, ".")
+    try:
+        value = float(body)
+    except ValueError:
+        return None
+    return -value if negative else value
 
 
 def _numeric_from_text(values: pd.Series) -> pd.Series:
-    """Read business-formatted numbers: "$1,203.55", "(48.10)", "1 234,50".
+    """Read business-formatted numbers cell by cell: "$1,203.55", "(48.10)", "1 234,50".
 
     A thousands separator is punctuation, not data, and an amount in
     parentheses is how every accounting export writes a negative. Reading
     them as text loses the largest values in the file, which are exactly the
     ones with a separator in them.
     """
-    text = values.astype("string").str.strip()
-    money = text.str.match(_MONEY, na=False)
-    text = text.where(money)
-    negative = text.str.contains(r"\(", na=False)
-    text = text.str.replace(r"[^\d,.]", "", regex=True)
-    # "1.234,50" is European; "1,234.50" is not. Whichever separator comes
-    # last is the decimal point.
-    european = text.str.contains(r",\d{1,2}$", na=False) & ~text.str.contains(r"\.\d", na=False)
-    text = text.mask(
-        european, text.str.replace(".", "", regex=False).str.replace(",", ".", regex=False)
-    )
-    text = text.mask(~european, text.str.replace(",", "", regex=False))
-    parsed = pd.to_numeric(text, errors="coerce")
-    return parsed.mask(negative & parsed.notna(), -parsed)
+    return values.map(
+        lambda value: _read_formatted_number(value) if isinstance(value, str) else None
+    ).astype("float64")
 
 
 # A date written day-or-month first: "3/1/2024", "03-01-24". A year-leading
@@ -254,11 +306,7 @@ def clean_dataframe(
     datetime_columns_inferred = _normalize_datetime_columns(cleaned)
     unparsed_date_cells = 0
     notes: list[str] = []
-    if _widen_columns_that_would_overflow(cleaned):
-        notes.append(
-            "A column's values are large enough that their total would not fit in a whole "
-            "number, so it is measured as a decimal; the last few digits are approximate."
-        )
+
     if datetime_columns_inferred:
         notes.append(
             "Timezone offsets were dropped; dates are read as the local time they were written in."
@@ -301,10 +349,12 @@ def clean_dataframe(
                 # punctuation a finance export writes: grouping separators, a
                 # currency symbol, parentheses for a negative. The values that
                 # need it are the large ones, so leaving them out biases every
-                # total downwards.
-                formatted = _numeric_from_text(cleaned[column])
-                if formatted.notna().sum() > parsed_numeric.notna().sum():
-                    parsed_numeric = formatted
+                # total downwards. Only the gaps are filled -- a value plain
+                # parsing already read ("1e3") is never replaced.
+                gaps = parsed_numeric.isna() & cleaned[column].notna()
+                if gaps.any():
+                    formatted = _numeric_from_text(cleaned[column].where(gaps))
+                    parsed_numeric = parsed_numeric.astype("float64").fillna(formatted)
             if parsed_numeric.notna().sum() / non_null_before >= numeric_ratio:
                 cleaned[column] = parsed_numeric
                 numeric_columns_inferred += 1
@@ -325,6 +375,14 @@ def clean_dataframe(
                         notes.append(_ordering_note(column, ordering))
                     cleaned[column] = _drop_timezone(parsed_dates)
                     datetime_columns_inferred += 1
+
+    # Inference can produce a new int64 column, so the overflow check runs
+    # once everything that will be numeric already is.
+    if _widen_columns_that_would_overflow(cleaned):
+        notes.append(
+            "A column's values are large enough that their total would not fit in a whole "
+            "number, so it is measured as a decimal; the last few digits are approximate."
+        )
 
     duplicate_rows = int(cleaned.duplicated().sum())
     if drop_duplicates:

--- a/app.py
+++ b/app.py
@@ -3,19 +3,96 @@
 from __future__ import annotations
 
 import hashlib
+import importlib
 import os
 import secrets
+import sys
+from pathlib import Path
 
 import pandas as pd
 import streamlit as st
 from streamlit.errors import StreamlitSecretNotFoundError
 
-from analysis import column_profile
-from business_insights import BusinessBrief, analyze_business, build_business_report
-from demo_data import make_demo_data
-from file_io import list_excel_sheets, list_sample_datasets, read_tabular_file, safe_csv
-from nlq import QueryPlan, answer_question, suggested_questions
-from pipeline import (
+# ---------------------------------------------------------------------------
+# Keep ADA's own modules current across deploys.
+#
+# Streamlit re-executes this file on every rerun, but a module it has already
+# imported stays in sys.modules until the process restarts -- and a hosted
+# process can outlive many deploys. When file_io.py gained a function and this
+# file started importing it, the host was still holding July's file_io and
+# raised "cannot import name" until someone rebooted it by hand. So before any
+# local import, every local module whose source on disk no longer matches what
+# was loaded is reloaded, leaves first so dependants rebind to fresh code.
+# ---------------------------------------------------------------------------
+_HERE = Path(__file__).resolve().parent
+_LOCAL_MODULES = (  # dependency order: a module lists only modules above it
+    "formatting", "schema", "timeseries", "anomalies", "forecasting", "aggregation",
+    "analysis", "autovis", "file_io", "demo_data", "business_insights", "nlq",
+    "pipeline", "ai_insights", "ui",
+)
+
+
+def _source_digest(name: str) -> str:
+    path = _HERE / f"{name}.py"
+    return hashlib.sha256(path.read_bytes()).hexdigest() if path.exists() else ""
+
+
+@st.cache_resource(show_spinner=False)
+def _loaded_digests() -> dict[str, str]:
+    """What each local module looked like when this process first loaded it."""
+    return {}
+
+
+def _refresh_stale_modules() -> None:
+    loaded = _loaded_digests()
+    stale = [
+        name
+        for name in _LOCAL_MODULES
+        if name in sys.modules and loaded.get(name) not in ("", None, _source_digest(name))
+    ]
+    if stale:
+        # Reload the whole chain from the first stale module onwards, so a
+        # module that imported a name from it is rebound rather than left
+        # holding the old object.
+        first = min(_LOCAL_MODULES.index(name) for name in stale)
+        for name in _LOCAL_MODULES[first:]:
+            if name in sys.modules:
+                importlib.reload(sys.modules[name])
+    for name in _LOCAL_MODULES:
+        loaded[name] = _source_digest(name)
+
+
+_refresh_stale_modules()
+
+
+@st.cache_resource(show_spinner=False)
+def build_identifier() -> str:
+    """The revision this process is serving, so a mixed deploy is visible.
+
+    Prefers the git commit; falls back to a digest of the source files, which
+    also changes if any one of them differs from the rest of the checkout.
+    """
+    head = _HERE / ".git" / "HEAD"
+    try:
+        ref = head.read_text().strip()
+        if ref.startswith("ref: "):
+            ref = (_HERE / ".git" / ref[5:]).read_text().strip()
+        if len(ref) >= 7:
+            return ref[:7]
+    except OSError:
+        pass
+    digest = hashlib.sha256()
+    for name in _LOCAL_MODULES + ("app",):
+        digest.update(_source_digest(name).encode())
+    return "src-" + digest.hexdigest()[:7]
+
+
+from analysis import column_profile  # noqa: E402 - the refresh above must run first
+from business_insights import BusinessBrief, analyze_business, build_business_report  # noqa: E402
+from demo_data import make_demo_data  # noqa: E402
+from file_io import list_excel_sheets, list_sample_datasets, read_tabular_file, safe_csv  # noqa: E402
+from nlq import QueryPlan, answer_question, suggested_questions  # noqa: E402
+from pipeline import (  # noqa: E402
     apply_focus,
     apply_role_selection,
     cleaning_audit_frame,
@@ -28,7 +105,7 @@ from pipeline import (
 # at module scope meant one missing package took down the whole product --
 # including the deterministic analysis that is the reason to open ADA without
 # a key at all. A failure here disables the two optional calls and nothing else.
-try:
+try:  # noqa: E402
     from ai_insights import (
         DEFAULT_PRESET,
         MODEL_PRESETS,
@@ -46,7 +123,7 @@ except Exception as error:  # noqa: BLE001 - any import failure must degrade, no
     AI_LAYER_ERROR = f"{type(error).__name__}: {error}"
     DEFAULT_PRESET, MODEL_PRESETS, AINarrative = "", {}, ()
 
-from ui import (
+from ui import (  # noqa: E402
     inject_styles,
     render_ai_narrative,
     render_brief,
@@ -369,7 +446,7 @@ if source_mode == "Upload your file":
     )
     if uploaded_file is None:
         render_how_it_works()
-        render_footer()
+        render_footer(build=build_identifier())
         st.stop()
 
 try:
@@ -403,7 +480,7 @@ try:
     else:
         # No usable source: show the explainer rather than a traceback.
         render_how_it_works()
-        render_footer()
+        render_footer(build=build_identifier())
         st.stop()
 
     prepared = prepare_analysis(raw_dataframe, row_limit=MAX_ANALYSIS_ROWS)
@@ -618,4 +695,4 @@ with data_tab:
     st.subheader("Data dictionary")
     st.dataframe(column_profile(dataframe), hide_index=True, width="stretch")
 
-render_footer()
+render_footer(build=build_identifier())

--- a/nlq.py
+++ b/nlq.py
@@ -15,7 +15,7 @@ from typing import Literal
 
 import pandas as pd
 
-from aggregation import TrendSeries, build_trend, preferred_frequency
+from aggregation import TrendSeries, build_trend, preferred_frequency, unlabelled_label
 from formatting import format_number
 from schema import ColumnRoles
 
@@ -105,9 +105,6 @@ MONTH_NAMES = {
 
 MAX_FILTER_CANDIDATES = 200
 BREAKDOWN_LIMIT = 12
-# Rows whose segment is blank still hold measure values, so they are shown
-# under a label rather than deleted out of the denominator.
-UNLABELLED = "(not recorded)"
 
 QUERY_STOPWORDS = {
     "a", "about", "across", "all", "and", "are", "by", "can", "do", "does", "each",
@@ -424,7 +421,8 @@ def _grouped_frame(
     # the reader never saw.
     labelled = dataframe.copy()
     labelled[plan.dimension] = labelled[plan.dimension].astype(object).where(
-        labelled[plan.dimension].notna(), UNLABELLED
+        labelled[plan.dimension].notna(),
+        unlabelled_label(labelled[plan.dimension].dropna().unique()),
     )
     working = labelled
     if plan.aggregation == "count" or not plan.measure:

--- a/tests/test_ai_insights.py
+++ b/tests/test_ai_insights.py
@@ -187,6 +187,28 @@ class PlanValidationTests(unittest.TestCase):
         self.assertEqual(plan.dimension, "Region")
         self.assertEqual(plan.grain, "M")
 
+    def test_the_breakdown_sentence_names_the_aggregation_that_runs(self):
+        """A mean described as "total" is the exact lie the gate exists to stop."""
+        for aggregation, word in (("sum", "total"), ("mean", "average"), ("median", "median"),
+                                  ("min", "minimum"), ("max", "maximum")):
+            with self.subTest(aggregation=aggregation):
+                plan = self._plan(intent="breakdown", aggregation=aggregation,
+                                  measure="Revenue", dimension="Region")
+                assert plan is not None
+                self.assertIn(f"{word} Revenue", describe_query_plan(plan))
+
+    def test_a_small_pre_aggregated_table_can_be_broken_down(self):
+        """Two regions in a two-row summary are unique by construction, not an id."""
+        summary = pd.DataFrame({"Region": ["West", "East"], "Revenue": [100.0, 200.0]})
+
+        plan = _to_query_plan(
+            AIQueryPlan(answerable=True, intent="breakdown", aggregation="sum",
+                        measure="Revenue", dimension="Region"),
+            summary, detect_roles(summary),
+        )
+
+        self.assertIsNotNone(plan)
+
     def test_every_approved_plan_executes_without_raising(self):
         """Nothing that survives validation may blow up in the executor."""
         for intent in ("aggregate", "count", "rank", "breakdown", "trend", "growth"):

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -142,6 +142,40 @@ class TimezoneTests(unittest.TestCase):
 
 
 class BusinessFormattedNumberTests(unittest.TestCase):
+    def test_a_leading_minus_sign_is_never_lost(self):
+        """The one mistake this parser must not be able to make: a refund
+        becoming revenue because the sign was stripped with the punctuation."""
+        frame = pd.DataFrame({"Amount": ["-100", "1,000", "-$1,000.00", "$2,000.00", "(48.10)"]})
+
+        cleaned, _ = clean_dataframe(frame)
+
+        self.assertEqual(cleaned["Amount"].tolist(), [-100.0, 1000.0, -1000.0, 2000.0, -48.10])
+
+    def test_european_decimals_keep_their_magnitude(self):
+        frame = pd.DataFrame({"Amount": ["1.234,50", "2.345,60", "1 234,50", "1'234.50"]})
+
+        cleaned, _ = clean_dataframe(frame)
+
+        self.assertEqual(cleaned["Amount"].tolist(), [1234.5, 2345.6, 1234.5, 1234.5])
+
+    def test_a_value_plain_parsing_already_read_is_never_replaced(self):
+        frame = pd.DataFrame({"Amount": ["1e3"] + ["1,000"] * 19})
+
+        cleaned, _ = clean_dataframe(frame)
+
+        self.assertEqual(int(cleaned["Amount"].isna().sum()), 0)
+        self.assertEqual(cleaned["Amount"].iloc[0], 1000.0)
+
+    def test_overflow_widening_sees_columns_that_inference_produced(self):
+        frame = pd.DataFrame({"Amount": ["5000000000000000000"] * 2})
+
+        cleaned, report = clean_dataframe(frame)
+
+        self.assertGreater(float(cleaned["Amount"].sum()), 0)
+        self.assertAlmostEqual(float(cleaned["Amount"].sum()), 1e19, delta=1e4)
+        self.assertTrue(any("would not fit" in note for note in report.notes))
+
+
     def test_thousands_separators_do_not_delete_the_largest_values(self):
         frame = pd.DataFrame({"Revenue": ["950.00", "1,203.55", "12,400.10", "88.20"]})
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,5 +1,11 @@
+import os
+import shutil
+import subprocess
 import sys
+import tempfile
+import textwrap
 import unittest
+from pathlib import Path
 
 import pandas as pd
 from streamlit.testing.v1 import AppTest
@@ -90,6 +96,60 @@ class SourceSelectionTests(unittest.TestCase):
 
         self.assertFalse(app.exception)
         self.assertEqual(len(app.tabs), 6)
+
+
+class StaleModuleTests(unittest.TestCase):
+    """A deploy that adds a symbol must not strand a long-lived server process.
+
+    Streamlit re-executes app.py on every rerun but keeps already-imported
+    modules cached. The public app was down for a day because file_io.py
+    gained a function the cached copy did not have. This reproduces that in a
+    subprocess -- one process, two runs, source changed between them.
+    """
+
+    SIM = textwrap.dedent(
+        r"""
+        import sys, runpy, warnings, logging, io, contextlib
+        warnings.filterwarnings("ignore"); logging.disable(logging.CRITICAL)
+        def run():
+            try:
+                with contextlib.redirect_stderr(io.StringIO()):
+                    runpy.run_path("app.py", run_name="__main__")
+            except SystemExit:
+                pass
+        run()
+        with open("file_io.py", "a") as handle:
+            handle.write("\n\ndef brand_new_export(frame):\n    return 'fresh'\n")
+        src = open("app.py").read().replace(
+            "from file_io import list_excel_sheets,",
+            "from file_io import brand_new_export, list_excel_sheets,",
+        )
+        open("app.py", "w").write(src)
+        run()
+        import file_io
+        print("FRESH" if hasattr(file_io, "brand_new_export") else "STALE")
+        """
+    )
+
+    def test_a_symbol_added_by_a_deploy_is_importable_without_a_restart(self):
+        root = Path(__file__).resolve().parent.parent
+        with tempfile.TemporaryDirectory() as scratch:
+            for path in root.glob("*.py"):
+                shutil.copy(path, scratch)
+            for folder in ("samples", ".streamlit", "assets"):
+                if (root / folder).exists():
+                    shutil.copytree(root / folder, Path(scratch) / folder)
+            result = subprocess.run(
+                [sys.executable, "-c", self.SIM],
+                cwd=scratch,
+                capture_output=True,
+                text=True,
+                timeout=300,
+                env={**os.environ, "PYTHONPATH": scratch},
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr[-2000:])
+        self.assertIn("FRESH", result.stdout, result.stdout[-2000:])
 
 
 class OptionalAiLayerTests(unittest.TestCase):

--- a/tests/test_nlq.py
+++ b/tests/test_nlq.py
@@ -281,6 +281,20 @@ class ShareOfTotalTests(unittest.TestCase):
         self.assertAlmostEqual(float(answer.table["Total Revenue"].sum()), 1050.0)
         self.assertIn("(not recorded)", list(answer.table["Region"]))
 
+    def test_a_real_not_recorded_value_is_not_merged_with_blanks(self):
+        frame = pd.DataFrame(
+            {"Region": [None, "(not recorded)", None, "(not recorded)"], "Revenue": [300.0] * 4}
+        )
+        plan = QueryPlan(
+            intent="breakdown", aggregation="sum", measure="Revenue", dimension="Region"
+        )
+
+        answer = execute_plan(plan, frame, self._roles(frame))
+
+        # Two populations, two rows, each with its own 600.
+        self.assertEqual(len(answer.table), 2)
+        self.assertEqual(set(answer.table["Total Revenue"]), {600.0})
+
     def test_a_dimension_that_is_entirely_blank_does_not_crash(self):
         frame = pd.DataFrame({"Region": [None, None], "Revenue": [1.0, 2.0]})
         plan = QueryPlan(

--- a/ui.py
+++ b/ui.py
@@ -599,11 +599,14 @@ def render_chat_rejected() -> None:
     st.markdown("I did not run that calculation. You can ask another question whenever you’re ready.")
 
 
-def render_footer() -> None:
+def render_footer(*, build: str = "") -> None:
+    # The build tag is what lets a mixed or stale deployment be recognised
+    # from the page itself, instead of from a redacted traceback.
+    tag = f' &nbsp;·&nbsp; <span class="build">build {escape(build)}</span>' if build else ""
     st.markdown(
-        """
+        f"""
         <footer class="footer"><span>ADA · Automated Data Analyst · Built by Sainesh Nakra</span>
-        <span><a href="https://sainesh.com/" target="_blank">Portfolio ↗</a> &nbsp;·&nbsp; <a href="https://github.com/saineshnakra/automated-data-analyst" target="_blank">Contribute ↗</a></span></footer>
+        <span><a href="https://sainesh.com/" target="_blank">Portfolio ↗</a> &nbsp;·&nbsp; <a href="https://github.com/saineshnakra/automated-data-analyst" target="_blank">Contribute ↗</a>{tag}</span></footer>
         """,
         unsafe_allow_html=True,
     )


### PR DESCRIPTION
## What problem does this solve?

Two things, both urgent.

**The public app has been down since 08:03 UTC today, and the cause is one config line from July.** `.streamlit/config.toml` sets `fileWatcherType = "none"`. With the watcher off, Streamlit re-executes `app.py` on every rerun but **never reloads a module it has already imported**, for the life of the server process — and a hosted process outlives many deploys.

- PR #24 added `describe_query_plan` to `ai_insights.py` and imported it from `app.py`. The host still held July's `ai_insights` → `ImportError: cannot import name 'describe_query_plan'`. That was the original outage.
- #37 guarded that import and added `safe_csv` to `file_io.py`. Same mechanism, next stale module → the error the follow-up review saw at `from file_io import … safe_csv`.

Every push since has just changed which symbol the error names. The browser redacts the message, which is why it read as an unexplained `ImportError`. Reproduced exactly: one process, two runs of `app.py`, a function added to `file_io.py` between them.

**#37 also introduced four regressions**, found by an independent follow-up review. The worst: the formatted-number parser stripped every non-digit character and took the minus sign with it — `-100` became `100`, a refund became revenue. Worse than the unparsed text it replaced.

## What changed?

**Deployment (`5e8e141`)** — three layers, each sufficient for the case it covers:
- The file watcher is back on, with the reason written beside the setting.
- Before any local import, `app.py` compares each of ADA's own modules on disk against what this process loaded and reloads the stale ones, leaves-first so dependants rebind. A subprocess test reproduces the outage and asserts the second run imports the new symbol; without the refresh it raises the production error.
- The footer carries a **build tag** — git commit, or a source digest that also changes if any one file is out of step. A mixed deploy is now visible from the page.

**Regressions (`4388835`):**
- Number parser rewritten per-cell: sign settled first from a leading minus or accounting parentheses and never touched again; decimal mark is whichever separator comes last, so `1.234,50` is 1234.5 not 1.2345; only gaps plain parsing left are filled, so a valid `1e3` is never replaced; the int64 overflow guard now runs *after* inference produces int64 columns.
- `describe_query_plan` named the aggregation the executor uses, instead of hard-coding "total" for a `mean` breakdown.
- `_usable_dimension` no longer refuses a two-row regional summary for being "unique" — uniqueness only counts as identifier evidence across enough rows, and the name-based check is consulted first.
- The `(not recorded)` label for blank segments steps until unused, so a file that already contains that literal isn't merged into it.

## Evidence and trust boundaries

- No new external calls, no new dependencies, no cost change.
- The module refresh only touches ADA's own modules in this directory, by name, and only when a file's digest differs from what was loaded. It never reloads third-party packages.
- Number parsing: the sign-preservation property is now tested directly — a leading minus, a currency-prefixed minus, and accounting parentheses all stay negative.

## Verification

- [x] `ruff check .`
- [x] `python -m unittest discover -s tests -v` — **262 tests**
- [x] New or changed analytical behavior has tests — 8 added, including the outage reproduction
- [ ] UI changes include screenshots — footer gains a `build <sha>` tag, covered by `AppTest`
- [x] No credentials, private datasets, or generated build output are committed

CI on this PR: `test (3.11)`, `test (3.12)`, `test (3.13)` all green.

## After merging — one manual step

**This does not restart the process the host is running now.** Open the app in the Streamlit dashboard → **Manage app → Reboot**. Once. After that, the footer should read `build <7-char sha>` matching `main`, and future deploys pick up module changes on their own.