### PR TITLE
1/N Add the metric contract, unread for now

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -1,0 +1,88 @@
+"""What a measure is, decided once and consumed everywhere.
+
+The rate change fixed the headline, then the trend, then chat, and each
+surface disagreed with the next about whether a rate adds up. It does not:
+two months of conversion rate do not sum to anything, a segment's share of
+"total conversion rate" is not a share of anything, and a waterfall of
+changes in segment averages does not reconcile to the change in the overall
+average. So the decision is made here, once, and every surface asks for it
+rather than inferring it again from the column name.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from formatting import is_percentage, normalized_name, percentage_outranks_currency
+
+# A measure where going up is bad. Whole-word: "Cost" and "Refund Amount"
+# count, "Cost Savings" does not.
+ADVERSE_MEASURE_TOKENS = frozenset({
+    "cost", "costs", "expense", "expenses", "spend", "churn", "refund", "refunds",
+    "returns", "loss", "losses", "overdue", "delay", "delays", "hours", "tickets",
+    "complaints", "defects", "errors", "bounce", "debt", "outstanding",
+})
+# A measure whose first word settles it as good news whatever follows:
+# "Revenue After Returns" is revenue.
+FAVOURABLE_MEASURE_TOKENS = frozenset({
+    "revenue", "sales", "profit", "income", "margin", "bookings", "mrr", "arr", "gmv",
+    "orders", "units", "conversion", "conversions", "retention", "signups", "leads",
+})
+FAVOURABLE_OVERRIDES = frozenset({"savings", "saved", "recovered", "avoided"})
+
+
+def increase_is_welcome(measure: str | None) -> bool:
+    """Whether a rise in this measure is good news.
+
+    The first word decides when it is itself a known measure -- "Revenue After
+    Returns" is revenue, "Refund Amount" is a refund. Otherwise the head noun
+    decides: "Customer Acquisition Cost" is a cost. A word in the middle is a
+    qualifier and does not flip the reading.
+    """
+    if not measure:
+        return True
+    words = normalized_name(measure).split()
+    if not words or any(word in FAVOURABLE_OVERRIDES for word in words):
+        return True
+    first, last = words[0], words[-1]
+    if first in FAVOURABLE_MEASURE_TOKENS:
+        return True
+    if first in ADVERSE_MEASURE_TOKENS:
+        return False
+    return last not in ADVERSE_MEASURE_TOKENS
+
+
+@dataclass(frozen=True)
+class MetricSpec:
+    """How a measure combines, and what may be said about it."""
+
+    name: str | None
+    aggregation: str  # sum | mean | count
+    unit: str  # amount | rate | count
+    increase_is_welcome: bool
+
+    @property
+    def additive(self) -> bool:
+        """Whether parts add up to the whole.
+
+        Only then do shares of a total, a concentration index or a waterfall
+        of segment changes mean anything. A rate is an average of averages.
+        """
+        return self.aggregation != "mean"
+
+    @property
+    def combines_as(self) -> str:
+        return {"sum": "total", "mean": "average", "count": "count"}[self.aggregation]
+
+
+def resolve_metric(name: str | None) -> MetricSpec:
+    """The one place a column name becomes a decision about arithmetic."""
+    if not name:
+        return MetricSpec(name=None, aggregation="count", unit="count", increase_is_welcome=True)
+    if is_percentage(name) and percentage_outranks_currency(name):
+        return MetricSpec(
+            name=name, aggregation="mean", unit="rate", increase_is_welcome=increase_is_welcome(name)
+        )
+    return MetricSpec(
+        name=name, aggregation="sum", unit="amount", increase_is_welcome=increase_is_welcome(name)
+    )

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,48 @@
+"""The one place a metric says how it combines and which way is good news.
+
+Nothing reads this yet: it is the groundwork the rate fixes are built on, and
+it is separate so the rule itself can be reviewed before the eight surfaces
+that will follow it.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from metrics import increase_is_welcome, resolve_metric
+
+
+class MetricSpecTests(unittest.TestCase):
+    def test_a_rate_averages_and_an_amount_totals(self):
+        rate = resolve_metric("Conversion Rate")
+        self.assertEqual(rate.aggregation, "mean")
+        self.assertEqual(rate.unit, "rate")
+        self.assertFalse(rate.additive)
+        self.assertEqual(rate.combines_as, "average")
+
+        amount = resolve_metric("Revenue")
+        self.assertEqual(amount.aggregation, "sum")
+        self.assertEqual(amount.unit, "amount")
+        self.assertTrue(amount.additive)
+        self.assertEqual(amount.combines_as, "total")
+
+    def test_no_measure_counts_rows(self):
+        counted = resolve_metric(None)
+        self.assertEqual(counted.aggregation, "count")
+        self.assertEqual(counted.combines_as, "count")
+
+    def test_direction_of_good_is_read_from_the_whole_name(self):
+        # "Cost Savings" is not a cost, and "Revenue After Returns" is not a
+        # return. A substring test on either would get both backwards.
+        self.assertTrue(increase_is_welcome("Revenue After Returns"))
+        self.assertTrue(increase_is_welcome("Cost Savings"))
+        self.assertTrue(increase_is_welcome("Units"))
+        self.assertFalse(increase_is_welcome("Cost"))
+        self.assertFalse(increase_is_welcome("Refund Amount"))
+
+    def test_an_unnamed_metric_is_not_assumed_to_be_bad_news(self):
+        self.assertTrue(increase_is_welcome(None))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**88 lines of code. Nothing imports this yet.** First of a stack that replaces #40 — merge from the bottom up.

## What problem does this solve?

ADA decides three things about a measure over and over, in eight different places, and they had drifted apart:

- **How it combines.** The brief summed a conversion rate while Explore averaged it. Four records of 20% are not 80%.
- **What unit it is in.** A rate that moved from 28% to 31% was reported as "increased 10.7%" — the relative reading of a number that moved three points.
- **Which direction is good news.** A falling cost was described with the words written for a falling revenue.

## What changed?

`resolve_metric` answers all three once, so the surfaces that read it agree by construction rather than by everyone remembering.

`increase_is_welcome` reads the **whole** name rather than looking for a substring: "Cost Savings" is not a cost and "Revenue After Returns" is not a return, and a substring test gets both backwards.

This is deliberately first and deliberately alone, so the rule can be argued with before the code that depends on it lands.

## Evidence and trust boundaries

No behaviour change anywhere — nothing calls this yet, so the eight surfaces still do exactly what they do on `main`. No external call, no cost change, no privacy boundary touched.

## Verification

- [x] `ruff check .`
- [x] `python -m unittest discover -s tests -v` (296 tests)
- [x] New or changed analytical behavior has tests — `tests/test_metrics.py`
- [ ] UI changes include screenshots (none: no UI in this change)
- [x] No credentials, private datasets, or generated build output are committed

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJw6wjHqjrZCHsU1rsT6pf)_