### PR TITLE
Add accessible text summaries for dashboard charts

### DIFF
--- a/chart_summaries.py
+++ b/chart_summaries.py
@@ -1,0 +1,137 @@
+import pandas as pd
+
+
+def summarize_trend(
+    frame: pd.DataFrame,
+    x_col: str,
+    y_col: str,
+) -> str:
+    """Create a short text summary for a trend chart."""
+    data = frame[[x_col, y_col]].dropna()
+
+    if data.empty:
+        return "No data is available for this trend chart."
+
+    first_value = data[y_col].iloc[0]
+    last_value = data[y_col].iloc[-1]
+
+    if first_value == 0:
+        change_text = "with no percentage change available"
+    else:
+        change = ((last_value - first_value) / abs(first_value)) * 100
+        change_text = f"({change:+.1f}% from the first value)"
+
+    if last_value > first_value:
+        direction = "increased"
+    elif last_value < first_value:
+        direction = "decreased"
+    else:
+        direction = "was unchanged"
+
+    return (
+        f"{y_col} {direction} from {first_value:,.2f} "
+        f"to {last_value:,.2f} {change_text}."
+    )
+
+
+def summarize_categories(
+    frame: pd.DataFrame,
+    category_col: str,
+    value_col: str,
+) -> str:
+    """Create a short text summary for a category/segment chart."""
+    data = frame[[category_col, value_col]].dropna()
+
+    if data.empty:
+        return "No data is available for this category chart."
+
+    grouped = (
+        data.groupby(category_col, as_index=False)[value_col]
+        .sum()
+        .sort_values(value_col, ascending=False)
+    )
+
+    if grouped.empty:
+        return "No category values are available."
+
+    highest = grouped.iloc[0]
+    lowest = grouped.iloc[-1]
+
+    return (
+        f"{category_col} is highest for "
+        f"{highest[category_col]} ({highest[value_col]:,.2f}) "
+        f"and lowest for {lowest[category_col]} "
+        f"({lowest[value_col]:,.2f})."
+    )
+
+
+def summarize_distribution(
+    frame: pd.DataFrame,
+    value_col: str,
+) -> str:
+    """Create a short text summary for a distribution chart."""
+    data = pd.to_numeric(frame[value_col], errors="coerce").dropna()
+
+    if data.empty:
+        return "No numeric data is available for this distribution chart."
+
+    return (
+        f"{value_col} has {len(data):,} values, "
+        f"with a median of {data.median():,.2f}, "
+        f"ranging from {data.min():,.2f} to {data.max():,.2f}."
+    )
+
+
+def summarize_relationship(
+    frame: pd.DataFrame,
+    x_col: str,
+    y_col: str,
+) -> str:
+    """Create a short text summary for a relationship/scatter chart."""
+    data = frame[[x_col, y_col]].copy()
+    data[x_col] = pd.to_numeric(data[x_col], errors="coerce")
+    data[y_col] = pd.to_numeric(data[y_col], errors="coerce")
+    data = data.dropna()
+
+    if len(data) < 2:
+        return "Not enough numeric data is available to summarize this relationship."
+
+    correlation = data[x_col].corr(data[y_col])
+
+    if pd.isna(correlation):
+        return f"No measurable relationship is available between {x_col} and {y_col}."
+
+    if correlation > 0.3:
+        direction = "positive"
+    elif correlation < -0.3:
+        direction = "negative"
+    else:
+        direction = "weak"
+
+    return (
+        f"The relationship between {x_col} and {y_col} is "
+        f"{direction}, with a correlation of {correlation:.2f}."
+    )
+
+
+def summarize_heatmap(
+    frame: pd.DataFrame,
+    row_col: str,
+    col_col: str,
+    value_col: str,
+) -> str:
+    """Create a short text summary for a heatmap."""
+    data = frame[[row_col, col_col, value_col]].dropna()
+
+    if data.empty:
+        return "No data is available for this heatmap."
+
+    highest = data.loc[data[value_col].idxmax()]
+    lowest = data.loc[data[value_col].idxmin()]
+
+    return (
+        f"The highest value is {highest[value_col]:,.2f} "
+        f"for {row_col}={highest[row_col]} and {col_col}={highest[col_col]}. "
+        f"The lowest value is {lowest[value_col]:,.2f} "
+        f"for {row_col}={lowest[row_col]} and {col_col}={lowest[col_col]}."
+  )

--- a/chart_summaries.py
+++ b/chart_summaries.py
@@ -6,14 +6,13 @@ def summarize_trend(
     x_col: str,
     y_col: str,
 ) -> str:
-    """Create a short text summary for a trend chart."""
     data = frame[[x_col, y_col]].dropna()
 
     if data.empty:
         return "No data is available for this trend chart."
 
-    first_value = data[y_col].iloc[0]
-    last_value = data[y_col].iloc[-1]
+    first_value = float(data[y_col].iloc[0])
+    last_value = float(data[y_col].iloc[-1])
 
     if first_value == 0:
         change_text = "with no percentage change available"
@@ -39,7 +38,6 @@ def summarize_categories(
     category_col: str,
     value_col: str,
 ) -> str:
-    """Create a short text summary for a category/segment chart."""
     data = frame[[category_col, value_col]].dropna()
 
     if data.empty:
@@ -69,7 +67,6 @@ def summarize_distribution(
     frame: pd.DataFrame,
     value_col: str,
 ) -> str:
-    """Create a short text summary for a distribution chart."""
     data = pd.to_numeric(frame[value_col], errors="coerce").dropna()
 
     if data.empty:
@@ -87,7 +84,6 @@ def summarize_relationship(
     x_col: str,
     y_col: str,
 ) -> str:
-    """Create a short text summary for a relationship/scatter chart."""
     data = frame[[x_col, y_col]].copy()
     data[x_col] = pd.to_numeric(data[x_col], errors="coerce")
     data[y_col] = pd.to_numeric(data[y_col], errors="coerce")
@@ -120,7 +116,6 @@ def summarize_heatmap(
     col_col: str,
     value_col: str,
 ) -> str:
-    """Create a short text summary for a heatmap."""
     data = frame[[row_col, col_col, value_col]].dropna()
 
     if data.empty:
@@ -134,4 +129,39 @@ def summarize_heatmap(
         f"for {row_col}={highest[row_col]} and {col_col}={highest[col_col]}. "
         f"The lowest value is {lowest[value_col]:,.2f} "
         f"for {row_col}={lowest[row_col]} and {col_col}={lowest[col_col]}."
-  )
+    )
+
+
+def summarize_movement(
+    frame: pd.DataFrame,
+    category_col: str,
+    value_col: str,
+) -> str:
+    data = frame[[category_col, value_col]].dropna()
+
+    if data.empty:
+        return "No movement data is available."
+
+    positive = data[data[value_col] > 0]
+    negative = data[data[value_col] < 0]
+
+    parts = []
+
+    if not positive.empty:
+        item = positive.loc[positive[value_col].idxmax()]
+        parts.append(
+            f"largest increase was {item[category_col]} "
+            f"({item[value_col]:+,.2f})"
+        )
+
+    if not negative.empty:
+        item = negative.loc[negative[value_col].idxmin()]
+        parts.append(
+            f"largest decrease was {item[category_col]} "
+            f"({item[value_col]:+,.2f})"
+        )
+
+    net_change = data[value_col].sum()
+    parts.append(f"net change was {net_change:+,.2f}")
+
+    return "The " + ", ".join(parts) + "."

--- a/tests/test_chart_summaries.py
+++ b/tests/test_chart_summaries.py
@@ -1,0 +1,136 @@
+import unittest
+
+import pandas as pd
+
+from chart_summaries import (
+    summarize_categories,
+    summarize_distribution,
+    summarize_heatmap,
+    summarize_movement,
+    summarize_relationship,
+    summarize_trend,
+)
+
+
+class ChartSummaryTests(unittest.TestCase):
+
+    def test_trend_summary(self):
+        frame = pd.DataFrame({
+            "Period": ["Jan", "Feb", "Mar"],
+            "Value": [100, 120, 150],
+        })
+
+        summary = summarize_trend(frame, "Period", "Value")
+
+        self.assertIn("increased", summary)
+        self.assertIn("100.00", summary)
+        self.assertIn("150.00", summary)
+        self.assertIn("+50.0%", summary)
+
+    def test_category_summary(self):
+        frame = pd.DataFrame({
+            "Segment": ["A", "B", "C"],
+            "Value": [100, 300, 200],
+        })
+
+        summary = summarize_categories(frame, "Segment", "Value")
+
+        self.assertIn("highest", summary)
+        self.assertIn("B", summary)
+        self.assertIn("300.00", summary)
+        self.assertIn("lowest", summary)
+        self.assertIn("A", summary)
+
+    def test_distribution_summary(self):
+        frame = pd.DataFrame({
+            "Value": [10, 20, 30],
+        })
+
+        summary = summarize_distribution(frame, "Value")
+
+        self.assertIn("3", summary)
+        self.assertIn("20.00", summary)
+        self.assertIn("10.00", summary)
+        self.assertIn("30.00", summary)
+
+    def test_relationship_summary(self):
+        frame = pd.DataFrame({
+            "X": [1, 2, 3],
+            "Y": [2, 4, 6],
+        })
+
+        summary = summarize_relationship(frame, "X", "Y")
+
+        self.assertIn("positive", summary)
+        self.assertIn("1.00", summary)
+
+    def test_heatmap_summary(self):
+        frame = pd.DataFrame({
+            "Segment": ["A", "A", "B", "B"],
+            "Period": ["Jan", "Feb", "Jan", "Feb"],
+            "Value": [10, 40, 20, 30],
+        })
+
+        summary = summarize_heatmap(
+            frame,
+            "Segment",
+            "Period",
+            "Value",
+        )
+
+        self.assertIn("highest", summary)
+        self.assertIn("40.00", summary)
+        self.assertIn("A", summary)
+        self.assertIn("Feb", summary)
+
+    def test_movement_summary(self):
+        frame = pd.DataFrame({
+            "Segment": ["A", "B", "C"],
+            "Change": [50, -30, 10],
+        })
+
+        summary = summarize_movement(
+            frame,
+            "Segment",
+            "Change",
+        )
+
+        self.assertIn("largest increase", summary)
+        self.assertIn("A", summary)
+        self.assertIn("largest decrease", summary)
+        self.assertIn("B", summary)
+        self.assertIn("net change", summary)
+        self.assertIn("+30.00", summary)
+
+    def test_empty_data_is_handled(self):
+        frame = pd.DataFrame({
+            "Period": [],
+            "Value": [],
+        })
+
+        summary = summarize_trend(
+            frame,
+            "Period",
+            "Value",
+        )
+
+        self.assertIn("No data", summary)
+
+    def test_summary_does_not_invent_causes(self):
+        frame = pd.DataFrame({
+            "Period": ["Jan", "Feb"],
+            "Value": [100, 150],
+        })
+
+        summary = summarize_trend(
+            frame,
+            "Period",
+            "Value",
+        )
+
+        self.assertNotIn("because", summary.lower())
+        self.assertNotIn("caused by", summary.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui.py
+++ b/ui.py
@@ -20,6 +20,13 @@ from forecasting import build_forecast, describe_backtest
 from formatting import format_number, format_period
 from nlq import QueryAnswer
 from schema import ColumnRoles
+from chart_summaries import (
+    summarize_categories,
+    summarize_distribution,
+    summarize_heatmap,
+    summarize_relationship,
+    summarize_trend,
+)
 
 if TYPE_CHECKING:  # The AI layer is optional; ui must import without it.
     from ai_insights import AINarrative

--- a/ui.py
+++ b/ui.py
@@ -24,6 +24,7 @@ from chart_summaries import (
     summarize_categories,
     summarize_distribution,
     summarize_heatmap,
+    summarize_movement,
     summarize_relationship,
     summarize_trend,
 )

--- a/ui.py
+++ b/ui.py
@@ -235,12 +235,13 @@ def style_chart(figure: go.Figure, *, height: int = 390) -> go.Figure:
     figure.update_yaxes(gridcolor="#EEF0F3", zeroline=False, tickfont={"color": MUTED})
     return figure
 
-
 def render_dashboard(dataframe: pd.DataFrame, roles: ColumnRoles) -> None:
     series = build_trend(dataframe, roles)
     trend = series.frame
     segments = segment_frame(dataframe, roles)
+
     chart_columns = st.columns(2, gap="medium")
+
     with chart_columns[0]:
         if not trend.empty:
             figure = px.area(
@@ -251,8 +252,14 @@ def render_dashboard(dataframe: pd.DataFrame, roles: ColumnRoles) -> None:
                 title=f"{roles.measure or 'Records'} over time",
                 color_discrete_sequence=[ACCENT],
             )
-            figure.update_traces(line={"width": 3}, fillcolor="rgba(99,91,255,.11)")
+
+            figure.update_traces(
+                line={"width": 3},
+                fillcolor="rgba(99,91,255,.11)",
+            )
+
             anomalies = detect_anomalies(trend)
+
             if anomalies:
                 figure.add_trace(
                     go.Scatter(
@@ -266,15 +273,27 @@ def render_dashboard(dataframe: pd.DataFrame, roles: ColumnRoles) -> None:
                             "color": "#E35D6A",
                             "line": {"width": 2, "color": "white"},
                         },
-                        hovertemplate="%{x|%b %Y}: %{y:,.0f} — outside the expected band<extra>Anomaly</extra>",
+                        hovertemplate=(
+                            "%{x|%b %Y}: %{y:,.0f} "
+                            "— outside the expected band"
+                            "<extra>Anomaly</extra>"
+                        ),
                     )
                 )
+
             forecast = build_forecast(trend)
+
             if forecast:
                 figure.add_trace(
                     go.Scatter(
-                        x=[*forecast.periods, *reversed(forecast.periods)],
-                        y=[*forecast.upper, *reversed(forecast.lower)],
+                        x=[
+                            *forecast.periods,
+                            *reversed(forecast.periods),
+                        ],
+                        y=[
+                            *forecast.upper,
+                            *reversed(forecast.lower),
+                        ],
                         mode="lines",
                         fill="toself",
                         fillcolor="rgba(139,92,246,.09)",
@@ -283,25 +302,62 @@ def render_dashboard(dataframe: pd.DataFrame, roles: ColumnRoles) -> None:
                         showlegend=False,
                     )
                 )
+
                 figure.add_trace(
                     go.Scatter(
-                        x=[trend.iloc[-1]["Period"], *forecast.periods],
-                        y=[float(trend.iloc[-1]["Value"]), *forecast.values],
+                        x=[
+                            trend.iloc[-1]["Period"],
+                            *forecast.periods,
+                        ],
+                        y=[
+                            float(trend.iloc[-1]["Value"]),
+                            *forecast.values,
+                        ],
                         mode="lines",
                         name="Forecast",
-                        line={"width": 2.5, "dash": "dash", "color": "#8B5CF6"},
-                        hovertemplate="%{x|%b %Y}: %{y:,.0f} — baseline forecast<extra></extra>",
+                        line={
+                            "width": 2.5,
+                            "dash": "dash",
+                            "color": "#8B5CF6",
+                        },
+                        hovertemplate=(
+                            "%{x|%b %Y}: %{y:,.0f} "
+                            "— baseline forecast<extra></extra>"
+                        ),
                     )
                 )
-            st.plotly_chart(style_chart(figure), width="stretch", config={"displayModeBar": False})
+
+            st.plotly_chart(
+                style_chart(figure),
+                width="stretch",
+                config={"displayModeBar": False},
+            )
+
+            st.caption(
+                "Chart summary: "
+                + summarize_trend(
+                    trend,
+                    "Period",
+                    "Value",
+                )
+            )
+
             if forecast:
                 st.caption(
-                    f"Baseline forecast: {forecast.method} · {describe_backtest(forecast.backtest)}."
+                    f"Baseline forecast: {forecast.method} · "
+                    f"{describe_backtest(forecast.backtest)}."
                 )
+
             for note in series.notes:
                 st.caption(f"Timeline: {note}")
+
         else:
-            st.markdown('<div class="empty-state">Select a date column to reveal movement over time.</div>', unsafe_allow_html=True)
+            st.markdown(
+                '<div class="empty-state">'
+                "Select a date column to reveal movement over time."
+                "</div>",
+                unsafe_allow_html=True,
+            )
 
     with chart_columns[1]:
         if not segments.empty:
@@ -313,61 +369,202 @@ def render_dashboard(dataframe: pd.DataFrame, roles: ColumnRoles) -> None:
                 title=f"{roles.measure or 'Records'} by {roles.dimension}",
                 color_discrete_sequence=[LEAF],
             )
-            figure.update_traces(marker_line_width=0, hovertemplate="%{y}: %{x:,.2f}<extra></extra>")
-            st.plotly_chart(style_chart(figure), width="stretch", config={"displayModeBar": False})
+
+            figure.update_traces(
+                marker_line_width=0,
+                hovertemplate="%{y}: %{x:,.2f}<extra></extra>",
+            )
+
+            st.plotly_chart(
+                style_chart(figure),
+                width="stretch",
+                config={"displayModeBar": False},
+            )
+
+            st.caption(
+                "Chart summary: "
+                + summarize_categories(
+                    segments,
+                    "Segment",
+                    "Value",
+                )
+            )
+
         else:
-            st.markdown('<div class="empty-state">Select a segment column to reveal contribution.</div>', unsafe_allow_html=True)
+            st.markdown(
+                '<div class="empty-state">'
+                "Select a segment column to reveal contribution."
+                "</div>",
+                unsafe_allow_html=True,
+            )
 
     movement_columns = st.columns(2, gap="medium")
+
     with movement_columns[0]:
         drivers = driver_frame(dataframe, roles)
+
         if not drivers.empty:
             waterfall = go.Figure(
                 go.Waterfall(
-                    x=[*drivers["Segment"], "Net change"],
-                    y=[*drivers["Change"], 0],
-                    measure=[*(["relative"] * len(drivers)), "total"],
-                    connector={"line": {"color": "#E5E7EB"}},
-                    increasing={"marker": {"color": RISE}},
-                    decreasing={"marker": {"color": FALL}},
-                    totals={"marker": {"color": ACCENT}},
-                    hovertemplate="%{x}: %{delta:+,.0f}<extra></extra>",
+                    x=[
+                        *drivers["Segment"],
+                        "Net change",
+                    ],
+                    y=[
+                        *drivers["Change"],
+                        0,
+                    ],
+                    measure=[
+                        *(["relative"] * len(drivers)),
+                        "total",
+                    ],
+                    connector={
+                        "line": {
+                            "color": "#E5E7EB",
+                        }
+                    },
+                    increasing={
+                        "marker": {
+                            "color": RISE,
+                        }
+                    },
+                    decreasing={
+                        "marker": {
+                            "color": FALL,
+                        }
+                    },
+                    totals={
+                        "marker": {
+                            "color": ACCENT,
+                        }
+                    },
+                    hovertemplate=(
+                        "%{x}: %{delta:+,.0f}"
+                        "<extra></extra>"
+                    ),
                 )
             )
-            waterfall.update_layout(title=f"What moved {roles.measure} — latest vs previous period")
-            st.plotly_chart(style_chart(waterfall), width="stretch", config={"displayModeBar": False})
+
+            waterfall.update_layout(
+                title=(
+                    f"What moved {roles.measure} — "
+                    "latest vs previous period"
+                )
+            )
+
+            st.plotly_chart(
+                style_chart(waterfall),
+                width="stretch",
+                config={"displayModeBar": False},
+            )
+
+            st.caption(
+                "Chart summary: "
+                + summarize_movement(
+                    drivers,
+                    "Segment",
+                    "Change",
+                )
+            )
+
         else:
             st.markdown(
-                '<div class="empty-state">A date, metric, and segment together unlock the movement waterfall.</div>',
+                '<div class="empty-state">'
+                "A date, metric, and segment together unlock "
+                "the movement waterfall."
+                "</div>",
                 unsafe_allow_html=True,
             )
 
     with movement_columns[1]:
-        heat = heatmap_frame(dataframe, roles, frequency=series.frequency)
+        heat = heatmap_frame(
+            dataframe,
+            roles,
+            frequency=series.frequency,
+        )
+
         if not heat.empty and len(heat.columns) >= 2:
             heatmap = go.Figure(
                 go.Heatmap(
                     z=heat.to_numpy(),
-                    x=[format_period(period, series.frequency) for period in heat.columns],
-                    y=[str(segment) for segment in heat.index],
-                    colorscale=[[0, "#F6F7F9"], [0.5, "#B9B1FF"], [1, "#4E43C7"]],
-                    hovertemplate="%{y} · %{x}: %{z:,.0f}<extra></extra>",
+                    x=[
+                        format_period(
+                            period,
+                            series.frequency,
+                        )
+                        for period in heat.columns
+                    ],
+                    y=[
+                        str(segment)
+                        for segment in heat.index
+                    ],
+                    colorscale=[
+                        [0, "#F6F7F9"],
+                        [0.5, "#B9B1FF"],
+                        [1, "#4E43C7"],
+                    ],
+                    hovertemplate=(
+                        "%{y} · %{x}: %{z:,.0f}"
+                        "<extra></extra>"
+                    ),
                     showscale=False,
                 )
             )
+
             heatmap.update_layout(
-                title=f"{roles.measure or 'Records'} intensity by {roles.dimension} and period"
+                title=(
+                    f"{roles.measure or 'Records'} intensity "
+                    f"by {roles.dimension} and period"
+                )
             )
-            heatmap.update_yaxes(autorange="reversed")
-            st.plotly_chart(style_chart(heatmap), width="stretch", config={"displayModeBar": False})
+
+            heatmap.update_yaxes(
+                autorange="reversed"
+            )
+
+            st.plotly_chart(
+                style_chart(heatmap),
+                width="stretch",
+                config={"displayModeBar": False},
+            )
+
+            heat_summary = (
+                heat.rename_axis("Segment")
+                .reset_index()
+                .melt(
+                    id_vars="Segment",
+                    var_name="Period",
+                    value_name="Value",
+                )
+            )
+
+            st.caption(
+                "Chart summary: "
+                + summarize_heatmap(
+                    heat_summary,
+                    "Segment",
+                    "Period",
+                    "Value",
+                )
+            )
+
         else:
             st.markdown(
-                '<div class="empty-state">A date and a segment together unlock the intensity heatmap.</div>',
+                '<div class="empty-state">'
+                "A date and a segment together unlock "
+                "the intensity heatmap."
+                "</div>",
                 unsafe_allow_html=True,
             )
 
-    numeric = [column for column in roles.numeric if dataframe[column].nunique(dropna=True) > 2]
+    numeric = [
+        column
+        for column in roles.numeric
+        if dataframe[column].nunique(dropna=True) > 2
+    ]
+
     lower_columns = st.columns(2, gap="medium")
+
     with lower_columns[0]:
         if roles.measure:
             figure = px.histogram(
@@ -377,20 +574,60 @@ def render_dashboard(dataframe: pd.DataFrame, roles: ColumnRoles) -> None:
                 title=f"Distribution of {roles.measure}",
                 color_discrete_sequence=["#0E8F6E"],
             )
-            st.plotly_chart(style_chart(figure), width="stretch", config={"displayModeBar": False})
+
+            st.plotly_chart(
+                style_chart(figure),
+                width="stretch",
+                config={"displayModeBar": False},
+            )
+
+            st.caption(
+                "Chart summary: "
+                + summarize_distribution(
+                    dataframe,
+                    roles.measure,
+                )
+            )
+
     with lower_columns[1]:
-        partner = next((column for column in numeric if column != roles.measure), None)
+        partner = next(
+            (
+                column
+                for column in numeric
+                if column != roles.measure
+            ),
+            None,
+        )
+
         if roles.measure and partner:
             figure = px.scatter(
                 dataframe,
                 x=partner,
                 y=roles.measure,
-                color=roles.dimension if roles.dimension else None,
+                color=(
+                    roles.dimension
+                    if roles.dimension
+                    else None
+                ),
                 opacity=0.62,
                 title=f"{roles.measure} vs {partner}",
                 color_discrete_sequence=list(SERIES_COLORS),
             )
-            st.plotly_chart(style_chart(figure), width="stretch", config={"displayModeBar": False})
+
+            st.plotly_chart(
+                style_chart(figure),
+                width="stretch",
+                config={"displayModeBar": False},
+            )
+
+            st.caption(
+                "Chart summary: "
+                + summarize_relationship(
+                    dataframe,
+                    partner,
+                    roles.measure,
+                )
+            )
 
 
 def _chat_answer_figure(result: QueryAnswer) -> go.Figure | None:


### PR DESCRIPTION
## Summary

- Add deterministic text summaries for dashboard charts
- Add summaries for trend, category, movement, heatmap, distribution, and relationship charts
- Add unit tests for chart summary functions independently of Streamlit
- Keep summaries based only on the displayed data without inventing causes or benchmarks

## Testing

- Added unit tests covering all chart summary functions
- Added empty-data handling test
- Added test to ensure summaries do not invent causes

## Related Issue

Closes #2