### PR TITLE
Walk every customer journey and fix what breaks along the way

### DIFF
--- a/aggregation.py
+++ b/aggregation.py
@@ -15,10 +15,10 @@ from dataclasses import dataclass
 import numpy as np
 import pandas as pd
 
-from formatting import format_period
+from formatting import format_period, is_percentage, percentage_outranks_currency
 from schema import ColumnRoles
 
-GRAIN_ORDER = ("W", "M", "Q")
+GRAIN_ORDER = ("W", "M", "Q", "Y")
 
 
 def _grain_for_span(span_days: int) -> str:
@@ -40,7 +40,23 @@ def _grain_for_cadence(dates: pd.Series) -> str:
         return "W"
     if typical <= 45:
         return "M"
-    return "Q"
+    if typical <= 140:
+        return "Q"
+    # Four annual figures are four years, not sixteen quarters twelve of
+    # which nobody measured and which were being filled with zero.
+    return "Y"
+
+
+def measure_aggregation(measure: str | None) -> str:
+    """How a measure combines across rows: rates average, amounts add.
+
+    Adding two months of conversion rate produces a number with no meaning,
+    and every surface built on period totals was doing exactly that. The
+    decision lives here so trend, segment and headline agree.
+    """
+    if measure and is_percentage(measure) and percentage_outranks_currency(measure):
+        return "mean"
+    return "sum"
 
 
 def _period_frequency(date_series: pd.Series) -> str:
@@ -168,12 +184,15 @@ def build_trend(
     working = dataframe[columns].dropna(subset=[roles.date]).copy()
     if working.empty:
         return TrendSeries(frame=EMPTY_TREND.copy(), frequency=frequency or "M")
+    # Internal names from here on. A measure the file calls "Period" was being
+    # overwritten by the period buckets built below, then summed as datetimes.
+    working.columns = ["__date"] + (["__measure"] if roles.measure else [])
 
-    frequency = frequency or _period_frequency(working[roles.date])
-    working["Period"] = working[roles.date].dt.to_period(frequency).dt.to_timestamp()
+    frequency = frequency or _period_frequency(working["__date"])
+    working["Period"] = working["__date"].dt.to_period(frequency).dt.to_timestamp()
 
     partial_period, partial_coverage, short_coverage, completeness_checked = (
-        _trailing_partial_period(working[roles.date], working["Period"], frequency)
+        _trailing_partial_period(working["__date"], working["Period"], frequency)
     )
     if partial_period is not None:
         remaining = working[working["Period"] < partial_period]
@@ -183,8 +202,10 @@ def build_trend(
             partial_period, partial_coverage = None, ""
 
     if roles.measure:
-        result = working.groupby("Period", as_index=False)[roles.measure].sum()
-        result = result.rename(columns={roles.measure: "Value"})
+        result = working.groupby("Period", as_index=False)["__measure"].agg(
+            measure_aggregation(roles.measure)
+        )
+        result = result.rename(columns={"__measure": "Value"})
     else:
         result = working.groupby("Period", as_index=False).size().rename(columns={"size": "Value"})
     result = result.sort_values("Period").reset_index(drop=True)
@@ -243,18 +264,26 @@ def segment_frame(dataframe: pd.DataFrame, roles: ColumnRoles, limit: int = 12) 
     if not roles.dimension:
         return pd.DataFrame(columns=["Segment", "Value"])
 
-    working = dataframe.dropna(subset=[roles.dimension]).copy()
+    working = dataframe[[roles.dimension] + ([roles.measure] if roles.measure else [])].copy()
+    working.columns = ["__segment"] + (["__measure"] if roles.measure else [])
+    # Rows with no label still hold the measure. Dropping them made every
+    # share on the page a share of the labelled rows only, and a file that was
+    # mostly unlabelled produced no segment evidence at all.
+    label = unlabelled_label(working["__segment"].dropna().unique())
+    working["__segment"] = working["__segment"].astype(object).where(working["__segment"].notna(), label)
     if working.empty:
         return pd.DataFrame(columns=["Segment", "Value"])
 
     if roles.measure:
-        result = working.groupby(roles.dimension, as_index=False)[roles.measure].sum()
-        result = result.rename(columns={roles.dimension: "Segment", roles.measure: "Value"})
+        result = working.groupby("__segment", as_index=False)["__measure"].agg(
+            measure_aggregation(roles.measure)
+        )
+        result = result.rename(columns={"__segment": "Segment", "__measure": "Value"})
     else:
         result = (
-            working.groupby(roles.dimension, as_index=False)
+            working.groupby("__segment", as_index=False)
             .size()
-            .rename(columns={roles.dimension: "Segment", "size": "Value"})
+            .rename(columns={"__segment": "Segment", "size": "Value"})
         )
     return result.sort_values("Value", ascending=False).head(limit).reset_index(drop=True)
 
@@ -296,16 +325,22 @@ def segment_period_change(
     # periods being compared exist in one view and not the other.
     frequency = series.frequency
     working = dataframe[[roles.date, roles.measure, roles.dimension]].copy()
-    working = working.dropna(subset=[roles.date, roles.measure])
+    working.columns = ["__date", "__measure", "__segment"]
+    working = working.dropna(subset=["__date", "__measure"])
     # A row with no segment label still carries measure value. Dropping it
     # here and keeping it in the trend meant the drivers were shares of a
     # movement they did not add up to.
-    working[roles.dimension] = working[roles.dimension].astype(object).where(
-        working[roles.dimension].notna(), unlabelled_label(working[roles.dimension].dropna().unique())
+    working["__segment"] = working["__segment"].astype(object).where(
+        working["__segment"].notna(), unlabelled_label(working["__segment"].dropna().unique())
     )
-    working["Period"] = working[roles.date].dt.to_period(frequency).dt.to_timestamp()
+    working["Period"] = working["__date"].dt.to_period(frequency).dt.to_timestamp()
     comparison = working[working["Period"].isin([previous_period, current_period])]
-    grouped = comparison.groupby([roles.dimension, "Period"])[roles.measure].sum().unstack(fill_value=0)
+    grouped = (
+        comparison.groupby(["__segment", "Period"])["__measure"]
+        .agg(measure_aggregation(roles.measure))
+        .unstack(fill_value=0)
+    )
+    grouped.index.name = roles.dimension
     if previous_period not in grouped or current_period not in grouped:
         return None
 
@@ -347,15 +382,24 @@ def heatmap_frame(
 
     top_segments = segment_frame(dataframe, roles, limit=limit)["Segment"]
     columns = [roles.date, roles.dimension] + ([roles.measure] if roles.measure else [])
-    working = dataframe[columns].dropna(subset=[roles.date, roles.dimension]).copy()
-    working = working[working[roles.dimension].isin(top_segments)]
+    working = dataframe[columns].dropna(subset=[roles.date]).copy()
+    working.columns = ["__date", "__segment"] + (["__measure"] if roles.measure else [])
+    working["__segment"] = working["__segment"].astype(object).where(
+        working["__segment"].notna(), unlabelled_label(working["__segment"].dropna().unique())
+    )
+    working = working[working["__segment"].isin(top_segments)]
     if working.empty:
         return pd.DataFrame()
 
-    frequency = frequency or _period_frequency(working[roles.date])
-    working["Period"] = working[roles.date].dt.to_period(frequency).dt.to_timestamp()
+    frequency = frequency or _period_frequency(working["__date"])
+    working["Period"] = working["__date"].dt.to_period(frequency).dt.to_timestamp()
     if roles.measure:
-        pivot = working.groupby([roles.dimension, "Period"])[roles.measure].sum().unstack(fill_value=0)
+        pivot = (
+            working.groupby(["__segment", "Period"])["__measure"]
+            .agg(measure_aggregation(roles.measure))
+            .unstack(fill_value=0)
+        )
     else:
-        pivot = working.groupby([roles.dimension, "Period"]).size().unstack(fill_value=0)
+        pivot = working.groupby(["__segment", "Period"]).size().unstack(fill_value=0)
+    pivot.index.name = roles.dimension
     return pivot.loc[pivot.sum(axis=1).sort_values(ascending=False).index]

--- a/analysis.py
+++ b/analysis.py
@@ -52,6 +52,14 @@ def _speculative_dates(values: pd.Series) -> pd.Series:
         return pd.to_datetime(values, errors="coerce")
 
 
+def _is_blank(series: pd.Series) -> pd.Series:
+    """Missing, or text that is nothing but whitespace -- an empty cell either way."""
+    blank = series.isna()
+    if series.dtype == object or str(series.dtype) == "string":
+        blank = blank | series.astype("string").str.strip().eq("").fillna(False)
+    return blank
+
+
 def _drop_timezone(series: pd.Series) -> pd.Series:
     """Return the same instants as naive local time.
 
@@ -187,8 +195,15 @@ _DAY_OR_MONTH_FIRST = re.compile(r"^\s*\d{1,2}[/-]\d{1,2}[/-]\d{2,4}")
 
 def _dated(values: pd.Series, *, dayfirst: bool) -> pd.Series:
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore", UserWarning)
-        return pd.to_datetime(values, errors="coerce", dayfirst=dayfirst)
+        warnings.simplefilter("ignore", (UserWarning, FutureWarning))
+        parsed = pd.to_datetime(values, errors="coerce", dayfirst=dayfirst)
+        if parsed.dtype == object:
+            # Mixed offsets -- a file spanning a daylight-saving change --
+            # come back as objects, which no downstream step can use. There
+            # is no single wall clock to keep, so UTC is the honest choice.
+            parsed = pd.to_datetime(values, errors="coerce", dayfirst=dayfirst, utc=True)
+            parsed = parsed.dt.tz_localize(None)
+        return parsed
 
 
 def _read_dates(values: pd.Series) -> tuple[pd.Series, str]:
@@ -289,10 +304,10 @@ def clean_dataframe(
     original_rows, original_columns = cleaned.shape
     cleaned.columns = _make_unique_columns(cleaned.columns)
 
-    empty_columns = [column for column in cleaned.columns if cleaned[column].isna().all()]
+    empty_columns = [column for column in cleaned.columns if _is_blank(cleaned[column]).all()]
     cleaned = cleaned.drop(columns=empty_columns)
 
-    empty_row_mask = cleaned.isna().all(axis=1)
+    empty_row_mask = cleaned.apply(_is_blank).all(axis=1)
     empty_rows_removed = int(empty_row_mask.sum())
     cleaned = cleaned.loc[~empty_row_mask].copy()
 

--- a/business_insights.py
+++ b/business_insights.py
@@ -9,6 +9,7 @@ import pandas as pd
 
 from aggregation import (
     build_trend,
+    measure_aggregation,
     preferred_frequency,
     segment_frame,
     segment_period_change,
@@ -74,6 +75,29 @@ def _period_changes(values: np.ndarray) -> np.ndarray:
     return (current[usable] - previous[usable]) / np.abs(previous[usable]) * 100
 
 
+# A measure where going up is bad. Whole-word, head-noun style: "Cost" and
+# "Refund Amount" count, "Cost Savings" does not.
+ADVERSE_MEASURE_TOKENS = frozenset({
+    "cost", "costs", "expense", "expenses", "spend", "churn", "refund", "refunds",
+    "returns", "loss", "losses", "overdue", "delay", "delays", "hours", "tickets",
+    "complaints", "defects", "errors", "bounce", "debt", "outstanding",
+})
+FAVOURABLE_OVERRIDES = frozenset({"savings", "saved", "recovered"})
+
+
+def increase_is_welcome(measure: str | None) -> bool:
+    """Whether a rise in this measure is good news."""
+    if not measure:
+        return True
+    words = normalized_name(measure).split()
+    if not words or any(word in FAVOURABLE_OVERRIDES for word in words):
+        return True
+    # The head noun decides, and so does a leading one: "Refund Amount" is a
+    # refund before it is an amount. A word in the middle -- "Revenue After
+    # Returns" -- is a qualifier and does not flip the reading.
+    return words[-1] not in ADVERSE_MEASURE_TOKENS and words[0] not in ADVERSE_MEASURE_TOKENS
+
+
 def _movement_in_context(values: np.ndarray, change: float) -> str:
     """Say whether the latest movement is unusual for this particular series.
 
@@ -129,6 +153,9 @@ def _growth_evidence(dataframe: pd.DataFrame, roles: ColumnRoles) -> Evidence | 
     measure = roles.measure or "Records"
     measure_values = dataframe[roles.measure].dropna() if roles.measure else None
     direction = "increased" if change >= 0 else "decreased"
+    # A rising cost is not good news. Tone follows what the movement means
+    # for the business, and recommendations follow tone.
+    welcome = increase_is_welcome(roles.measure)
     context = _movement_in_context(values, change)
     if series.short_coverage:
         context += (
@@ -148,7 +175,7 @@ def _growth_evidence(dataframe: pd.DataFrame, roles: ColumnRoles) -> Evidence | 
             "(Latest period − previous period) ÷ |previous period|, set against the spread "
             "of past period-over-period changes"
         ),
-        tone="positive" if change >= 0 else "negative",
+        tone="positive" if (change >= 0) == welcome else "negative",
     )
 
 
@@ -459,7 +486,10 @@ def _relationship_evidence(dataframe: pd.DataFrame, roles: ColumnRoles) -> Evide
             "by a few extreme records rather than the bulk of the data."
         )
 
-    statement += " This is an association, not proof of causation."
+    statement += (
+        " This is an association, not proof of causation, and it was picked as the strongest "
+        "of several pairs -- a search that makes a chance result likelier than the interval suggests."
+    )
     return Evidence(
         kind="relationship",
         title="Strongest measurable relationship",
@@ -467,7 +497,9 @@ def _relationship_evidence(dataframe: pd.DataFrame, roles: ColumnRoles) -> Evide
         statement=statement,
         calculation=(
             "Pearson correlation across non-missing paired values, with a Fisher-transform "
-            "confidence interval and a Spearman rank check"
+            "confidence interval and a Spearman rank check. Chosen as the strongest of every "
+            "numeric pair, and the interval is not adjusted for that search -- read it as a "
+            "lead to test, not a result"
         ),
     )
 
@@ -520,12 +552,32 @@ def _quality_evidence(dataframe: pd.DataFrame) -> Evidence | None:
     )
 
 
+def _shown_evidence(evidence: list[Evidence], limit: int = 6) -> list[Evidence]:
+    """The executive preview, with a data-quality card never squeezed out.
+
+    Six cards is the reading budget. A quality warning past the sixth slot
+    was silently gone -- the one card that says the other five may be built
+    on incomplete data.
+    """
+    shown = list(evidence[:limit])
+    quality = next((item for item in evidence[limit:] if item.kind == "quality"), None)
+    if quality is not None:
+        shown = shown[: limit - 1] + [quality]
+    return shown
+
+
 def _recommendations(evidence: list[Evidence], roles: ColumnRoles) -> tuple[Recommendation, ...]:
     recommendations: list[Recommendation] = []
     by_kind = {item.kind: item for item in evidence}
 
     trend = by_kind.get("trend")
     driver = by_kind.get("driver")
+    # A segment that grew while the total fell did not cause the fall, so it
+    # is not named as the thing to reconcile. "Reconcile the Alpha decline"
+    # beside a card saying Alpha rose 110 is a contradiction on one page.
+    if driver and trend and driver.tone != trend.tone:
+        driver = None
+    adverse = "decline" if increase_is_welcome(roles.measure) else "increase"
     if trend and trend.tone == "negative":
         recommendations.append(
             Recommendation(
@@ -533,10 +585,10 @@ def _recommendations(evidence: list[Evidence], roles: ColumnRoles) -> tuple[Reco
                 (
                     f"Start with {driver.subject}"
                     if driver and driver.subject
-                    else "Find where the decline started"
+                    else f"Find where the {adverse} started"
                 ),
                 (
-                    f"Reconcile the {driver.subject} decline by customer, channel, and transaction; "
+                    f"Reconcile the {driver.subject} {adverse} by customer, channel, and transaction; "
                     "separate lost volume from pricing or mix."
                     if driver and driver.subject
                     else "Break the latest period down by "
@@ -551,9 +603,9 @@ def _recommendations(evidence: list[Evidence], roles: ColumnRoles) -> tuple[Reco
             Recommendation(
                 "Now",
                 (
-                    f"Make {driver.subject}'s growth repeatable"
+                    f"Make {driver.subject}'s improvement repeatable"
                     if driver and driver.subject
-                    else "Protect the growth driver"
+                    else "Protect what improved"
                 ),
                 (
                     f"Break {driver.subject}'s lift into volume, pricing, and mix; preserve the "
@@ -762,12 +814,16 @@ def analyze_business(dataframe: pd.DataFrame, roles: ColumnRoles | None = None) 
         headline = leader.statement
     elif roles.measure:
         measure_values = dataframe[roles.measure].dropna()
+        combined = (
+            measure_values.mean() if measure_aggregation(roles.measure) == "mean" else measure_values.sum()
+        )
         total_measure = format_number(
-            float(measure_values.sum()),
+            float(combined),
             roles.measure,
             column_values=measure_values,
         )
-        headline = f"{roles.measure} totals {total_measure} across the analyzed data."
+        verb = "averages" if measure_aggregation(roles.measure) == "mean" else "totals"
+        headline = f"{roles.measure} {verb} {total_measure} across the analyzed data."
     else:
         headline = f"{len(dataframe):,} records are ready for operational review."
 
@@ -787,7 +843,7 @@ def analyze_business(dataframe: pd.DataFrame, roles: ColumnRoles | None = None) 
         summary=" ".join(summary_parts),
         roles=roles,
         kpis=tuple(kpis),
-        evidence=tuple(evidence[:6]),
+        evidence=tuple(_shown_evidence(evidence)),
         recommendations=recommendations,
     )
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -51,6 +51,7 @@ python -m unittest discover -s tests -p "test_nlq.py" -v
 | `test_nlq.py` | Question parsing and plan execution |
 | `test_ai_insights.py` | Typed output and the privacy contract |
 | `test_autovis.py` | Chart-form choice and series folding |
+| `test_bug_bash.py` | Behaviours pinned after walking every customer journey |
 | `test_app.py` | Rendering smoke tests, and that the app survives without the AI layer |
 
 Tests use fake clients for anything model-related, so the suite needs no network

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -57,8 +57,11 @@ Everything in the second list is already on your screen before the call is made.
 ## What is never sent
 
 - Uploaded rows
-- Cell values
-- Column contents in any form — no samples, no previews, no "first five rows"
+- Your rows — not a sample, not a preview, not the first five
+- Cell values, with one exception stated above: the segment labels an
+  evidence sentence names, such as a customer or product name
+- The question you type stays local unless the rule parser cannot read it and
+  you have supplied a key; then the question itself goes to the planner
 - Your file, its name, or its bytes
 
 The payload builders (`build_query_schema`, `build_ai_payload` in

--- a/file_io.py
+++ b/file_io.py
@@ -7,6 +7,9 @@ from pathlib import Path
 from zipfile import BadZipFile
 
 import pandas as pd
+from pandas.io.parsers.readers import STR_NA_VALUES
+
+from formatting import normalized_name
 
 SUPPORTED_SUFFIXES = {".csv", ".xlsx", ".xlsm"}
 SAMPLES_DIRECTORY = Path(__file__).parent / "samples"
@@ -68,8 +71,42 @@ def list_excel_sheets(contents: bytes, filename: str) -> list[str]:
     try:
         with pd.ExcelFile(BytesIO(contents), engine="openpyxl") as workbook:
             return [str(name) for name in workbook.sheet_names]
-    except BadZipFile as error:
+    except (BadZipFile, KeyError) as error:
+        # A zip that is not a workbook -- no [Content_Types].xml -- surfaces
+        # from openpyxl as a KeyError, which the app did not catch.
         raise ValueError("The file is not a valid Excel workbook.") from error
+
+
+# pandas reads "NA" as missing by default. In business data it is North
+# America, and a region code was being turned into a blank before cleaning
+# ever saw it. Every other default marker is kept.
+NA_VALUES = sorted(STR_NA_VALUES - {"NA"})
+# A column whose last word says it holds a key is read as text, so an
+# account number written 00042 keeps its zeros instead of becoming 42.
+TEXT_HEAD_WORDS = frozenset({"id", "ids", "code", "codes", "zip", "postal", "phone", "sku", "number", "no"})
+
+
+def _kept_as_text(columns) -> dict[str, type]:
+    kept = {}
+    for column in columns:
+        words = normalized_name(str(column)).split()
+        if words and (words[-1] in TEXT_HEAD_WORDS or words == ["id"]):
+            kept[column] = str
+    return kept
+
+
+def _read_csv(contents: bytes, encoding: str, **options) -> pd.DataFrame:
+    """read_csv with the header peeked first, so id columns stay text."""
+    header = pd.read_csv(BytesIO(contents), encoding=encoding, nrows=0, **options)
+    return pd.read_csv(
+        BytesIO(contents),
+        encoding=encoding,
+        dtype=_kept_as_text(header.columns),
+        keep_default_na=False,
+        na_values=NA_VALUES,
+        low_memory=False,
+        **options,
+    )
 
 
 def _candidate_encodings(contents: bytes) -> tuple[str, ...]:
@@ -105,7 +142,7 @@ def _resplit_single_column(parsed: pd.DataFrame, contents: bytes, encoding: str)
     for separator in (";", "\t", "|"):
         if separator not in header:
             continue
-        candidate = pd.read_csv(BytesIO(contents), encoding=encoding, sep=separator, low_memory=False)
+        candidate = _read_csv(contents, encoding, sep=separator)
         if len(candidate.columns) > 1:
             return candidate
     return parsed
@@ -128,7 +165,7 @@ def _skip_title_row(parsed: pd.DataFrame, contents: bytes, encoding: str) -> pd.
     # table would shred it -- the mistake this rescue is meant to prevent.
     if "," in title or not header.count(",") or header.count(",") != first_row.count(","):
         return parsed
-    candidate = pd.read_csv(BytesIO(contents), encoding=encoding, header=1, low_memory=False)
+    candidate = _read_csv(contents, encoding, header=1)
     return candidate if len(candidate.columns) > 1 else parsed
 
 
@@ -141,18 +178,23 @@ def read_tabular_file(
     suffix = _validate(contents, filename)
     if suffix in EXCEL_SUFFIXES:
         try:
+            sheet = sheet_name if sheet_name is not None else 0
+            header = pd.read_excel(BytesIO(contents), engine="openpyxl", sheet_name=sheet, nrows=0)
             return pd.read_excel(
                 BytesIO(contents),
                 engine="openpyxl",
-                sheet_name=sheet_name if sheet_name is not None else 0,
+                sheet_name=sheet,
+                dtype=_kept_as_text(header.columns),
+                keep_default_na=False,
+                na_values=NA_VALUES,
             )
-        except BadZipFile as error:
+        except (BadZipFile, KeyError) as error:
             raise ValueError("The file is not a valid Excel workbook.") from error
 
     parse_errors: list[Exception] = []
     for encoding in _candidate_encodings(contents):
         try:
-            parsed = pd.read_csv(BytesIO(contents), encoding=encoding, low_memory=False)
+            parsed = _read_csv(contents, encoding)
             parsed = _resplit_single_column(parsed, contents, encoding)
             return _skip_title_row(parsed, contents, encoding)
         except (UnicodeDecodeError, pd.errors.ParserError) as error:

--- a/forecasting.py
+++ b/forecasting.py
@@ -212,6 +212,10 @@ def _backtest(periods: pd.DatetimeIndex, values: np.ndarray, *, monthly: bool) -
     predicted = line.at(horizon_positions) + _seasonal_adjustment(
         holdout_periods.month.to_numpy(), seasonal
     )
+    if float(train_values.min()) >= 0:
+        # Score the forecast that is actually shown: production clips a
+        # non-negative series at zero, so the backtest must too.
+        predicted = np.maximum(predicted, 0.0)
     actual = values[-holdout:]
     errors = np.abs(predicted - actual)
 

--- a/nlq.py
+++ b/nlq.py
@@ -15,7 +15,7 @@ from typing import Literal
 
 import pandas as pd
 
-from aggregation import TrendSeries, build_trend, preferred_frequency, unlabelled_label
+from aggregation import TrendSeries, build_trend, measure_aggregation, preferred_frequency, unlabelled_label
 from formatting import format_number
 from schema import ColumnRoles
 
@@ -277,10 +277,44 @@ def _unrecognized_query_tokens(
     return {token for token in question.split() if token.isalpha() and token not in allowed}
 
 
+# Phrasings the grammar cannot represent. Answering them with the nearest
+# supported question -- "revenue > 200" as the total of everything, "January
+# and February" as January -- is a precise answer to a question nobody asked.
+# Refusing hands them to the optional planner, or to the suggestion chips.
+# Comparison operators are checked on the raw text, because _norm strips them.
+UNSUPPORTED_OPERATORS = re.compile(r"[<>=\u2265\u2264\u2260]")
+UNSUPPORTED_PHRASES = re.compile(
+    r"\b(?:"
+    r"greater than|less than|more than \d+|fewer than|at least \d+|at most \d+|"
+    r"above \d+|below \d+|over \d+|under \d+|between \d+|exceeds?|exceeding|"
+    r"this (?:year|month|quarter|week)|last (?:year|month|quarter|week|\d+ (?:days|weeks|months|years))|"
+    r"next (?:year|month|quarter|week)|previous (?:year|month|quarter|week)|"
+    r"year to date|ytd|today|yesterday|past \d+|"
+    r"or"
+    r")\b"
+)
+
+
+def _asks_for_several_periods(q: str) -> bool:
+    """Two months or two years in one question is a set the plan cannot hold."""
+    months = {MONTH_NAMES[name] for name in MONTH_NAMES if re.search(rf"\b{name}\b", q)}
+    years = set(re.findall(r"\b(?:19|20)\d{2}\b", q))
+    return len(months) >= 2 or len(years) >= 2
+
+
+def unsupported_phrasing(question: str) -> bool:
+    q = _norm(question)
+    return bool(
+        UNSUPPORTED_OPERATORS.search(str(question))
+        or UNSUPPORTED_PHRASES.search(q)
+        or _asks_for_several_periods(q)
+    )
+
+
 def parse_question(question: str, dataframe: pd.DataFrame, roles: ColumnRoles) -> QueryPlan | None:
     """Turn a plain-English question into an explicit plan, or None if unsupported."""
     q = _norm(question)
-    if not q:
+    if not q or unsupported_phrasing(question):
         return None
 
     numeric_columns = [column for column in roles.numeric if column in dataframe.columns]
@@ -292,13 +326,25 @@ def parse_question(question: str, dataframe: pd.DataFrame, roles: ColumnRoles) -
         return None
     year, month = _detect_time_filter(q)
     grain = _detect_grain(q)
+    # For a grouped answer the matched dimension is the thing being grouped,
+    # so its values are not read as filters. For a plain total they are:
+    # "revenue for Region West" is a filter, and naming the column must not
+    # steal the value from it -- that answered with the all-region total.
     filters = _detect_value_filters(q, dataframe, roles, exclude=(dimension,))
+    filters_including_dimension = _detect_value_filters(q, dataframe, roles)
 
     aggregation: Aggregation | None = next(
         (AGGREGATION_WORDS[word] for word in AGGREGATION_WORDS if re.search(rf"\b{word}\b", q)),
         None,
     )
     top_match = re.search(r"\b(top|bottom)\s+(\d{1,3})\b", q)
+    if top_match and int(top_match.group(2)) < 1:
+        # "top 0" is not a ranking; it was showing the fallback twelve.
+        return None
+    # "highest" and "largest" rank; only the literal words ask for an extreme
+    # per group. Both live in AGGREGATION_WORDS as max, so they are told apart
+    # here rather than by silently downgrading every min/max to a sum.
+    explicit_extreme = bool(re.search(r"\b(min|minimum|max|maximum)\b", q))
     superlative = any(re.search(rf"\b{word}\b", q) for word in SUPERLATIVE_WORDS)
     wants_breakdown = bool(re.search(r"\b(by|per|across|breakdown|split|each)\b", q))
     wants_count = bool(re.search(r"\b(how many|count|number of)\b", q))
@@ -313,17 +359,25 @@ def parse_question(question: str, dataframe: pd.DataFrame, roles: ColumnRoles) -
         "grain": grain,
     }
 
+    ungrouped = {**base, "filters": filters_including_dimension}
+    # Chat combines a measure the way the dashboard does: rates average,
+    # amounts add. Saying "total" or "sum" out loud still gets a sum.
+    default_aggregation = measure_aggregation(base["measure"])
+
     if wants_count and not wants_growth:
         if dimension and wants_breakdown:
             return QueryPlan(intent="breakdown", aggregation="count", dimension=dimension, **base)
         countable = _match_countable(q, roles)
-        return QueryPlan(intent="count", aggregation="count", count_column=countable, **base)
+        return QueryPlan(intent="count", aggregation="count", count_column=countable, **ungrouped)
 
     if wants_growth and roles.date:
         wants_ranked_growth = superlative or any(word in q for word in ("which", "fastest", "slowest"))
         rank_dimension = dimension or (roles.dimension if wants_ranked_growth else None)
         ascending = bool(re.search(ASCENDING_PATTERN, q))
-        return QueryPlan(intent="growth", dimension=rank_dimension, ascending=ascending, **base)
+        top_n = int(top_match.group(2)) if top_match else None
+        return QueryPlan(
+            intent="growth", dimension=rank_dimension, ascending=ascending, top_n=top_n, **base
+        )
 
     if (top_match or superlative) and dimension:
         if top_match:
@@ -334,7 +388,7 @@ def parse_question(question: str, dataframe: pd.DataFrame, roles: ColumnRoles) -
             ascending = bool(re.search(ASCENDING_PATTERN, q))
         return QueryPlan(
             intent="rank",
-            aggregation=aggregation if aggregation in ("mean", "median") else "sum",
+            aggregation=_grouped_aggregation(aggregation, explicit_extreme, default_aggregation),
             dimension=dimension,
             top_n=top_n,
             ascending=ascending,
@@ -342,20 +396,37 @@ def parse_question(question: str, dataframe: pd.DataFrame, roles: ColumnRoles) -
         )
 
     if wants_trend and roles.date:
-        return QueryPlan(intent="trend", aggregation="sum", **base)
+        if aggregation not in (None, default_aggregation):
+            # The trend executor combines each period the way the measure
+            # combines. "Average revenue monthly" would be answered with sums,
+            # so it is not answered here; "average conversion rate monthly"
+            # is exactly what the executor does, so it is.
+            return None
+        return QueryPlan(intent="trend", aggregation=default_aggregation, **ungrouped)
 
     if dimension and (wants_breakdown or not measure):
         return QueryPlan(
             intent="breakdown",
-            aggregation=aggregation if aggregation in ("mean", "median") else "sum",
+            aggregation=_grouped_aggregation(aggregation, explicit_extreme, default_aggregation),
             dimension=dimension,
             **base,
         )
 
     if base["measure"] and (aggregation or measure):
-        return QueryPlan(intent="aggregate", aggregation=aggregation or "sum", **base)
+        return QueryPlan(intent="aggregate", aggregation=aggregation or default_aggregation, **ungrouped)
 
     return None
+
+
+def _grouped_aggregation(
+    aggregation: Aggregation | None, explicit_extreme: bool, default: Aggregation
+) -> Aggregation:
+    """What a rank or breakdown computes per group."""
+    if aggregation in ("mean", "median"):
+        return aggregation
+    if aggregation in ("min", "max") and explicit_extreme:
+        return aggregation
+    return default
 
 
 class TimeScopeUnavailable(Exception):
@@ -586,7 +657,7 @@ def execute_plan(plan: QueryPlan, dataframe: pd.DataFrame, roles: ColumnRoles) -
             plan=plan,
             answer=answer,
             calculation=_with_notes(
-                f"sum({plan.measure or 'rows'}) grouped per {grain_name}{scope}", series
+                f"{plan.aggregation}({plan.measure or 'rows'}) grouped per {grain_name}{scope}", series
             ),
             table=trend,
             chart="line",
@@ -631,12 +702,12 @@ def _execute_growth(
         frame = working[[roles.date, plan.dimension] + ([measure] if measure else [])].dropna(
             subset=[roles.date, plan.dimension]
         )
-        frame = frame.assign(Period=frame[roles.date].dt.to_period(grain).dt.to_timestamp())
-        frame = frame[frame["Period"].isin([previous_period, current_period])]
+        frame = frame.assign(__period=frame[roles.date].dt.to_period(grain).dt.to_timestamp())
+        frame = frame[frame["__period"].isin([previous_period, current_period])]
         if measure:
-            pivot = frame.groupby([plan.dimension, "Period"])[measure].sum().unstack(fill_value=0.0)
+            pivot = frame.groupby([plan.dimension, "__period"])[measure].sum().unstack(fill_value=0.0)
         else:
-            pivot = frame.groupby([plan.dimension, "Period"]).size().unstack(fill_value=0)
+            pivot = frame.groupby([plan.dimension, "__period"]).size().unstack(fill_value=0)
         if previous_period not in pivot.columns or current_period not in pivot.columns:
             return QueryAnswer(
                 question="",
@@ -682,6 +753,8 @@ def _execute_growth(
         change = (result["Latest"] - result["Previous"]) / result["Previous"].abs() * 100
         result["Change %"] = change.round(1)
         result = result.sort_values("Change %", ascending=plan.ascending).reset_index(drop=True)
+        if plan.top_n:
+            result = result.head(plan.top_n)
         leader = result.iloc[0]
         direction = "slowest" if plan.ascending else "fastest"
         answer = (

--- a/schema.py
+++ b/schema.py
@@ -89,6 +89,24 @@ _ANNOTATION = re.compile(r"\s*[(\[][^)\]]*[)\]]\s*$")
 DATE_NAME_TOKENS = ("date", "time", "timestamp", "created", "updated")
 
 
+EVENT_DATE_TOKENS = ("order", "transaction", "sale", "invoice", "posting", "created", "booking")
+FOLLOW_UP_DATE_TOKENS = ("ship", "delivery", "delivered", "due", "updated", "modified", "closed")
+
+
+def _date_preference(name: str) -> int:
+    words = normalized_name(name).split()
+    if any(token in words for token in EVENT_DATE_TOKENS):
+        return 2
+    if any(token in words for token in FOLLOW_UP_DATE_TOKENS):
+        return 0
+    return 1
+
+
+def _ordinal(text: str) -> int:
+    """A stable number for a string, so it can serve as a max() tiebreak."""
+    return int.from_bytes(text.encode()[:8].ljust(8, b"\0"), "big")
+
+
 def _named_like_a_date(name: str) -> bool:
     return any(token in normalized_name(name).split() for token in DATE_NAME_TOKENS)
 
@@ -141,7 +159,13 @@ def detect_roles(dataframe: pd.DataFrame) -> ColumnRoles:
         date_columns,
         key=lambda column: (
             1 if any(token in normalized_name(column) for token in ("date", "time", "created")) else 0,
+            # The event that produced the row outranks what happened to it
+            # afterwards: an order dates a sale, a shipment dates a delivery.
+            _date_preference(column),
             int(dataframe[column].notna().sum()),
+            # Name last, so two exports of one table in different column
+            # orders cannot land on different dates.
+            -_ordinal(normalized_name(column)),
         ),
         default=None,
     )

--- a/tests/test_bug_bash.py
+++ b/tests/test_bug_bash.py
@@ -1,0 +1,250 @@
+"""Bugs found walking every customer journey, each pinned so it cannot return."""
+
+import io
+import unittest
+import zipfile
+
+import numpy as np
+import pandas as pd
+
+import ui
+from aggregation import build_trend, measure_aggregation, segment_frame
+from analysis import clean_dataframe
+from autovis import recommend_chart
+from business_insights import analyze_business, increase_is_welcome
+from file_io import list_excel_sheets, read_tabular_file
+from nlq import answer_question, unsupported_phrasing
+from pipeline import prepare_analysis
+from schema import ColumnRoles, detect_roles
+
+MONTHS = pd.date_range("2024-01-01", periods=12, freq="MS")
+
+
+class UserColumnNameCollisionTests(unittest.TestCase):
+    """The file may call a column anything, including the names used internally."""
+
+    def test_a_measure_named_period_still_gets_a_brief(self):
+        frame = pd.DataFrame(
+            {"Date": pd.date_range("2024-01-01", periods=60), "Period": np.linspace(1, 9, 60),
+             "Region": ["a", "b"] * 30}
+        )
+
+        prepared = prepare_analysis(frame, row_limit=1000)
+
+        self.assertTrue(prepared.analyze().headline)
+
+    def test_a_category_named_records_can_be_explored(self):
+        frame = pd.DataFrame(
+            {"Date": pd.date_range("2024-01-01", periods=60), "Records": ["x", "y", "z"] * 20,
+             "Revenue": np.arange(60.0)}
+        )
+        prepared = prepare_analysis(frame, row_limit=1000)
+
+        spec = recommend_chart(prepared.dataframe, ["Records"])
+        shown = ui._explore_frame(prepared.dataframe, spec)
+
+        self.assertEqual(len(shown), 3)
+
+
+class RefusedPhrasingTests(unittest.TestCase):
+    """A precise answer to a different question is worse than no answer."""
+
+    def setUp(self):
+        self.frame = pd.DataFrame(
+            {"Month": MONTHS[:4], "Region": ["West", "East", "West", "East"],
+             "Revenue": [100.0, 200.0, 300.0, 400.0]}
+        )
+        self.roles = detect_roles(self.frame)
+
+    def test_unrepresentable_phrasings_are_refused_before_parsing(self):
+        for question in (
+            "Revenue > 200", "Revenue in January and February", "Revenue this year",
+            "Revenue for West or Partner", "total revenue last quarter", "revenue in 2024 and 2025",
+            "revenue at least 300", "revenue over 1000", "revenue more than 50",
+        ):
+            with self.subTest(question=question):
+                self.assertTrue(unsupported_phrasing(question))
+                self.assertIsNone(answer_question(question, self.frame, self.roles))
+
+    def test_plans_the_executor_would_misanswer_are_refused_by_the_parser(self):
+        # These read fine; it is the plan that cannot be honoured.
+        for question in ("average Revenue monthly", "top 0 Region by Revenue"):
+            with self.subTest(question=question):
+                self.assertFalse(unsupported_phrasing(question))
+                self.assertIsNone(answer_question(question, self.frame, self.roles))
+
+    def test_supported_phrasings_are_not_caught_by_the_refusal(self):
+        for question in ("total revenue", "revenue over time", "top 2 region by revenue",
+                         "revenue by region", "revenue in march 2024"):
+            with self.subTest(question=question):
+                self.assertFalse(unsupported_phrasing(question))
+                self.assertIsNotNone(answer_question(question, self.frame, self.roles))
+
+    def test_naming_the_column_does_not_steal_its_value_from_the_filter(self):
+        answer = answer_question("total Revenue for Region West", self.frame, self.roles)
+
+        self.assertIsNotNone(answer)
+        self.assertIn("$400.00", answer.answer)
+
+    def test_an_explicit_minimum_is_computed_not_summed(self):
+        answer = answer_question("minimum Revenue by Region", self.frame, self.roles)
+
+        self.assertIsNotNone(answer)
+        self.assertEqual(answer.plan.aggregation, "min")
+
+    def test_top_n_applies_to_a_growth_ranking(self):
+        answer = answer_question("top 1 Region growth", self.frame, self.roles)
+
+        self.assertIsNotNone(answer)
+        self.assertEqual(len(answer.table), 1)
+
+
+class RateMeasureTests(unittest.TestCase):
+    """A rate is averaged; adding two months of conversion rate means nothing."""
+
+    def setUp(self):
+        self.frame = pd.DataFrame(
+            {"Date": MONTHS[:4], "Conversion Rate": [0.1, 0.2, 0.3, 0.4], "Channel": ["a", "b"] * 2}
+        )
+        self.roles = detect_roles(self.frame)
+
+    def test_the_rule_lives_in_one_place(self):
+        self.assertEqual(measure_aggregation("Conversion Rate"), "mean")
+        self.assertEqual(measure_aggregation("Revenue"), "sum")
+        self.assertEqual(measure_aggregation("Margin Amount"), "sum")
+
+    def test_the_headline_averages_a_rate_with_a_matching_number(self):
+        brief = analyze_business(pd.DataFrame({"Date": MONTHS[:2], "Conversion Rate": [0.1, 0.2]}))
+
+        self.assertIn("averages", brief.headline)
+        self.assertIn("15.0%", brief.headline)
+
+    def test_chat_averages_a_rate_unless_told_to_total_it(self):
+        averaged = answer_question("conversion rate", self.frame, self.roles)
+        totalled = answer_question("total conversion rate", self.frame, self.roles)
+
+        self.assertEqual(averaged.plan.aggregation, "mean")
+        self.assertIn("25.0%", averaged.answer)
+        self.assertEqual(totalled.plan.aggregation, "sum")
+
+    def test_a_rate_trend_is_one_of_period_means(self):
+        series = build_trend(self.frame, self.roles)
+
+        self.assertAlmostEqual(float(series.frame["Value"].iloc[0]), 0.1)
+
+
+class DirectionOfGoodTests(unittest.TestCase):
+    def test_a_rising_cost_is_bad_news(self):
+        self.assertFalse(increase_is_welcome("Cost"))
+        self.assertFalse(increase_is_welcome("Refund Amount"))
+        self.assertTrue(increase_is_welcome("Revenue"))
+        self.assertTrue(increase_is_welcome("Cost Savings"))
+
+        frame = pd.DataFrame({"Month": MONTHS, "Cost": np.linspace(30, 90, 12)})
+        brief = analyze_business(frame)
+        trend = next(item for item in brief.evidence if item.kind == "trend")
+
+        self.assertEqual(trend.tone, "negative")
+        self.assertNotIn("growth", brief.recommendations[0].title.lower())
+
+    def test_a_segment_that_grew_is_not_blamed_for_a_fall(self):
+        frame = pd.DataFrame(
+            {"Month": list(MONTHS[:2]) * 2, "Segment": ["Alpha", "Alpha", "Beta", "Beta"],
+             "Revenue": [100.0, 210.0, 500.0, 370.0]}
+        )
+
+        brief = analyze_business(frame)
+
+        for item in brief.recommendations:
+            self.assertNotIn("Alpha decline", item.action)
+
+
+class SegmentDenominatorTests(unittest.TestCase):
+    def test_blank_segments_stay_in_the_total(self):
+        frame = pd.DataFrame(
+            {"Date": MONTHS, "Region": ["West", "East"] + [None] * 10,
+             "Revenue": [100.0, 200.0] + [90.0] * 10}
+        )
+        roles = ColumnRoles(date="Date", measure="Revenue", dimension="Region", identifier=None,
+                            numeric=("Revenue",), dimensions=("Region",))
+
+        segments = segment_frame(frame, roles)
+
+        self.assertAlmostEqual(float(segments["Value"].sum()), float(frame["Revenue"].sum()))
+
+
+class RoleDeterminismTests(unittest.TestCase):
+    def test_the_event_date_wins_whatever_order_the_columns_arrive_in(self):
+        frame = pd.DataFrame(
+            {"Order Date": MONTHS[:10], "Ship Date": MONTHS[:10] + pd.Timedelta(days=3), "Revenue": range(10)}
+        )
+
+        self.assertEqual(detect_roles(frame).date, "Order Date")
+        self.assertEqual(detect_roles(frame[["Ship Date", "Order Date", "Revenue"]]).date, "Order Date")
+
+
+class CalendarTests(unittest.TestCase):
+    def test_annual_figures_are_years_not_zero_filled_quarters(self):
+        frame = pd.DataFrame(
+            {"Year": pd.to_datetime(["2020-01-01", "2021-01-01", "2022-01-01", "2023-01-01"]),
+             "Revenue": [100.0, 120.0, 150.0, 170.0]}
+        )
+
+        series = build_trend(frame, detect_roles(frame))
+
+        self.assertEqual(series.frequency, "Y")
+        self.assertEqual(series.filled_periods, 0)
+        self.assertEqual(len(series.frame), 4)
+
+
+class IngestionTests(unittest.TestCase):
+    def test_mixed_utc_offsets_still_become_a_date_column(self):
+        frame = pd.DataFrame(
+            {"created_at": ["2024-01-15T10:00:00+01:00", "2024-06-15T10:00:00+02:00"] * 10,
+             "Revenue": range(20)}
+        )
+
+        cleaned, _ = clean_dataframe(frame)
+
+        self.assertTrue(pd.api.types.is_datetime64_any_dtype(cleaned["created_at"]))
+        self.assertEqual(detect_roles(cleaned).date, "created_at")
+
+    def test_a_whitespace_only_column_is_empty(self):
+        frame = pd.DataFrame({"Date": MONTHS[:5], "Revenue": range(5), "Note": ["  "] * 5})
+
+        self.assertNotIn("Note", clean_dataframe(frame)[0].columns)
+
+    def test_a_zip_that_is_not_a_workbook_is_a_readable_error(self):
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, "w") as archive:
+            archive.writestr("hello.txt", "hi")
+
+        for reader in (list_excel_sheets, read_tabular_file):
+            with self.subTest(reader=reader.__name__), self.assertRaises(ValueError):
+                reader(buffer.getvalue(), "x.xlsx")
+
+    def test_na_is_north_america_not_missing(self):
+        frame = read_tabular_file(b"Region,Revenue\nNA,10\nEU,20\n", "f.csv")
+
+        self.assertEqual(frame["Region"].tolist(), ["NA", "EU"])
+
+    def test_an_id_column_keeps_its_leading_zeros(self):
+        frame = read_tabular_file(b"Customer ID,Revenue\n00042,10\n00007,20\n", "f.csv")
+
+        self.assertEqual(frame["Customer ID"].tolist(), ["00042", "00007"])
+        self.assertEqual(frame["Revenue"].tolist(), [10, 20])
+
+
+class EvidenceBudgetTests(unittest.TestCase):
+    def test_a_quality_card_is_never_squeezed_out_by_the_six_card_cap(self):
+        from business_insights import Evidence, _shown_evidence
+
+        filler = [
+            Evidence(kind=f"k{i}", title="t", value="v", statement="s", calculation="c") for i in range(7)
+        ]
+        quality = Evidence(kind="quality", title="q", value="v", statement="s", calculation="c")
+
+        shown = _shown_evidence(filler + [quality])
+
+        self.assertEqual(len(shown), 6)
+        self.assertIn(quality, shown)

--- a/ui.py
+++ b/ui.py
@@ -183,10 +183,19 @@ def render_evidence(brief: BusinessBrief, *, limit: int | None = None) -> None:
 
 
 def render_ai_narrative(narrative: AINarrative, *, model: str) -> None:
+    # Each action names the evidence it rests on, and the model's own caveats
+    # are shown rather than dropped: both were in the typed response and
+    # neither reached the page, which left the confident parts of the read
+    # standing without the parts that qualified them.
     actions = "".join(
         f'<article class="ai-action"><span class="confidence">{escape(item.confidence)} confidence</span>'
-        f'<strong>{escape(item.title)}</strong><p>{escape(item.recommendation)}</p></article>'
+        f'<strong>{escape(item.title)}</strong><p>{escape(item.recommendation)}</p>'
+        f'<p class="ai-evidence"><em>Evidence:</em> {escape(item.evidence)}</p></article>'
         for item in narrative.actions
+    )
+    watchouts = "".join(f"<li>{escape(item)}</li>" for item in narrative.watchouts)
+    watchout_block = (
+        f'<div class="ai-watchouts"><strong>Watch-outs</strong><ul>{watchouts}</ul></div>' if watchouts else ""
     )
     st.markdown(
         f"""
@@ -195,6 +204,8 @@ def render_ai_narrative(narrative: AINarrative, *, model: str) -> None:
           <h2>{escape(narrative.executive_summary)}</h2>
           <p>{escape(narrative.strategic_read)}</p>
           <div class="ai-actions">{actions}</div>
+          {watchout_block}
+          <p class="ai-caveat">Written by a model from the computed evidence above. It can misread that evidence; the calculations are authoritative, the read is not.</p>
         </section>
         """,
         unsafe_allow_html=True,
@@ -480,8 +491,10 @@ def _explore_frame(
         return dataframe[grouping].dropna()
 
     if spec.aggregation == "count" or not spec.y:
-        frame = dataframe.groupby(keys, dropna=True, observed=True).size().reset_index(name="Records")
-        value = "Records"
+        # A column the file calls "Records" collides with the count column
+        # built here, so the count takes a name the frame is not using.
+        value = next(name for name in ("Records", "Record count", "Rows") if name not in dataframe.columns)
+        frame = dataframe.groupby(keys, dropna=True, observed=True).size().reset_index(name=value)
     else:
         frame = dataframe.groupby(keys, dropna=True, observed=True)[spec.y].sum().reset_index()
         value = spec.y
@@ -494,7 +507,9 @@ def _explore_frame(
 
 def _explore_figure(frame: pd.DataFrame, spec) -> go.Figure | None:
     """Draw exactly the form the recommendation asked for."""
-    value = spec.y if (spec.y and spec.y in frame.columns) else "Records"
+    # The grouped frame's last column is always the value being plotted,
+    # whatever it had to be called.
+    value = spec.y if (spec.y and spec.y in frame.columns) else str(frame.columns[-1])
 
     if spec.form in ("line", "area"):
         if spec.color:


### PR DESCRIPTION
## What problem does this solve?

Thirty realistic files of every business shape (SaaS MRR, retail transactions, a general ledger, AR ageing, web analytics, HR, inventory, marketing spend, a wide P&L, tickets, annual-only, cost metrics, mixed-sign profit, hostile column names, mixed time zones, Unicode headers…) were pushed through every surface — brief, dashboard, chat, Explore, drill-down, role override, export — and every interactive journey was driven end-to-end with `AppTest`. An independent follow-up review of #37 had found a parallel set. This fixes what broke, plus the review's remaining items that are bugs rather than roadmap.

The theme is **semantic correctness**: places where ADA computed an exact answer to a different question.

## What changed?

**Ask ADA answered questions it cannot represent with the nearest one it can.** `revenue > 200` → the all-time total. `January and February` → January. `West or Partner` → both at once. `average revenue monthly` → monthly *sums*. `top 0` → the default twelve. Each is now **refused** (handed to the optional planner or the chips). Naming the column beside its value — `for Region West` — read the column and dropped the value, answering with every region's total. An explicit `minimum` was silently summed. `top 1 … growth` ignored the N.

**A rate was added up everywhere.** *"Conversion Rate totals 30.0%"* for two months of 10% and 20%. One function (`measure_aggregation`) now says how a measure combines — rates average, amounts add — and trend, segments, headline and chat all ask it, so the surfaces agree. Saying "total" out loud still gets a sum.

**A rising cost was "growth" to protect.** Tone follows what a movement means for the business. A segment that grew while the total fell is no longer named as "the decline to reconcile".

**Internal names collided with user columns.** A measure called `Period` was overwritten by the trend's period buckets and summed as datetimes; a category called `Records` collided with Explore's count column. Internal names throughout.

**Segments, calendars, roles.** Blank-segment rows were dropped from the ranking, so every share was a share of labelled rows only (a mostly-unlabelled file had *no* segment evidence). Four annual figures became sixteen quarters, twelve zero-filled. Which of two date columns won depended on column order.

**Ingestion.** Mixed UTC offsets across a DST change came back as `object`; a whitespace-only column survived; a zip that isn't a workbook raised an uncaught `KeyError`; `NA` was read as missing rather than North America; account number `00042` became `42`. The backtest scored an unclipped forecast the page never shows.

**Presentation honesty.** A data-quality card past the sixth slot was silently dropped. The AI read hid each action's evidence and the model's own watch-outs. The strongest correlation is now labelled as the largest of a search whose interval isn't adjusted for that search. `docs/privacy.md` said two different things in two sections.

## Evidence and trust boundaries

- No new external calls, dependencies, or cost.
- **Rates now average rather than sum** in the trend, segment table, headline and chat. This changes numbers on any file whose measure is named like a rate (`rate`, `margin`, `ratio`, `%`). It is the unweighted mean — a true conversion rate would weight by sessions; that needs unit metadata ADA does not yet have and is disclosed, not hidden.
- Chat refuses more than it did. Every refusal is a question that was previously answered wrongly.
- `NA` is no longer a missing-value marker on read. `N/A`, `NULL`, `NaN`, `null`, blanks and the rest of pandas' default list still are.

## Verification

- [x] `ruff check .`
- [x] `python -m unittest discover -s tests -v` — **285 tests**, 27 new in `tests/test_bug_bash.py`, one per behaviour
- [x] New or changed analytical behavior has tests
- [x] No credentials, private datasets, or generated build output are committed
- [ ] UI changes include screenshots — AI panel gains evidence lines and a watch-outs list; covered by `AppTest`

CI on this PR: `test (3.11)`, `test (3.12)`, `test (3.13)` all green. The 30-file sweep and the AppTest journeys (every suggestion chip, every sample dataset, every role-selector option, drill-down then chat, 20 Explore combinations, nine typed questions including refusals, upload mode) all pass on the final code.

## Not fixed, deliberately

- **Filter provenance in AI plans** — a plan can carry a valid filter the question never mentioned. The approval sentence shows it; that is the mitigation today.
- **Weighted rates** and **multiplicity-corrected correlation intervals** — both need design, not a patch. Labelled honestly instead.
- **Leading partial period after truncation** — the analysed date range is shown; the first period is not separately flagged.
- **Contrast ratios and parse-time resource bounds** (reviewer R-22).