### PR TITLE
6/N Do not let the row cap invent a collapse, or an empty file

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 
 import pandas as pd
 
+from aggregation import preferred_frequency
 from analysis import CleaningReport, clean_dataframe
 from business_insights import BusinessBrief, analyze_business
 from schema import ColumnRoles, detect_roles
@@ -37,7 +38,25 @@ def _most_recent(dataframe: pd.DataFrame, date_column: str | None, row_limit: in
         return dataframe
     if date_column and date_column in dataframe.columns:
         order = dataframe[date_column].rank(method="first", ascending=False, na_option="bottom")
-        return dataframe.loc[order <= row_limit]
+        kept = dataframe.loc[order <= row_limit]
+        # A cut that lands inside a period leaves that period half-present,
+        # and a half-present oldest period reads as growth into the next one.
+        # It is dropped whenever any row of it was cut.
+        dates = kept[date_column].dropna()
+        if not dates.empty:
+            grain = preferred_frequency(dates)
+            buckets = dataframe[date_column].dt.to_period(grain)
+            oldest = dates.min().to_period(grain)
+            if (buckets[~dataframe.index.isin(kept.index)] == oldest).any():
+                whole = kept[buckets.loc[kept.index] != oldest]
+                # Only when something survives it. Every kept row sitting in
+                # one truncated period is the ordinary shape of a big export
+                # from a busy week: dropping it leaves ZERO rows, and the app
+                # then reports an empty dataset and a $0.00 headline for a
+                # file with a quarter of a million rows in it.
+                if not whole.empty:
+                    kept = whole
+        return kept
     return dataframe.tail(row_limit)
 
 

--- a/tests/test_partial_period_trim.py
+++ b/tests/test_partial_period_trim.py
@@ -1,0 +1,66 @@
+"""The row cap must not invent a collapse, or an empty file.
+
+A large upload is trimmed to its most recent rows. When that cut lands inside
+a period, the oldest kept period is half-present - a February holding one of
+its two records reads as 100 against March's 200, and the brief reports a
+doubling that never happened.
+
+The second half is the guard on the first. Dropping that period is right when
+there is something behind it and catastrophic when there is not: a quarter of a
+million rows all stamped within one busy week are ALL in the truncated period,
+and removing it leaves nothing to analyze at all.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import pandas as pd
+
+from pipeline import prepare_analysis
+
+
+def dated(pairs):
+    frame = pd.DataFrame(pairs, columns=["Date", "Revenue"])
+    frame["Date"] = pd.to_datetime(frame["Date"])
+    return frame
+
+
+class PartialPeriodTests(unittest.TestCase):
+    def test_a_half_present_oldest_period_is_dropped(self):
+        # Two records a month for eight months. Keeping fifteen of sixteen
+        # cuts one February record, so February is partial.
+        rows = [(f"2025-{month:02d}-{day:02d}", 100.0) for month in range(2, 10) for day in (10, 20)]
+        prepared = prepare_analysis(dated(rows), row_limit=15)
+        self.assertEqual(prepared.analyzed_from, pd.Timestamp("2025-03-10"))
+        self.assertNotIn(2, prepared.dataframe["Date"].dt.month.unique())
+
+    def test_a_period_that_survives_the_cut_whole_is_kept(self):
+        # Sixteen of sixteen: nothing was cut, so nothing is dropped.
+        rows = [(f"2025-{month:02d}-{day:02d}", 100.0) for month in range(2, 10) for day in (10, 20)]
+        prepared = prepare_analysis(dated(rows), row_limit=16)
+        self.assertEqual(prepared.analyzed_from, pd.Timestamp("2025-02-10"))
+
+    def test_a_file_that_is_all_one_period_is_not_emptied(self):
+        # The guard. Every kept row is in the truncated period; dropping it
+        # would report an empty dataset and a $0.00 headline for 400 rows.
+        rows = [("2025-03-03", float(n)) for n in range(400)]
+        prepared = prepare_analysis(dated(rows), row_limit=100)
+        self.assertEqual(len(prepared.dataframe), 100)
+        self.assertGreater(prepared.dataframe["Revenue"].sum(), 0)
+
+    def test_a_file_under_the_cap_is_untouched(self):
+        rows = [(f"2025-0{month}-10", 100.0) for month in range(1, 6)]
+        prepared = prepare_analysis(dated(rows), row_limit=1000)
+        self.assertEqual(len(prepared.dataframe), 5)
+        self.assertEqual(prepared.analyzed_from, pd.Timestamp("2025-01-10"))
+
+    def test_a_file_with_no_dates_still_takes_its_tail(self):
+        frame = pd.DataFrame({"Segment": list("abcdefghij"), "Revenue": [float(n) for n in range(10)]})
+        prepared = prepare_analysis(frame, row_limit=4)
+        self.assertEqual(len(prepared.dataframe), 4)
+        self.assertEqual(prepared.dataframe["Revenue"].tolist(), [6.0, 7.0, 8.0, 9.0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**23 lines of code.** Independent of #42–#46.

## What problem does this solve?

A large upload is trimmed to its most recent rows. When that cut lands inside a period, the oldest kept period is **half-present** — a February holding one of its two records reads as 100 against March's 200, and the brief reports a doubling the file does not contain.

## What changed?

The oldest kept period is dropped whenever any row of it was cut.

**And the guard on that**, which is why this is not a two-line change: dropping that period is right when there is something behind it and catastrophic when there is not. A quarter of a million rows all stamped within one busy week are *all* in the truncated period, and removing it leaves nothing at all — an empty dataset and a `$0.00` headline for a file the user can see is enormous. A partial period that is the whole slice is still the only evidence there is, and the trend card already tells the reader it is partial.

## Evidence and trust boundaries

Changes which rows are analyzed for a file over the row cap: the oldest, partially-present period is now excluded, so the first point on the trend and `analyzed_from` both move forward. That is the correction — the excluded period was never comparable with the ones after it.

**Scope note:** only the trim. `pipeline.py` carries two other changes on the release branch — the selection sentinel and the cleaning-audit rows — and both depend on code that has not landed yet, so they follow separately.

## Verification

- [x] `ruff check .`
- [x] `python -m unittest discover -s tests -v` (290 tests)
- [x] New or changed analytical behavior has tests — `tests/test_partial_period_trim.py`, including the all-one-period file that the guard exists for
- [ ] UI changes include screenshots (none: no UI in this change)
- [x] No credentials, private datasets, or generated build output are committed

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJw6wjHqjrZCHsU1rsT6pf)_