### PR TITLE
5/N Say percentage points when a rate moves

### DIFF
--- a/formatting.py
+++ b/formatting.py
@@ -97,6 +97,24 @@ def percentage_outranks_currency(column: str | None) -> bool:
     return bool(words) and words[-1] in PERCENTAGE_TOKENS
 
 
+def rate_scale(column_values: pd.Series | None, value: float = 0.0) -> str:
+    """Whether a rate column stores fractions (0.25) or points (25)."""
+    return "fraction" if _percentage_uses_fraction_scale(value, column_values) else "points"
+
+
+def format_rate_change(delta: float, column_values: pd.Series | None) -> str:
+    """A change in a rate is a number of percentage points, not a percentage.
+
+    20% to 40% is twenty points, or a hundred percent relative. Saying
+    "increased by 20%" for that is ambiguous at best and wrong on the relative
+    reading, so the unit is always spelt out.
+    """
+    if not np.isfinite(delta):
+        return "an unmeasurable amount"
+    points = delta * 100 if rate_scale(column_values, delta) == "fraction" else delta
+    return f"{abs(points):.1f} percentage points"
+
+
 def _column_reads_as_percentage(value: float, column_values: pd.Series | None) -> bool:
     """Judge plausibility once for the column, not once per value.
 

--- a/tests/test_rate_change_units.py
+++ b/tests/test_rate_change_units.py
@@ -1,0 +1,66 @@
+"""A change in a rate is a number of percentage points.
+
+20% to 40% is twenty points, or a hundred percent relative. Both readings are
+defensible and they disagree by a factor of five, so "increased by 20%" is
+ambiguous at best and wrong on the relative reading. The unit gets spelt out.
+
+The other half is scale. Some files store a rate as 0.25 and some as 25, and
+the same delta means different things in each: a jump of 0.2 is twenty points
+in the first file and a fifth of a point in the second. rate_scale decides once
+per column rather than once per value, so a column cannot be read one way in
+the headline and another in the table.
+
+Nothing calls these yet - the surfaces that will are their own pull requests.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+import pandas as pd
+
+from formatting import format_rate_change, rate_scale
+
+
+class RateScaleTests(unittest.TestCase):
+    def test_a_column_of_fractions_is_read_as_fractions(self):
+        self.assertEqual(rate_scale(pd.Series([0.1, 0.25, 0.4])), "fraction")
+
+    def test_a_column_of_points_is_read_as_points(self):
+        # 12.5 as a fraction would be 1,250% - which no conversion rate is.
+        self.assertEqual(rate_scale(pd.Series([12.5, 30.0, 47.2])), "points")
+
+    def test_no_column_falls_back_to_the_value_itself(self):
+        self.assertEqual(rate_scale(None, 0.25), "fraction")
+        self.assertEqual(rate_scale(None, 25.0), "points")
+
+
+class RateChangeTests(unittest.TestCase):
+    def test_a_fraction_column_scales_up_to_points(self):
+        rates = pd.Series([0.2, 0.4])
+        self.assertEqual(format_rate_change(0.2, rates), "20.0 percentage points")
+
+    def test_a_points_column_is_already_points(self):
+        rates = pd.Series([20.0, 40.0])
+        self.assertEqual(format_rate_change(20.0, rates), "20.0 percentage points")
+
+    def test_the_size_is_reported_without_its_sign(self):
+        # The direction is the sentence's job; this is the magnitude, so a
+        # caller writing "fell by ..." does not produce "fell by -3.0".
+        rates = pd.Series([0.2, 0.4])
+        self.assertEqual(format_rate_change(-0.03, rates), "3.0 percentage points")
+
+    def test_a_relative_reading_never_appears(self):
+        # 20 -> 40 is a hundred percent relative. That number must not be what
+        # comes out of a function about points.
+        self.assertNotIn("100", format_rate_change(0.2, pd.Series([0.2, 0.4])))
+
+    def test_an_unmeasurable_change_says_so_rather_than_printing_nan(self):
+        for bad in (float("nan"), np.inf, -np.inf):
+            with self.subTest(delta=bad):
+                self.assertEqual(format_rate_change(bad, None), "an unmeasurable amount")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**18 lines of code. No behaviour change — nothing calls these yet.** Independent of #42–#45.

## What problem does this solve?

20% to 40% is twenty **points**, or a hundred **percent** relative. Both readings are defensible and they disagree by a factor of five, so "increased by 20%" is ambiguous at best and wrong on the relative reading. ADA was printing exactly that.

The other half is **scale**. Some files store a rate as `0.25` and some as `25`, and the same delta means different things in each: a jump of 0.2 is twenty points in the first file and a fifth of a point in the second.

## What changed?

`format_rate_change` spells the unit out.

`rate_scale` decides once per **column** rather than once per value, so a column cannot be read one way in the headline and another in the table directly below it.

The magnitude comes back **without its sign**, because direction is the sentence's job — a caller writing "fell by …" should not end up with "fell by -3.0". A non-finite delta says "an unmeasurable amount" rather than printing `nan` at somebody.

The surfaces that will call these — the brief, the trend card, the chat answers — are each their own pull request.

## Evidence and trust boundaries

These two functions are the unit and scale rule for every rate ADA will report. Nothing calls them in this change, so no number on screen moves. No external call, no cost change.

## Verification

- [x] `ruff check .`
- [x] `python -m unittest discover -s tests -v` (293 tests)
- [x] New or changed analytical behavior has tests — `tests/test_rate_change_units.py`
- [ ] UI changes include screenshots (none: no UI in this change)
- [x] No credentials, private datasets, or generated build output are committed

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJw6wjHqjrZCHsU1rsT6pf)_