### PR TITLE
3/N Average a rate over a period, and leave its empty periods empty

### DIFF
--- a/aggregation.py
+++ b/aggregation.py
@@ -15,7 +15,8 @@ from dataclasses import dataclass
 import numpy as np
 import pandas as pd
 
-from formatting import format_period, is_percentage, percentage_outranks_currency
+from formatting import format_period
+from metrics import resolve_metric
 from schema import ColumnRoles
 
 GRAIN_ORDER = ("W", "M", "Q", "Y")
@@ -48,15 +49,8 @@ def _grain_for_cadence(dates: pd.Series) -> str:
 
 
 def measure_aggregation(measure: str | None) -> str:
-    """How a measure combines across rows: rates average, amounts add.
-
-    Adding two months of conversion rate produces a number with no meaning,
-    and every surface built on period totals was doing exactly that. The
-    decision lives here so trend, segment and headline agree.
-    """
-    if measure and is_percentage(measure) and percentage_outranks_currency(measure):
-        return "mean"
-    return "sum"
+    """How a measure combines across rows: rates average, amounts add."""
+    return resolve_metric(measure).aggregation
 
 
 def _period_frequency(date_series: pd.Series) -> str:
@@ -98,6 +92,9 @@ class TrendSeries:
     frame: pd.DataFrame
     frequency: str
     filled_periods: int = 0
+    #: True when those periods were filled with zero (an additive measure),
+    #: False when they were left empty (a rate has no observation to average).
+    filled_as_zero: bool = True
     partial_period: pd.Timestamp | None = None
     partial_coverage: str = ""
     # A period the data stops part-way through, but not far enough through for
@@ -124,8 +121,15 @@ class TrendSeries:
             )
         if self.filled_periods:
             plural = "periods" if self.filled_periods > 1 else "period"
+            # A rate's gaps are NOT zeroes - nobody converted at 0%, nobody
+            # measured at all - so the caption cannot say they were counted as
+            # zero while the chart shows a break in the line.
+            settled = (
+                "counted as zero" if self.filled_as_zero else "left empty, since an average "
+                "needs an observation"
+            )
             notes.append(
-                f"{self.filled_periods} {plural} with no rows counted as zero, keeping the "
+                f"{self.filled_periods} {plural} with no rows {settled}, keeping the "
                 "timeline evenly spaced."
             )
         return tuple(notes)
@@ -175,18 +179,24 @@ def build_trend(
     dataframe: pd.DataFrame,
     roles: ColumnRoles,
     frequency: str | None = None,
+    count_column: str | None = None,
 ) -> TrendSeries:
-    """Aggregate the measure over a human-sized grain, on an even timeline."""
+    """Aggregate the measure over a human-sized grain, on an even timeline.
+
+    With ``count_column`` and no measure, each period holds the number of
+    distinct values in that column: customers per month, not rows per month.
+    """
     if not roles.date:
         return TrendSeries(frame=EMPTY_TREND.copy(), frequency=frequency or "M")
 
-    columns = [roles.date] + ([roles.measure] if roles.measure else [])
+    counted = count_column if count_column and not roles.measure and count_column != roles.date else None
+    columns = [roles.date] + ([roles.measure] if roles.measure else []) + ([counted] if counted else [])
     working = dataframe[columns].dropna(subset=[roles.date]).copy()
     if working.empty:
         return TrendSeries(frame=EMPTY_TREND.copy(), frequency=frequency or "M")
     # Internal names from here on. A measure the file calls "Period" was being
     # overwritten by the period buckets built below, then summed as datetimes.
-    working.columns = ["__date"] + (["__measure"] if roles.measure else [])
+    working.columns = ["__date"] + (["__measure"] if roles.measure else []) + (["__count"] if counted else [])
 
     frequency = frequency or _period_frequency(working["__date"])
     working["Period"] = working["__date"].dt.to_period(frequency).dt.to_timestamp()
@@ -201,20 +211,34 @@ def build_trend(
         else:
             partial_period, partial_coverage = None, ""
 
-    if roles.measure:
-        result = working.groupby("Period", as_index=False)["__measure"].agg(
-            measure_aggregation(roles.measure)
-        )
-        result = result.rename(columns={"__measure": "Value"})
+    metric = resolve_metric(roles.measure)
+    if counted:
+        result = working.groupby("Period")["__count"].nunique().rename("Value").reset_index()
+    elif roles.measure:
+        grouped = working.groupby("Period")["__measure"]
+        # A period whose every value is missing is a missing period, not a
+        # period that measured zero: sum(min_count=1) keeps it NaN.
+        totals = grouped.sum(min_count=1) if metric.aggregation == "sum" else grouped.mean()
+        result = totals.rename("Value").reset_index()
     else:
         result = working.groupby("Period", as_index=False).size().rename(columns={"size": "Value"})
     result = result.sort_values("Period").reset_index(drop=True)
 
-    result, filled = _fill_empty_periods(result, frequency)
+    # A month with no rows is a month of zero sales, but it is not a month
+    # of zero conversion rate -- there is no observation, so the gap stays
+    # empty. And with fewer than three distinct dates there is no cadence to
+    # fill against at all; two month-end readings were being spread into
+    # three invented zero weeks.
+    fill_value = 0.0 if metric.additive else float("nan")
+    if working["__date"].nunique() >= 3:
+        result, filled = _fill_empty_periods(result, frequency, fill_value)
+    else:
+        filled = 0
     return TrendSeries(
         frame=result,
         frequency=frequency,
         filled_periods=filled,
+        filled_as_zero=metric.additive,
         partial_period=partial_period,
         partial_coverage=partial_coverage,
         short_coverage=short_coverage,
@@ -222,7 +246,9 @@ def build_trend(
     )
 
 
-def _fill_empty_periods(trend: pd.DataFrame, frequency: str) -> tuple[pd.DataFrame, int]:
+def _fill_empty_periods(
+    trend: pd.DataFrame, frequency: str, fill_value: float = 0.0
+) -> tuple[pd.DataFrame, int]:
     """Materialise periods with no rows as zero, so gaps stop bending the fit.
 
     A month in which nothing was sold is a month of zero sales, not a month
@@ -243,7 +269,7 @@ def _fill_empty_periods(trend: pd.DataFrame, frequency: str) -> tuple[pd.DataFra
 
     filled = (
         trend.set_index("Period")
-        .reindex(complete, fill_value=0.0)
+        .reindex(complete, fill_value=fill_value)
         .rename_axis("Period")
         .reset_index()
     )
@@ -335,14 +361,26 @@ def segment_period_change(
     )
     working["Period"] = working["__date"].dt.to_period(frequency).dt.to_timestamp()
     comparison = working[working["Period"].isin([previous_period, current_period])]
+    metric = resolve_metric(roles.measure)
     grouped = (
         comparison.groupby(["__segment", "Period"])["__measure"]
-        .agg(measure_aggregation(roles.measure))
-        .unstack(fill_value=0)
+        .agg(metric.aggregation)
+        .unstack()
     )
     grouped.index.name = roles.dimension
     if previous_period not in grouped or current_period not in grouped:
         return None
+    if metric.additive:
+        # A segment with no rows in a period sold nothing in it: zero.
+        grouped = grouped.fillna(0.0)
+    else:
+        # A segment with no rows in a period has no average in it. Filling
+        # with zero made a region that first appears this month "rise from
+        # 0.0% to 31.0%", so a segment has to be present on both sides to
+        # have a change at all.
+        grouped = grouped.dropna(subset=[previous_period, current_period])
+        if grouped.empty:
+            return None
 
     grouped["Change"] = grouped[current_period] - grouped[previous_period]
     return grouped, previous_period, current_period
@@ -358,7 +396,9 @@ def driver_frame(dataframe: pd.DataFrame, roles: ColumnRoles, limit: int = 9) ->
     top = changes.head(limit)
     frame = pd.DataFrame({"Segment": top.index.astype(str), "Change": top.to_numpy(dtype=float)})
     remainder = float(changes.iloc[limit:].sum())
-    if len(changes) > limit and remainder:
+    # Changes in segment averages do not sum to anything, so there is no
+    # "other" bar to add up for a rate -- only the segments shown.
+    if len(changes) > limit and remainder and resolve_metric(roles.measure).additive:
         other = pd.DataFrame({"Segment": ["Other segments"], "Change": [remainder]})
         frame = pd.concat([frame, other], ignore_index=True)
     return frame

--- a/metrics.py
+++ b/metrics.py
@@ -1,0 +1,88 @@
+"""What a measure is, decided once and consumed everywhere.
+
+The rate change fixed the headline, then the trend, then chat, and each
+surface disagreed with the next about whether a rate adds up. It does not:
+two months of conversion rate do not sum to anything, a segment's share of
+"total conversion rate" is not a share of anything, and a waterfall of
+changes in segment averages does not reconcile to the change in the overall
+average. So the decision is made here, once, and every surface asks for it
+rather than inferring it again from the column name.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from formatting import is_percentage, normalized_name, percentage_outranks_currency
+
+# A measure where going up is bad. Whole-word: "Cost" and "Refund Amount"
+# count, "Cost Savings" does not.
+ADVERSE_MEASURE_TOKENS = frozenset({
+    "cost", "costs", "expense", "expenses", "spend", "churn", "refund", "refunds",
+    "returns", "loss", "losses", "overdue", "delay", "delays", "hours", "tickets",
+    "complaints", "defects", "errors", "bounce", "debt", "outstanding",
+})
+# A measure whose first word settles it as good news whatever follows:
+# "Revenue After Returns" is revenue.
+FAVOURABLE_MEASURE_TOKENS = frozenset({
+    "revenue", "sales", "profit", "income", "margin", "bookings", "mrr", "arr", "gmv",
+    "orders", "units", "conversion", "conversions", "retention", "signups", "leads",
+})
+FAVOURABLE_OVERRIDES = frozenset({"savings", "saved", "recovered", "avoided"})
+
+
+def increase_is_welcome(measure: str | None) -> bool:
+    """Whether a rise in this measure is good news.
+
+    The first word decides when it is itself a known measure -- "Revenue After
+    Returns" is revenue, "Refund Amount" is a refund. Otherwise the head noun
+    decides: "Customer Acquisition Cost" is a cost. A word in the middle is a
+    qualifier and does not flip the reading.
+    """
+    if not measure:
+        return True
+    words = normalized_name(measure).split()
+    if not words or any(word in FAVOURABLE_OVERRIDES for word in words):
+        return True
+    first, last = words[0], words[-1]
+    if first in FAVOURABLE_MEASURE_TOKENS:
+        return True
+    if first in ADVERSE_MEASURE_TOKENS:
+        return False
+    return last not in ADVERSE_MEASURE_TOKENS
+
+
+@dataclass(frozen=True)
+class MetricSpec:
+    """How a measure combines, and what may be said about it."""
+
+    name: str | None
+    aggregation: str  # sum | mean | count
+    unit: str  # amount | rate | count
+    increase_is_welcome: bool
+
+    @property
+    def additive(self) -> bool:
+        """Whether parts add up to the whole.
+
+        Only then do shares of a total, a concentration index or a waterfall
+        of segment changes mean anything. A rate is an average of averages.
+        """
+        return self.aggregation != "mean"
+
+    @property
+    def combines_as(self) -> str:
+        return {"sum": "total", "mean": "average", "count": "count"}[self.aggregation]
+
+
+def resolve_metric(name: str | None) -> MetricSpec:
+    """The one place a column name becomes a decision about arithmetic."""
+    if not name:
+        return MetricSpec(name=None, aggregation="count", unit="count", increase_is_welcome=True)
+    if is_percentage(name) and percentage_outranks_currency(name):
+        return MetricSpec(
+            name=name, aggregation="mean", unit="rate", increase_is_welcome=increase_is_welcome(name)
+        )
+    return MetricSpec(
+        name=name, aggregation="sum", unit="amount", increase_is_welcome=increase_is_welcome(name)
+    )

--- a/tests/test_bug_bash.py
+++ b/tests/test_bug_bash.py
@@ -114,7 +114,9 @@ class RateMeasureTests(unittest.TestCase):
         self.assertEqual(measure_aggregation("Margin Amount"), "sum")
 
     def test_the_headline_averages_a_rate_with_a_matching_number(self):
-        brief = analyze_business(pd.DataFrame({"Date": MONTHS[:2], "Conversion Rate": [0.1, 0.2]}))
+        # No date, so no trend card: the fallback headline has to combine the
+        # rate honestly on its own.
+        brief = analyze_business(pd.DataFrame({"Conversion Rate": [0.1, 0.2], "Channel": ["a", "b"]}))
 
         self.assertIn("averages", brief.headline)
         self.assertIn("15.0%", brief.headline)

--- a/tests/test_rate_trends.py
+++ b/tests/test_rate_trends.py
@@ -1,0 +1,87 @@
+"""A rate is averaged over a period, and its empty periods stay empty.
+
+Both halves are the same mistake in two directions. Summing a conversion rate
+over a month answers a question nobody asked - four records of 20% do not make
+80%. And filling a month that has no records with 0.0 states that everybody who
+visited failed to convert, when in fact nobody visited.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+import pandas as pd
+
+from aggregation import build_trend
+from schema import detect_roles
+
+
+class RateTrendTests(unittest.TestCase):
+    def setUp(self):
+        # Four records a month: a sum and a mean differ by a factor of four.
+        rows = []
+        for month in ("2025-01-31", "2025-02-28", "2025-03-31"):
+            rows.extend((month, 0.2) for _ in range(4))
+        self.frame = pd.DataFrame(rows, columns=["Date", "Conversion Rate"])
+        self.frame["Date"] = pd.to_datetime(self.frame["Date"])
+
+    def test_a_rate_is_the_period_average_not_the_period_total(self):
+        series = build_trend(self.frame, detect_roles(self.frame))
+        np.testing.assert_allclose(series.frame["Value"].to_numpy(), [0.2, 0.2, 0.2])
+
+    def test_an_amount_is_still_the_period_total(self):
+        amounts = self.frame.rename(columns={"Conversion Rate": "Revenue"})
+        amounts["Revenue"] = 100.0
+        series = build_trend(amounts, detect_roles(amounts))
+        np.testing.assert_allclose(series.frame["Value"].to_numpy(), [400.0, 400.0, 400.0])
+
+
+class EmptyPeriodTests(unittest.TestCase):
+    def monthly(self, measure, *, skip):
+        """Twelve month-ends with one month absent from the file."""
+        months = [m for i, m in enumerate(pd.date_range("2025-01-31", periods=12, freq="ME"))
+                  if i != skip]
+        value = 0.2 if measure == "Conversion Rate" else 100.0
+        frame = pd.DataFrame({"Date": months, measure: [value] * len(months)})
+        return build_trend(frame, detect_roles(frame))
+
+    def test_a_missing_day_of_a_rate_is_empty_not_zero(self):
+        series = self.monthly("Conversion Rate", skip=4)
+        gap = series.frame.loc[series.frame["Period"] == pd.Timestamp("2025-05-01"), "Value"]
+        self.assertEqual(len(gap), 1)
+        self.assertTrue(np.isnan(float(gap.iloc[0])), "a rate nobody measured is not 0%")
+        self.assertFalse(series.filled_as_zero)
+
+    def test_a_missing_day_of_an_amount_is_a_day_that_sold_nothing(self):
+        series = self.monthly("Revenue", skip=4)
+        gap = series.frame.loc[series.frame["Period"] == pd.Timestamp("2025-05-01"), "Value"]
+        self.assertEqual(float(gap.iloc[0]), 0.0)
+        self.assertTrue(series.filled_as_zero)
+
+    def test_the_caption_says_which_of_the_two_happened(self):
+        self.assertIn("left empty", " ".join(self.monthly("Conversion Rate", skip=4).notes))
+        self.assertIn("counted as zero", " ".join(self.monthly("Revenue", skip=4).notes))
+
+    def test_a_period_whose_values_are_all_missing_stays_missing(self):
+        frame = pd.DataFrame(
+            {
+                "Date": pd.to_datetime(["2025-01-31", "2025-02-28", "2025-03-31"]),
+                "Revenue": [100.0, np.nan, 100.0],
+            }
+        )
+        series = build_trend(frame, detect_roles(frame))
+        february = series.frame.loc[series.frame["Period"] == pd.Timestamp("2025-02-01"), "Value"]
+        self.assertTrue(np.isnan(float(february.iloc[0])), "no reading is not a reading of zero")
+
+    def test_two_readings_are_not_spread_into_invented_periods(self):
+        frame = pd.DataFrame(
+            {"Month": pd.to_datetime(["2024-01-31", "2024-02-29"]), "Revenue": [100.0, 120.0]}
+        )
+        series = build_trend(frame, detect_roles(frame))
+        self.assertEqual(len(series.frame), 2)
+        self.assertEqual(series.filled_periods, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**90 lines of code. Stacked on #42 — review that one first.** The first surface to read the metric contract.

## What problem does this solve?

Two halves of one mistake.

Four records of 20% were **summed** into a period value of 80%, which answers a question nobody asked.

And a month with **no records at all** was filled with 0.0, which states that everyone who visited failed to convert — when in fact nobody visited.

## What changed?

The aggregation comes from the metric: `sum` for an amount, `mean` for a rate.

The gap value comes from the same place: zero for an amount, because a month with no sales did sell nothing, and empty for a rate, because an average needs an observation. A period whose every value is missing stays missing rather than totalling to zero.

The trend caption had to change with it. It said empty periods were "counted as zero" unconditionally, which for a rate now contradicts its own chart — so `TrendSeries` carries `filled_as_zero` and the note says which of the two actually happened.

## Evidence and trust boundaries

This changes a published number: a rate trend's period values are now means, not sums. That is the correction, but it means a rate chart will look different from the same file yesterday — lower, and by a factor of however many records a period held.

One existing test moves rather than changes meaning: the fallback headline it checks needs a frame with no date column, because with one it now gets a trend card instead and never reaches the fallback.

Empty periods of a rate now render as a break in the line rather than a dip to zero. #43 is what stops that `NaN` reaching the forecast.

## Verification

- [x] `ruff check .`
- [x] `python -m unittest discover -s tests -v` (292 tests)
- [x] New or changed analytical behavior has tests — `tests/test_rate_trends.py`
- [ ] UI changes include screenshots (the chart's own values change; no layout change)
- [x] No credentials, private datasets, or generated build output are committed

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJw6wjHqjrZCHsU1rsT6pf)_