### PR TITLE
2/N Stop a blank period turning a forecast into nan

### DIFF
--- a/anomalies.py
+++ b/anomalies.py
@@ -28,7 +28,7 @@ from dataclasses import dataclass
 import numpy as np
 import pandas as pd
 
-from timeseries import fit_trendline, robust_scale
+from timeseries import fit_trendline, observed_periods, robust_scale
 
 MIN_PERIODS = 8
 FALSE_ALARM_RATE = 0.05
@@ -88,7 +88,12 @@ def detect_anomalies(
     sensitivity, which is occasionally the right call but should be a
     deliberate one.
     """
-    if trend.empty or not {"Period", "Value"}.issubset(trend.columns) or len(trend) < min_periods:
+    if trend.empty or not {"Period", "Value"}.issubset(trend.columns):
+        return ()
+    # As in build_forecast: a period with no observation is not evidence, and
+    # one NaN makes the residual scale NaN, which silently flags nothing.
+    trend = observed_periods(trend)
+    if len(trend) < min_periods:
         return ()
 
     periods = pd.DatetimeIndex(pd.to_datetime(trend["Period"]))

--- a/forecasting.py
+++ b/forecasting.py
@@ -26,7 +26,7 @@ from dataclasses import dataclass
 import numpy as np
 import pandas as pd
 
-from timeseries import fit_trendline, period_grain, robust_scale
+from timeseries import fit_trendline, observed_periods, period_grain, robust_scale
 
 MIN_PERIODS = 8
 MIN_SEASONAL_PERIODS = 18
@@ -129,7 +129,13 @@ def build_forecast(
     min_periods: int = MIN_PERIODS,
 ) -> Forecast | None:
     """Forecast the next periods, or return None when history is too thin."""
-    if trend.empty or not {"Period", "Value"}.issubset(trend.columns) or len(trend) < min_periods:
+    if trend.empty or not {"Period", "Value"}.issubset(trend.columns):
+        return None
+    # Unobserved periods are NaN by design (see aggregation's calendar rules).
+    # Dropped BEFORE the length check, so "enough history" counts periods that
+    # were actually measured rather than blanks the fit cannot use anyway.
+    trend = observed_periods(trend)
+    if len(trend) < min_periods:
         return None
 
     periods = pd.DatetimeIndex(pd.to_datetime(trend["Period"]))

--- a/tests/test_observed_periods.py
+++ b/tests/test_observed_periods.py
@@ -1,0 +1,88 @@
+"""A period nobody measured is not a number the arithmetic can carry.
+
+The trend frame holds an unobserved period as NaN, which is the honest value
+and the right one for the chart. But `to_numpy(dtype=float)` hands that NaN to
+Theil-Sen, one NaN makes the slope NaN, and every forecast value, band edge and
+residual downstream is NaN as well. The forecast card printed "nan", the
+backtest caption claimed the model "did not beat" a naive one it had never been
+scored against, and anomaly detection returned nothing at all for a series with
+an obvious spike in it.
+
+The frames here are built by hand rather than through build_trend, because the
+change that makes build_trend produce gaps is a separate pull request. What is
+under test is what the two consumers do when a gap arrives.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+import pandas as pd
+
+from anomalies import detect_anomalies
+from forecasting import build_forecast
+from timeseries import observed_periods
+
+
+def trend(values):
+    return pd.DataFrame(
+        {"Period": pd.date_range("2022-01-31", periods=len(values), freq="ME"), "Value": values}
+    )
+
+
+class ObservedPeriodsTests(unittest.TestCase):
+    def test_a_frame_with_no_gaps_is_returned_untouched(self):
+        frame = trend([1.0, 2.0, 3.0])
+        self.assertIs(observed_periods(frame), frame)
+
+    def test_gaps_are_dropped_and_the_rest_kept_in_order(self):
+        frame = trend([1.0, np.nan, 3.0])
+        kept = observed_periods(frame)
+        self.assertEqual(kept["Value"].tolist(), [1.0, 3.0])
+        self.assertTrue(kept["Period"].is_monotonic_increasing)
+
+    def test_an_empty_or_shapeless_frame_is_survivable(self):
+        self.assertTrue(observed_periods(pd.DataFrame()).empty)
+        odd = pd.DataFrame({"Period": []})
+        self.assertIs(observed_periods(odd), odd)
+
+
+class ForecastTests(unittest.TestCase):
+    def test_one_blank_month_does_not_make_the_whole_forecast_nan(self):
+        values = [100.0 + 5 * i for i in range(24)]
+        values[7] = np.nan
+        forecast = build_forecast(trend(values))
+        self.assertIsNotNone(forecast)
+        for name in ("values", "lower", "upper"):
+            numbers = np.asarray(getattr(forecast, name), dtype=float)
+            self.assertFalse(np.isnan(numbers).any(), f"{name} carries NaN")
+
+    def test_history_is_counted_in_periods_that_were_measured(self):
+        # Eight rows, one of them blank, is seven observations - below the
+        # minimum, and refusing is the honest answer rather than fitting a
+        # line through a NaN.
+        values = [100.0, np.nan] + [100.0 + i for i in range(6)]
+        self.assertIsNone(build_forecast(trend(values), min_periods=8))
+
+
+class AnomalyTests(unittest.TestCase):
+    def test_a_spike_is_still_found_when_a_month_is_blank(self):
+        values = [100.0] * 24
+        values[5] = np.nan
+        values[18] = 1000.0
+        found = detect_anomalies(trend(values))
+        self.assertTrue(found, "an obvious spike went unreported")
+        self.assertEqual(
+            pd.Timestamp(found[0].period).to_period("M"),
+            pd.Timestamp("2023-07-31").to_period("M"),
+        )
+
+    def test_a_series_with_no_gaps_is_unaffected(self):
+        values = [100.0] * 24
+        values[18] = 1000.0
+        self.assertTrue(detect_anomalies(trend(values)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/timeseries.py
+++ b/timeseries.py
@@ -157,3 +157,34 @@ def robust_scale(residuals: np.ndarray) -> float:
 
     fallback = float(np.mean(deviations)) * MEAN_ABS_DEV_SCALE
     return fallback if fallback > 0 else 0.0
+
+
+def observed_periods(trend: pd.DataFrame) -> pd.DataFrame:
+    """A trend with its unobserved periods removed.
+
+    A period whose every value was missing is held as NaN rather than zero -
+    that distinction is the whole point of the calendar rules in aggregation,
+    and it is right. But NaN is not a number the arithmetic downstream can
+    carry: ``to_numpy(dtype=float)`` hands it to Theil-Sen, one NaN makes the
+    slope NaN, and from there every forecast value, every band edge and every
+    residual is NaN. The visible damage was a forecast card reading "nan" and
+    the backtest caption saying the model "did not beat" a naive one it was
+    never scored against, plus anomaly detection returning nothing at all for
+    a series with an obvious spike in it.
+
+    So the gap is preserved where it means something - the chart, the caption,
+    the filled-period count - and dropped here, where a period with no
+    observation is simply not evidence about the trend. Fitting a line through
+    the periods that WERE observed is the honest reading of a series with a
+    hole in it; the alternative is refusing to forecast at all because one
+    month of a three-year history was blank.
+
+    Returns the frame unchanged when nothing is missing, so the common path
+    pays one ``isna`` and no copy.
+    """
+    if trend.empty or "Value" not in trend.columns:
+        return trend
+    missing = trend["Value"].isna()
+    if not missing.any():
+        return trend
+    return trend.loc[~missing]


### PR DESCRIPTION
**50 lines of code. Stacked on #42 — review that one first.** The diff against `main` includes #42; the diff against its base is this change alone.

## What problem does this solve?

A period with no observation is held as `NaN` in the trend frame. That is the honest value and the right one for the chart — but it is not a number the arithmetic downstream can carry. Both consumers read `Value` straight into a float array, one `NaN` makes the Theil-Sen slope `NaN`, and from there every forecast value, every band edge and every residual is `NaN` too.

What that looked like on screen:

- the forecast card printing **`nan`**
- the backtest caption reporting an **"average error of nan%"** and concluding the model "did not beat" a naive one it was never scored against
- anomaly detection returning **nothing at all** for a series with an obvious spike in it

All three are the app stating something false rather than declining to answer.

## What changed?

`timeseries.observed_periods` drops unobserved periods, and both `build_forecast` and `detect_anomalies` call it. The gap is still preserved where it means something — the chart, the caption, the filled-period count — and dropped here, where a period nobody measured is simply not evidence about the trend.

The length check now runs **after** the drop, so "enough history" counts periods that were actually measured. Eight rows with one blank is seven observations, and refusing is better than fitting a line through a hole.

## Evidence and trust boundaries

Changes what the forecast and the anomaly list are computed from: periods with no observation are no longer part of the fit. Fitting through the periods that *were* observed is the honest reading of a series with a hole in it; the alternative is refusing to forecast at all because one month of a three-year history was blank. No external call, no cost change.

## Verification

- [x] `ruff check .`
- [x] `python -m unittest discover -s tests -v` (296 tests)
- [x] New or changed analytical behavior has tests — `tests/test_observed_periods.py`. The frames are built by hand: the change that makes `build_trend` produce these gaps is #43, and this one is about what the consumers do when a gap arrives.
- [ ] UI changes include screenshots (none: no UI in this change)
- [x] No credentials, private datasets, or generated build output are committed

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJw6wjHqjrZCHsU1rsT6pf)_