### PR TITLE
Land the consistency release on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
       - name: Install dependencies
-        run: python -m pip install -r requirements-dev.txt
+        # constraints.txt pins the resolution that was tested; requirements
+        # state the supported ranges. Without the pin a green run would
+        # depend on whatever resolved that morning.
+        run: python -m pip install -r requirements-dev.txt -c constraints.txt
       - name: Lint
         run: ruff check .
       - name: Test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,40 @@ In the pull request body, explain:
 Keep pull requests focused. Avoid unrelated formatting churn, and do not add a
 dependency without a concrete product need.
 
+## Size: about 100 lines of code
+
+**A pull request should change at most ~100 lines of executable code.** Prose,
+tests and fixtures do not count against it — a 40-line fix with 300 lines of
+tests and a long explanation is exactly right, and a 400-line refactor with no
+tests is exactly wrong.
+
+This is not tidiness. Review quality falls off a cliff somewhere around a
+hundred lines: past that, a reviewer reads for *plausibility* rather than for
+*bugs*, and approves things nobody actually checked. That failure has already
+happened in this repository — a large change here shipped with a green suite of
+385 tests and still carried eight defects, including a forecast that printed
+`nan` and a row cap that could reduce a 250,000-row upload to nothing. Every one
+of them was obvious in a fifty-line diff and invisible in a four-thousand-line
+one.
+
+So if your change is bigger than that, split it. In order of preference:
+
+1. **By behaviour.** One user-visible change per pull request, with the tests
+   that prove it. "Rates are averaged, not summed" is one; "a rate moves in
+   percentage points" is another, even though they touch the same file.
+2. **Groundwork first.** A new module, a shared helper or a renamed function
+   with no behaviour change is its own pull request, and it is a *small* one to
+   review because nothing should move. The change that uses it comes next.
+3. **As a stack.** Open them in order, each based on the last, and say so in the
+   body: `Stacked on #123 — review that first`. Merge from the bottom up.
+
+Two things that do **not** count as splitting: shipping a large change as
+several commits in one pull request (a reviewer still faces the whole diff), and
+holding tests back for a follow-up (a change and its tests are one unit).
+
+Generated or vendored files, lockfiles, and mechanical renames applied by a tool
+are exempt — say which in the body so a reviewer can skip them with confidence.
+
 ## Analytical standard
 
 A useful insight is reproducible from visible evidence. New recommendations must

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,8 +47,11 @@ These protect the thing that makes ADA worth using. Full reasoning in
 3. Formatting changes how a value looks, never what it is.
 4. Evidence is calculated; recommendations are interpretation. Keep them apart,
    and never claim cause.
-5. Raw rows and cell values never reach a model, and model-generated code is
-   never executed.
+5. Raw rows never reach a model, and no cell value does either, with one
+   documented exception: an evidence sentence names the segment it describes,
+   so a segment label can travel inside the strategic read
+   ([docs/privacy.md](docs/privacy.md)). Model-generated code is never
+   executed.
 6. Every analytical rule gets a test, including how it degrades on thin data.
 7. The product works with no API key.
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CI](https://github.com/saineshnakra/automated-data-analyst/actions/workflows/ci.yml/badge.svg)](https://github.com/saineshnakra/automated-data-analyst/actions/workflows/ci.yml)
 [![Python](https://img.shields.io/badge/Python-3.11%20%7C%203.12%20%7C%203.13-3776ab?logo=python&logoColor=white)](https://www.python.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-20a779.svg)](https://github.com/saineshnakra/automated-data-analyst/blob/main/LICENSE)
+[![Stars](https://img.shields.io/github/stars/saineshnakra/automated-data-analyst?style=flat&logo=github&color=f5b731&label=Star%20this%20repo)](https://github.com/saineshnakra/automated-data-analyst/stargazers)
 
 **Upload a CSV or Excel file. Get a dashboard, an executive brief, anomaly
 flags, a forecast, and answers to plain-English questions — with the calculation
@@ -14,6 +15,11 @@ shown under every number.**
 [Contributing](https://github.com/saineshnakra/automated-data-analyst/blob/main/CONTRIBUTING.md)
 
 **Source:** [github.com/saineshnakra/automated-data-analyst](https://github.com/saineshnakra/automated-data-analyst)
+
+> **⭐ If ADA saved you an afternoon, [star the repo](https://github.com/saineshnakra/automated-data-analyst).**
+> It is the whole marketing budget: stars are what put this in front of the next
+> person looking for a tool that shows its arithmetic. One click, and it costs
+> you nothing.
 
 ![ADA turns CSV and Excel files into decision-ready business dashboards](https://raw.githubusercontent.com/saineshnakra/automated-data-analyst/main/assets/ada-social-preview.png)
 
@@ -134,6 +140,14 @@ the code.
 **Built with ADA**
 
 - *Yours could be here.*
+
+## Star it
+
+You read the whole thing — [that is worth a star](https://github.com/saineshnakra/automated-data-analyst/stargazers).
+ADA has no ads, no launch budget and no growth team; it gets found because
+people who liked it clicked the button. If you are shipping something with it,
+[say so in an issue](https://github.com/saineshnakra/automated-data-analyst/issues/new)
+and it goes in the list above.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ADA — Automated Data Analyst
 
 [![CI](https://github.com/saineshnakra/automated-data-analyst/actions/workflows/ci.yml/badge.svg)](https://github.com/saineshnakra/automated-data-analyst/actions/workflows/ci.yml)
-[![Python](https://img.shields.io/badge/Python-3.11%2B-3776ab?logo=python&logoColor=white)](https://www.python.org/)
+[![Python](https://img.shields.io/badge/Python-3.11%20%7C%203.12%20%7C%203.13-3776ab?logo=python&logoColor=white)](https://www.python.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-20a779.svg)](https://github.com/saineshnakra/automated-data-analyst/blob/main/LICENSE)
 
 **Upload a CSV or Excel file. Get a dashboard, an executive brief, anomaly
@@ -24,7 +24,7 @@ and which is the segment, then builds the analysis around that.
 
 - **Dashboard** — trend, segment breakdown, movement waterfall, segment × period heatmap
 - **Ask ADA** — plain-English questions answered locally with pandas, calculation shown
-- **Anomaly flags** — periods outside a calibrated band, sized so a stable series false-alarms about once in twenty analyses
+- **Anomaly flags** — periods outside a calibrated band, sized so a stable series with continuous, roughly normal noise false-alarms about once in twenty analyses ([what that assumes](https://github.com/saineshnakra/automated-data-analyst/blob/main/docs/reference/anomalies.md#what-the-5-assumes))
 - **Forecast** — a guarded baseline that refuses to run on thin history and reports when it was no better than assuming no change
 - **Evidence and next steps** — every finding carries its calculation; recommendations are labelled as interpretation, never as cause
 - **Downloads** — Markdown executive brief and cleaned CSV
@@ -69,21 +69,28 @@ streamlit run app.py
 
 No API key required. The app opens with a built-in demo dataset.
 
+Python: tested on 3.11, 3.12 and 3.13 (the CI matrix); `requires-python` is
+`>=3.11`. To install the exact package versions CI tests against, add
+`-c constraints.txt` to the `pip install` line.
+
 ## Does my data leave my machine?
 
 **Running ADA yourself: no.** Cleaning, schema detection, every chart, and every
 Ask ADA answer are computed locally with pandas, with no network call at all.
 
 **Using the hosted demo: your file is uploaded to a Streamlit server**, because
-that is what uploading a file to a website means. It is held in memory for the
-session and never written to a database. If that matters for your data, run ADA
-locally — it is four commands above and needs no key.
+that is what uploading a file to a website means. The parsed file is held in
+that server process's memory — a bounded cache of at most eight files for up to
+an hour, which outlives your browser session — and is never written to disk or
+to a database. If that matters for your data, run ADA locally — it is four
+commands above and needs no key.
 
 An optional AI layer adds two things when you supply a key: a query planner for
 questions the rules cannot parse, and a strategic narrative. The planner shows
 its proposed calculation and waits for your confirmation before ADA executes it
-locally. **Neither ever receives your rows.** They receive column names, types,
-and already-computed evidence — and because an evidence sentence names the
+locally. **Neither ever receives your rows.** The planner receives your question
+and the column names, types and roles; the narrative receives the schema and
+the already-computed evidence — and because an evidence sentence names the
 segment it is about, a segment label such as a customer or product name can
 appear in it. Nothing else from a cell does. Model-generated code is never
 executed.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ The roadmap favors analytical depth and trust over a larger pile of charts. Item
 
 ## Recently delivered
 
-- **Calibrated anomaly threshold** — the residual band is simulated per history length so a stable series raises a false flag about once in twenty analyses, instead of the one-in-four a fixed three deviations produced
+- **Calibrated anomaly threshold** — the residual band is simulated per history length so a stable series with continuous, roughly normal noise raises a false flag about once in twenty analyses ([what that assumes](docs/reference/anomalies.md#what-the-5-assumes)), instead of the one-in-four a fixed three deviations produced
 - **Honest timelines** — an in-progress trailing period is excluded, periods with no rows count as zero, the grain respects how often the data is actually recorded, and every adjustment is stated
 - **Forecast that admits its limits** — a band that widens with the horizon and a scaled error that says outright when the baseline did not beat assuming no change
 - **Qualified evidence** — movement measured against the series' own volatility, and correlations reported with sample size, a confidence interval, and a rank check for outlier-driven relationships

--- a/aggregation.py
+++ b/aggregation.py
@@ -92,6 +92,9 @@ class TrendSeries:
     frame: pd.DataFrame
     frequency: str
     filled_periods: int = 0
+    #: True when those periods were filled with zero (an additive measure),
+    #: False when they were left empty (a rate has no observation to average).
+    filled_as_zero: bool = True
     partial_period: pd.Timestamp | None = None
     partial_coverage: str = ""
     # A period the data stops part-way through, but not far enough through for
@@ -118,8 +121,15 @@ class TrendSeries:
             )
         if self.filled_periods:
             plural = "periods" if self.filled_periods > 1 else "period"
+            # A rate's gaps are NOT zeroes - nobody converted at 0%, nobody
+            # measured at all - so the caption cannot say they were counted as
+            # zero while the chart shows a break in the line.
+            settled = (
+                "counted as zero" if self.filled_as_zero else "left empty, since an average "
+                "needs an observation"
+            )
             notes.append(
-                f"{self.filled_periods} {plural} with no rows counted as zero, keeping the "
+                f"{self.filled_periods} {plural} with no rows {settled}, keeping the "
                 "timeline evenly spaced."
             )
         return tuple(notes)
@@ -228,6 +238,7 @@ def build_trend(
         frame=result,
         frequency=frequency,
         filled_periods=filled,
+        filled_as_zero=metric.additive,
         partial_period=partial_period,
         partial_coverage=partial_coverage,
         short_coverage=short_coverage,

--- a/aggregation.py
+++ b/aggregation.py
@@ -169,18 +169,24 @@ def build_trend(
     dataframe: pd.DataFrame,
     roles: ColumnRoles,
     frequency: str | None = None,
+    count_column: str | None = None,
 ) -> TrendSeries:
-    """Aggregate the measure over a human-sized grain, on an even timeline."""
+    """Aggregate the measure over a human-sized grain, on an even timeline.
+
+    With ``count_column`` and no measure, each period holds the number of
+    distinct values in that column: customers per month, not rows per month.
+    """
     if not roles.date:
         return TrendSeries(frame=EMPTY_TREND.copy(), frequency=frequency or "M")
 
-    columns = [roles.date] + ([roles.measure] if roles.measure else [])
+    counted = count_column if count_column and not roles.measure and count_column != roles.date else None
+    columns = [roles.date] + ([roles.measure] if roles.measure else []) + ([counted] if counted else [])
     working = dataframe[columns].dropna(subset=[roles.date]).copy()
     if working.empty:
         return TrendSeries(frame=EMPTY_TREND.copy(), frequency=frequency or "M")
     # Internal names from here on. A measure the file calls "Period" was being
     # overwritten by the period buckets built below, then summed as datetimes.
-    working.columns = ["__date"] + (["__measure"] if roles.measure else [])
+    working.columns = ["__date"] + (["__measure"] if roles.measure else []) + (["__count"] if counted else [])
 
     frequency = frequency or _period_frequency(working["__date"])
     working["Period"] = working["__date"].dt.to_period(frequency).dt.to_timestamp()
@@ -196,7 +202,9 @@ def build_trend(
             partial_period, partial_coverage = None, ""
 
     metric = resolve_metric(roles.measure)
-    if roles.measure:
+    if counted:
+        result = working.groupby("Period")["__count"].nunique().rename("Value").reset_index()
+    elif roles.measure:
         grouped = working.groupby("Period")["__measure"]
         # A period whose every value is missing is a missing period, not a
         # period that measured zero: sum(min_count=1) keeps it NaN.

--- a/aggregation.py
+++ b/aggregation.py
@@ -15,7 +15,8 @@ from dataclasses import dataclass
 import numpy as np
 import pandas as pd
 
-from formatting import format_period, is_percentage, percentage_outranks_currency
+from formatting import format_period
+from metrics import resolve_metric
 from schema import ColumnRoles
 
 GRAIN_ORDER = ("W", "M", "Q", "Y")
@@ -48,15 +49,8 @@ def _grain_for_cadence(dates: pd.Series) -> str:
 
 
 def measure_aggregation(measure: str | None) -> str:
-    """How a measure combines across rows: rates average, amounts add.
-
-    Adding two months of conversion rate produces a number with no meaning,
-    and every surface built on period totals was doing exactly that. The
-    decision lives here so trend, segment and headline agree.
-    """
-    if measure and is_percentage(measure) and percentage_outranks_currency(measure):
-        return "mean"
-    return "sum"
+    """How a measure combines across rows: rates average, amounts add."""
+    return resolve_metric(measure).aggregation
 
 
 def _period_frequency(date_series: pd.Series) -> str:
@@ -201,16 +195,27 @@ def build_trend(
         else:
             partial_period, partial_coverage = None, ""
 
+    metric = resolve_metric(roles.measure)
     if roles.measure:
-        result = working.groupby("Period", as_index=False)["__measure"].agg(
-            measure_aggregation(roles.measure)
-        )
-        result = result.rename(columns={"__measure": "Value"})
+        grouped = working.groupby("Period")["__measure"]
+        # A period whose every value is missing is a missing period, not a
+        # period that measured zero: sum(min_count=1) keeps it NaN.
+        totals = grouped.sum(min_count=1) if metric.aggregation == "sum" else grouped.mean()
+        result = totals.rename("Value").reset_index()
     else:
         result = working.groupby("Period", as_index=False).size().rename(columns={"size": "Value"})
     result = result.sort_values("Period").reset_index(drop=True)
 
-    result, filled = _fill_empty_periods(result, frequency)
+    # A month with no rows is a month of zero sales, but it is not a month
+    # of zero conversion rate -- there is no observation, so the gap stays
+    # empty. And with fewer than three distinct dates there is no cadence to
+    # fill against at all; two month-end readings were being spread into
+    # three invented zero weeks.
+    fill_value = 0.0 if metric.additive else float("nan")
+    if working["__date"].nunique() >= 3:
+        result, filled = _fill_empty_periods(result, frequency, fill_value)
+    else:
+        filled = 0
     return TrendSeries(
         frame=result,
         frequency=frequency,
@@ -222,7 +227,9 @@ def build_trend(
     )
 
 
-def _fill_empty_periods(trend: pd.DataFrame, frequency: str) -> tuple[pd.DataFrame, int]:
+def _fill_empty_periods(
+    trend: pd.DataFrame, frequency: str, fill_value: float = 0.0
+) -> tuple[pd.DataFrame, int]:
     """Materialise periods with no rows as zero, so gaps stop bending the fit.
 
     A month in which nothing was sold is a month of zero sales, not a month
@@ -243,7 +250,7 @@ def _fill_empty_periods(trend: pd.DataFrame, frequency: str) -> tuple[pd.DataFra
 
     filled = (
         trend.set_index("Period")
-        .reindex(complete, fill_value=0.0)
+        .reindex(complete, fill_value=fill_value)
         .rename_axis("Period")
         .reset_index()
     )
@@ -335,14 +342,26 @@ def segment_period_change(
     )
     working["Period"] = working["__date"].dt.to_period(frequency).dt.to_timestamp()
     comparison = working[working["Period"].isin([previous_period, current_period])]
+    metric = resolve_metric(roles.measure)
     grouped = (
         comparison.groupby(["__segment", "Period"])["__measure"]
-        .agg(measure_aggregation(roles.measure))
-        .unstack(fill_value=0)
+        .agg(metric.aggregation)
+        .unstack()
     )
     grouped.index.name = roles.dimension
     if previous_period not in grouped or current_period not in grouped:
         return None
+    if metric.additive:
+        # A segment with no rows in a period sold nothing in it: zero.
+        grouped = grouped.fillna(0.0)
+    else:
+        # A segment with no rows in a period has no average in it. Filling
+        # with zero made a region that first appears this month "rise from
+        # 0.0% to 31.0%", so a segment has to be present on both sides to
+        # have a change at all.
+        grouped = grouped.dropna(subset=[previous_period, current_period])
+        if grouped.empty:
+            return None
 
     grouped["Change"] = grouped[current_period] - grouped[previous_period]
     return grouped, previous_period, current_period
@@ -358,7 +377,9 @@ def driver_frame(dataframe: pd.DataFrame, roles: ColumnRoles, limit: int = 9) ->
     top = changes.head(limit)
     frame = pd.DataFrame({"Segment": top.index.astype(str), "Change": top.to_numpy(dtype=float)})
     remainder = float(changes.iloc[limit:].sum())
-    if len(changes) > limit and remainder:
+    # Changes in segment averages do not sum to anything, so there is no
+    # "other" bar to add up for a rate -- only the segments shown.
+    if len(changes) > limit and remainder and resolve_metric(roles.measure).additive:
         other = pd.DataFrame({"Segment": ["Other segments"], "Change": [remainder]})
         frame = pd.concat([frame, other], ignore_index=True)
     return frame

--- a/ai_insights.py
+++ b/ai_insights.py
@@ -13,7 +13,15 @@ from pydantic import BaseModel, Field
 
 from business_insights import BusinessBrief
 from metrics import resolve_metric
-from nlq import AGGREGATION_LABELS, QueryAnswer, QueryPlan, ValueFilter, execute_plan
+from nlq import (
+    AGGREGATION_LABELS,
+    QueryAnswer,
+    QueryPlan,
+    ValueFilter,
+    execute_plan,
+    plan_accounts_for_numbers,
+    question_is_representable,
+)
 from schema import ColumnRoles, looks_like_identifier
 
 
@@ -130,8 +138,11 @@ class AIQueryPlan(BaseModel):
     top_n: int | None = Field(default=None, ge=1, le=50)
     ascending: bool = False
     filters: list[AIQueryFilter] = Field(default_factory=list, max_length=4)
-    year: int | None = Field(default=None, ge=1900, le=2100)
+    year: int | None = Field(default=None, ge=1800, le=2299)
     month: int | None = Field(default=None, ge=1, le=12)
+    # A single day ("2024-01-31", "January 15") or a calendar quarter ("Q1").
+    day: int | None = Field(default=None, ge=1, le=31)
+    quarter: int | None = Field(default=None, ge=1, le=4)
     grain: Literal["D", "W", "M", "Q", "Y"] | None = None
     # Distinct entities rather than rows: "how many customers" counts this column's unique values.
     count_column: str | None = None
@@ -144,6 +155,9 @@ Use only the listed column names, exactly as written; never invent a column.
 Filter values may only be phrases quoted from the question itself.
 For "how many <entities>", set intent="count" and count_column to the column that identifies
 one entity; leave it unset to count rows.
+A single date sets year, month and day; a quarter sets quarter (1-4) and never month.
+Every number in the question must appear in the plan (year, month, day, quarter, top_n or a
+filter value); if one cannot, the question is not answerable.
 If the schema cannot answer the question, set answerable to false instead of guessing."""
 
 
@@ -306,7 +320,13 @@ def _to_query_plan(
             return None
     # A time filter needs a column to apply it to; without one the executor
     # quietly returns the all-time figure under a scoped-looking sentence.
-    if (parsed.year is not None or parsed.month is not None) and not roles.date:
+    scoped_in_time = any(part is not None for part in (parsed.year, parsed.month, parsed.day, parsed.quarter))
+    if scoped_in_time and not roles.date:
+        return None
+    # A day without a month, or a quarter alongside a month, is not one scope.
+    if parsed.day is not None and parsed.month is None:
+        return None
+    if parsed.quarter is not None and parsed.month is not None:
         return None
     filters: list[ValueFilter] = []
     for item in parsed.filters:
@@ -327,6 +347,8 @@ def _to_query_plan(
         filters=tuple(filters),
         year=parsed.year,
         month=parsed.month,
+        day=parsed.day,
+        quarter=parsed.quarter,
         grain=parsed.grain if parsed.intent in GRAIN_INTENTS else None,
         source="ai",
     )
@@ -346,6 +368,13 @@ def plan_query_with_ai(
     if not api_key.strip():
         raise ValueError("An API key is required for the optional AI query planner.")
     if not question.strip():
+        return None
+    # The planner emits the same plan shape the rules do, so a question no
+    # plan can hold -- two metrics, an arithmetic expression, two months, a
+    # comparison operator -- is refused here as well. Asking the model would
+    # only get back the nearest question the plan can hold, presented for
+    # approval as though it were the one asked.
+    if not question_is_representable(question, dataframe, roles):
         return None
     if client is None:
         from openai import OpenAI
@@ -369,7 +398,12 @@ def plan_query_with_ai(
         parsed = AIQueryPlan.model_validate(parsed)
     if not parsed.answerable:
         return None
-    return _to_query_plan(parsed, dataframe, roles)
+    plan = _to_query_plan(parsed, dataframe, roles)
+    if plan is not None and not plan_accounts_for_numbers(question, plan):
+        # "Revenue 2024-01-31" planned as January 2024 dropped the 31, and
+        # with it the question.
+        return None
+    return plan
 
 
 MONTH_NAMES = {
@@ -386,7 +420,13 @@ def _scope_clause(plan: QueryPlan) -> str:
     clause = f" for {' and '.join(parts)}" if parts else ""
     if plan.month is not None:
         label = MONTH_NAMES.get(plan.month, str(plan.month))
-        clause += f" in {label} {plan.year}" if plan.year is not None else f" in {label}"
+        if plan.day is not None:
+            label = f"{label} {plan.day}"
+        clause += f" {'on' if plan.day else 'in'} {label} {plan.year}" if plan.year is not None else (
+            f" {'on' if plan.day else 'in'} {label}"
+        )
+    elif plan.quarter is not None:
+        clause += f" in Q{plan.quarter} {plan.year}" if plan.year is not None else f" in Q{plan.quarter}"
     elif plan.year is not None:
         clause += f" in {plan.year}"
     return clause

--- a/ai_insights.py
+++ b/ai_insights.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import asdict, dataclass
 from typing import Literal, Protocol
 
@@ -11,6 +12,7 @@ from pandas.api.types import is_bool_dtype, is_datetime64_any_dtype, is_numeric_
 from pydantic import BaseModel, Field
 
 from business_insights import BusinessBrief
+from metrics import resolve_metric
 from nlq import AGGREGATION_LABELS, QueryAnswer, QueryPlan, ValueFilter, execute_plan
 from schema import ColumnRoles, looks_like_identifier
 
@@ -131,6 +133,8 @@ class AIQueryPlan(BaseModel):
     year: int | None = Field(default=None, ge=1900, le=2100)
     month: int | None = Field(default=None, ge=1, le=12)
     grain: Literal["D", "W", "M", "Q", "Y"] | None = None
+    # Distinct entities rather than rows: "how many customers" counts this column's unique values.
+    count_column: str | None = None
 
 
 PLANNER_CONFIG = AIConfig("gpt-5.6-luna", "low", "Query planner")
@@ -138,6 +142,8 @@ PLANNER_CONFIG = AIConfig("gpt-5.6-luna", "low", "Query planner")
 PLANNER_INSTRUCTIONS = """You translate one business question about a single table into a strict query plan.
 Use only the listed column names, exactly as written; never invent a column.
 Filter values may only be phrases quoted from the question itself.
+For "how many <entities>", set intent="count" and count_column to the column that identifies
+one entity; leave it unset to count rows.
 If the schema cannot answer the question, set answerable to false instead of guessing."""
 
 
@@ -239,9 +245,27 @@ def _usable_dimension(dataframe: pd.DataFrame, column: str) -> bool:
         # row per distinct value.
         if (series.dropna() % 1 != 0).any() or distinct > present * IDENTIFIER_UNIQUENESS:
             return False
-    if present >= IDENTIFIER_EVIDENCE_ROWS and distinct > present * IDENTIFIER_UNIQUENESS:
+    # Uniqueness alone does not make a text column a key: a pre-aggregated
+    # table with thirty labelled rows is unique by construction. Uniqueness
+    # across enough rows AND values shaped like codes -- "T-0042", "INV0007"
+    # -- does.
+    if (
+        present >= IDENTIFIER_EVIDENCE_ROWS
+        and distinct > present * IDENTIFIER_UNIQUENESS
+        and _values_look_like_codes(series)
+    ):
         return False
     return True
+
+
+_CODE_SHAPE = re.compile(r"^[A-Za-z]{0,6}[-_ ]?\d{2,}[A-Za-z0-9-]*$")
+
+
+def _values_look_like_codes(series: pd.Series, sample: int = 200) -> bool:
+    values = series.dropna().astype(str).head(sample)
+    if values.empty:
+        return False
+    return bool(values.str.match(_CODE_SHAPE).mean() >= 0.8)
 
 
 def _to_query_plan(
@@ -256,14 +280,18 @@ def _to_query_plan(
     """
     measure = parsed.measure or roles.measure
     dimension = parsed.dimension
-    for column in (parsed.measure, parsed.dimension):
+    for column in (parsed.measure, parsed.dimension, parsed.count_column):
         if column is not None and column not in dataframe.columns:
             return None
+    if parsed.count_column is not None and parsed.intent != "count":
+        return None
     if parsed.intent in PERIOD_INTENTS and not roles.date:
         return None
-    # The executor sums periods whatever the plan says, so a plan promising an
-    # average over time would answer a different question than the one approved.
-    if parsed.intent in PERIOD_INTENTS and parsed.aggregation != "sum":
+    # The period executors combine each period the way the measure combines:
+    # amounts are summed, rates are averaged. A plan asking for the other
+    # operation would be approved with one sentence and executed with another,
+    # so it is refused rather than silently corrected.
+    if parsed.intent in PERIOD_INTENTS and parsed.aggregation != resolve_metric(measure).aggregation:
         return None
     if parsed.intent == "aggregate" and not measure:
         return None
@@ -290,6 +318,7 @@ def _to_query_plan(
         intent=parsed.intent,
         aggregation=parsed.aggregation,
         measure=measure if parsed.intent != "count" else None,
+        count_column=parsed.count_column if parsed.intent == "count" else None,
         # Every modifier the chosen intent's executor would ignore is dropped
         # here, so the approval sentence cannot advertise one.
         dimension=dimension if parsed.intent in DIMENSION_INTENTS else None,
@@ -381,16 +410,18 @@ def describe_query_plan(plan: QueryPlan) -> str:
         else:
             description = "count the matching records"
     elif plan.intent == "trend":
-        description = f"track total {measure} per {grain} over time"
+        combined = resolve_metric(plan.measure).combines_as if plan.measure else "count"
+        description = f"track {combined} {measure} per {grain} over time"
     elif plan.intent == "growth":
+        combined = resolve_metric(plan.measure).combines_as if plan.measure else "count"
         if plan.dimension:
             description = (
-                f"rank each {plan.dimension} by how much its total {measure} changed "
+                f"rank each {plan.dimension} by how much its {combined} {measure} changed "
                 f"from the previous {grain} to the latest one"
             )
         else:
             description = (
-                f"compare total {measure} in the latest {grain} with the previous one"
+                f"compare {combined} {measure} in the latest {grain} with the previous one"
             )
     elif plan.intent == "rank":
         direction = "lowest" if plan.ascending else "highest"

--- a/ai_insights.py
+++ b/ai_insights.py
@@ -263,11 +263,14 @@ def _usable_dimension(dataframe: pd.DataFrame, column: str) -> bool:
     # table with thirty labelled rows is unique by construction. Uniqueness
     # across enough rows AND values shaped like codes -- "T-0042", "INV0007"
     # -- does.
-    if (
-        present >= IDENTIFIER_EVIDENCE_ROWS
-        and distinct > present * IDENTIFIER_UNIQUENESS
-        and _values_look_like_codes(series)
-    ):
+    if present >= IDENTIFIER_EVIDENCE_ROWS and distinct > present * IDENTIFIER_UNIQUENESS:
+        # Code-shaped values ("T-0042", "INV0007") are a key beyond argument.
+        # But a column that is unique across enough rows is not a segment
+        # whatever its values look like: grouping sixty distinct email
+        # addresses gives sixty groups of one, which is the table again with a
+        # chart drawn on it. The code test decides how confident the refusal
+        # is, not whether to refuse - requiring it let every unique free-text
+        # column through, which is the failure this guard exists to stop.
         return False
     return True
 

--- a/analysis.py
+++ b/analysis.py
@@ -249,7 +249,11 @@ def _read_formatted_number(text: str) -> float | None:
         if raw[0] in "+-":
             if sign_seen:
                 return None
-            sign_seen, negative = True, raw[0] == "-"
+            # `or`, not `=`: a leading parenthesis has already said negative,
+            # and "(+100)" must not be read back as a positive hundred. Each
+            # marker may appear once; either one of them means owed.
+            sign_seen = True
+            negative = negative or raw[0] == "-"
             raw = raw[1:].lstrip()
         elif raw[0] in _CURRENCY_CHARS:
             if currency_seen:

--- a/analysis.py
+++ b/analysis.py
@@ -11,6 +11,8 @@ import numpy as np
 import pandas as pd
 from pandas.api.types import is_datetime64_any_dtype, is_numeric_dtype
 
+from schema import is_identifier_name
+
 
 @dataclass(frozen=True)
 class CleaningReport:
@@ -27,6 +29,8 @@ class CleaningReport:
     datetime_columns_inferred: int
     duplicate_rows_found: int = 0
     unparsed_date_cells: int = 0
+    numeric_cells_unreadable: int = 0
+    non_finite_cells: int = 0
     notes: tuple[str, ...] = ()
 
     def to_dict(self) -> dict[str, Any]:
@@ -40,6 +44,36 @@ class Insight:
     level: str = "info"
 
 
+# A UTC offset at the end of a timestamp: "+01:00", "+0100", "+01", "Z". It
+# has to follow a clock time, so the "-01" in "2024-01" is never taken for one.
+_TRAILING_OFFSET = re.compile(
+    r"^(.*?\d{1,2}:\d{2}(?::\d{2}(?:[.,]\d+)?)?)\s*(?:[Zz]|[+-]\d{2}(?::?\d{2})?)$"
+)
+OFFSETS_DROPPED_NOTE = (
+    "Timezone offsets were dropped; dates are read as the local time they were written in."
+)
+
+
+def _without_offsets(values: pd.Series) -> tuple[pd.Series, int]:
+    """Remove the UTC offset from each timestamp before it is parsed.
+
+    Every row keeps the wall clock it was written in. Parsing the offsets
+    instead made the result depend on the rest of the column: a file whose
+    rows all carried +01:00 kept its local times, but the moment one row
+    with +02:00 was appended pandas fell back to UTC and every existing row
+    moved an hour -- some of them into the previous month. A date must not
+    change because of what came after it.
+    """
+    carried = values.map(lambda value: isinstance(value, str) and bool(_TRAILING_OFFSET.match(value)))
+    dropped = int(carried.sum())
+    if not dropped:
+        return values, 0
+    stripped = values.map(
+        lambda value: _TRAILING_OFFSET.sub(r"\1", value) if isinstance(value, str) else value
+    )
+    return stripped, dropped
+
+
 def _speculative_dates(values: pd.Series) -> pd.Series:
     """Parse values as dates without complaining about the ones that are not.
 
@@ -49,7 +83,7 @@ def _speculative_dates(values: pd.Series) -> pd.Series:
     """
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UserWarning)
-        return pd.to_datetime(values, errors="coerce")
+        return pd.to_datetime(_without_offsets(values)[0], errors="coerce")
 
 
 def _is_blank(series: pd.Series) -> pd.Series:
@@ -74,6 +108,8 @@ def _drop_timezone(series: pd.Series) -> pd.Series:
 
 
 INT64_LIMIT = float(np.iinfo(np.int64).max)
+# The largest whole number a float holds exactly; above it, neighbours merge.
+EXACT_FLOAT_LIMIT = float(2**53)
 
 
 def _widen_columns_that_would_overflow(frame: pd.DataFrame) -> int:
@@ -105,16 +141,91 @@ def _normalize_datetime_columns(frame: pd.DataFrame) -> int:
     return changed
 
 
-# A business-formatted number: an optional sign or accounting parentheses, an
-# optional currency symbol, then digits with grouping punctuation. Anything
-# holding a slash or a letter is not this -- notably a date, which would
-# otherwise survive as a very large integer.
-# A business-formatted number: an optional sign or accounting parentheses, an
-# optional currency symbol, then digits with grouping punctuation. Anything
-# holding a slash or a letter is not this -- notably a date, which would
-# otherwise survive as a very large integer.
-_MONEY = re.compile(r"^[+-]?\(?\s*[-+]?\s*[$\u20ac\u00a3\u00a5\u20b9]?\s*\d[\d,.\s']*\)?$")
+def _drop_non_finite(frame: pd.DataFrame) -> dict[str, int]:
+    """Turn inf and -inf into missing, and say how many cells that was.
+
+    pandas reads the text "inf" as a number, and one such cell then owns
+    every total, mean and chart axis built on the column. It carries no
+    quantity a business file could mean, so it is treated as a value that
+    could not be read.
+    """
+    counts = {}
+    for column in frame.select_dtypes(include=["float64", "float32"]).columns:
+        infinite = np.isinf(frame[column])
+        if infinite.any():
+            frame[column] = frame[column].mask(infinite)
+            counts[column] = int(infinite.sum())
+    return counts
+
+
 _CURRENCY_CHARS = "$\u20ac\u00a3\u00a5\u20b9"
+_SEPARATOR_CHARS = ",. '"
+_DIGITS = "0123456789"
+
+
+def _digit_groups(body: str) -> tuple[list[str], list[str]] | None:
+    """Split "1,234.50" into its digit groups and the single marks between them.
+
+    Anything else -- a letter, a doubled mark, a mark with no digit on one
+    side -- is not a number, and saying so is the whole point: "(100",
+    "1,2,3" and "12 34" used to come out as 100, 123 and 1234.
+    """
+    groups: list[str] = []
+    marks: list[str] = []
+    current = ""
+    for char in body:
+        if char in _DIGITS:
+            current += char
+        elif char in _SEPARATOR_CHARS and current:
+            groups.append(current)
+            marks.append(char)
+            current = ""
+        else:
+            return None
+    if not current:
+        return None
+    groups.append(current)
+    return groups, marks
+
+
+def _integer_and_fraction(body: str) -> tuple[str, str] | None:
+    """Read the digits of a formatted number, deciding which mark is the decimal.
+
+    When both "," and "." appear, the one that comes last is the decimal
+    point and the other is grouping. When only one mark appears once, three
+    digits after a comma is grouping ("1,000") and one or two is a decimal
+    ("1234,50"); "1,234" alone reads as a thousand, which is what pandas and
+    every US export mean by it, and a single "." is always a decimal, as
+    pd.to_numeric reads it. A space or an apostrophe is only ever grouping.
+    Grouping marks must then delimit groups of exactly three digits, so a
+    stray mark is refused rather than read past.
+    """
+    split = _digit_groups(body)
+    if split is None:
+        return None
+    groups, marks = split
+    if not marks:
+        return groups[0], ""
+    last = marks[-1]
+    if len(marks) == 1:
+        if last == ",":
+            decimal = len(groups[-1]) in (1, 2)
+        else:
+            decimal = last == "."
+    else:
+        grouping = set(marks[:-1])
+        if len(grouping) != 1:
+            return None
+        if last in grouping:
+            decimal = False
+        elif last in ",.":
+            decimal = True
+        else:
+            return None
+    integer_groups, fraction = (groups[:-1], groups[-1]) if decimal else (groups, "")
+    if any(len(group) != 3 for group in integer_groups[1:]):
+        return None
+    return "".join(integer_groups), fraction
 
 
 def _read_formatted_number(text: str) -> float | None:
@@ -126,52 +237,39 @@ def _read_formatted_number(text: str) -> float | None:
     so refunds became revenue. That is the one mistake this function must not
     be able to make again, whatever else it gets wrong.
 
-    Then the separators. When both "," and "." appear, the one that comes
-    last is the decimal point and the other is grouping. When only one
-    appears, three digits after it is grouping ("1,000") and one or two is a
-    decimal ("1234,50"); "1,234" alone reads as a thousand, which is what
-    pandas and every US export mean by it.
+    A sign, a currency symbol and a pair of parentheses may lead the number
+    in any order -- "$-100" and "-$100" are both a hundred owed -- but each
+    at most once, and an opening parenthesis must have its closing one. The
+    digits then have to satisfy _integer_and_fraction.
     """
     raw = text.strip()
-    if not raw or not _MONEY.match(raw):
+    negative = False
+    sign_seen = currency_seen = parentheses_seen = False
+    while raw:
+        if raw[0] in "+-":
+            if sign_seen:
+                return None
+            sign_seen, negative = True, raw[0] == "-"
+            raw = raw[1:].lstrip()
+        elif raw[0] in _CURRENCY_CHARS:
+            if currency_seen:
+                return None
+            currency_seen = True
+            raw = raw[1:].lstrip()
+        elif raw[0] == "(":
+            if parentheses_seen or not raw.endswith(")"):
+                return None
+            parentheses_seen, negative = True, True
+            raw = raw[1:-1].strip()
+        else:
+            break
+    if not raw or raw.endswith(")"):
         return None
-    negative = raw.startswith("-") or (raw.startswith("(") and raw.endswith(")"))
-    body = raw.strip("()+-").strip()
-    if body.startswith("-") or body.startswith("+"):
-        # A second sign after the currency symbol, "$-100", or a redundant one
-        # inside accounting parentheses, "-(100)": both say negative once more.
-        negative = negative or body.startswith("-")
-        body = body[1:].strip()
-    body = "".join(ch for ch in body if ch not in _CURRENCY_CHARS and not ch.isspace() and ch != "'")
-    if not body or not body[0].isdigit():
+    digits = _integer_and_fraction(raw)
+    if digits is None:
         return None
-
-    last_comma, last_dot = body.rfind(","), body.rfind(".")
-    if last_comma >= 0 and last_dot >= 0:
-        decimal = "," if last_comma > last_dot else "."
-    elif last_comma >= 0:
-        digits_after = len(body) - last_comma - 1
-        decimal = "," if body.count(",") == 1 and digits_after in (1, 2) else None
-    elif last_dot >= 0:
-        digits_after = len(body) - last_dot - 1
-        # "1.234.567" is grouped; "1.234" is a decimal; "12.5" is a decimal.
-        decimal = None if body.count(".") > 1 else "."
-        if decimal == "." and body.count(".") == 1 and digits_after == 3 and len(body) > 4:
-            # "1.234" with nothing to disambiguate stays a decimal, matching
-            # pd.to_numeric; only the multi-dot form is treated as grouping.
-            decimal = "."
-    else:
-        decimal = None
-
-    grouping = {",", "."} - ({decimal} if decimal else set())
-    for mark in grouping:
-        body = body.replace(mark, "")
-    if decimal and decimal != ".":
-        body = body.replace(decimal, ".")
-    try:
-        value = float(body)
-    except ValueError:
-        return None
+    integer, fraction = digits
+    value = float(f"{integer}.{fraction or '0'}")
     return -value if negative else value
 
 
@@ -188,6 +286,24 @@ def _numeric_from_text(values: pd.Series) -> pd.Series:
     ).astype("float64")
 
 
+def _infer_numeric(values: pd.Series) -> tuple[pd.Series, bool]:
+    """Plain parsing first, then the formatted reader for whatever it left.
+
+    A value plain parsing already read ("1e3") is never replaced. The second
+    result says whether the formatted reader contributed anything, because
+    when it did the column is a float whatever the plain values were, and a
+    whole number past 2**53 has by then lost its last digits.
+    """
+    parsed = pd.to_numeric(values, errors="coerce")
+    gaps = parsed.isna() & values.notna()
+    if not gaps.any():
+        return parsed, False
+    formatted = _numeric_from_text(values.where(gaps))
+    if not formatted.notna().any():
+        return parsed, False
+    return parsed.astype("float64").fillna(formatted), True
+
+
 # A date written day-or-month first: "3/1/2024", "03-01-24". A year-leading
 # value is ISO and cannot be read two ways.
 _DAY_OR_MONTH_FIRST = re.compile(r"^\s*\d{1,2}[/-]\d{1,2}[/-]\d{2,4}")
@@ -198,16 +314,26 @@ def _dated(values: pd.Series, *, dayfirst: bool) -> pd.Series:
         warnings.simplefilter("ignore", (UserWarning, FutureWarning))
         parsed = pd.to_datetime(values, errors="coerce", dayfirst=dayfirst)
         if parsed.dtype == object:
-            # Mixed offsets -- a file spanning a daylight-saving change --
-            # come back as objects, which no downstream step can use. There
-            # is no single wall clock to keep, so UTC is the honest choice.
-            parsed = pd.to_datetime(values, errors="coerce", dayfirst=dayfirst, utc=True)
-            parsed = parsed.dt.tz_localize(None)
+            # Zones written in a form the offset stripper does not know, and
+            # not all the same, come back as objects no downstream step can
+            # use. Each keeps its own wall clock, the same policy as the
+            # rest of the column, rather than being moved to UTC.
+            parsed = pd.to_datetime(
+                parsed.map(
+                    lambda moment: moment.tz_localize(None)
+                    if isinstance(moment, pd.Timestamp) and moment.tzinfo is not None
+                    else moment
+                ),
+                errors="coerce",
+            )
         return parsed
 
 
-def _read_dates(values: pd.Series) -> tuple[pd.Series, str]:
+def _read_dates(values: pd.Series) -> tuple[pd.Series, str, int]:
     """Parse a date column, and say so when the ordering had to be guessed.
+
+    The third result is how many values carried a UTC offset, which was
+    removed before parsing so that each row keeps its own wall clock.
 
     "01/03/2024" is 1 March in most of the world and 3 January in the United
     States. When some row in the column settles it -- a 13 or higher in the
@@ -216,20 +342,25 @@ def _read_dates(values: pd.Series) -> tuple[pd.Series, str]:
     turning a year of monthly figures into twelve days of January is the one
     outcome nobody can detect downstream.
     """
+    values, offsets = _without_offsets(values)
     month_first = _dated(values, dayfirst=False)
     # Only a value that leads with a day or a month can be read two ways.
     # 2024-03-01 is ISO and settled; 01/03/2024 is not.
     two_ways = values.astype("string").str.match(_DAY_OR_MONTH_FIRST, na=False)
     if not bool(two_ways.any()):
-        return month_first, ""
+        return month_first, "", offsets
 
     day_first = _dated(values, dayfirst=True)
     if day_first.notna().sum() > month_first.notna().sum():
-        return day_first, "day-first"
+        return day_first, "day-first", offsets
     if month_first.notna().sum() > day_first.notna().sum():
-        return month_first, ""
+        return month_first, "", offsets
     disagree = two_ways & month_first.notna() & day_first.notna() & month_first.ne(day_first)
-    return month_first, "ambiguous" if bool(disagree.any()) else ""
+    return month_first, "ambiguous" if bool(disagree.any()) else "", offsets
+
+
+def _non_finite_note(column: str, count: int) -> str:
+    return f"{count} {column} values were infinite and were left missing."
 
 
 def _ordering_note(column: str, ordering: str) -> str:
@@ -320,62 +451,83 @@ def clean_dataframe(
     numeric_columns_inferred = 0
     datetime_columns_inferred = _normalize_datetime_columns(cleaned)
     unparsed_date_cells = 0
+    numeric_cells_unreadable = 0
+    non_finite_cells = 0
     notes: list[str] = []
 
     if datetime_columns_inferred:
-        notes.append(
-            "Timezone offsets were dropped; dates are read as the local time they were written in."
-        )
+        notes.append(OFFSETS_DROPPED_NOTE)
 
-    protected_numeric_tokens = ("id", "code", "zip", "postal", "phone")
     date_tokens = ("date", "time", "timestamp", "created", "updated")
     named_date_ratio, numeric_ratio, unnamed_date_ratio = 0.8, 0.95, 0.95
     date_sample_size = 50
 
     for column in cleaned.select_dtypes(include=["object", "string"]).columns:
         series = cleaned[column]
-        non_null_before = int(series.notna().sum())
         cleaned[column] = series.map(lambda value: value.strip() if isinstance(value, str) else value)
         cleaned[column] = cleaned[column].replace("", pd.NA)
         trimmed_text_columns += 1
 
-        if non_null_before == 0:
+        # Counted after trimming. A whitespace-only cell is a blank, and
+        # counting it as a value put a column of "$100", "$200", "  " under
+        # the bar, so it stayed text.
+        non_null = int(cleaned[column].notna().sum())
+        if non_null == 0:
             continue
 
         normalized_name = column.lower()
         named_like_a_date = any(token in normalized_name for token in date_tokens)
+        # A column named as a key holds neither a quantity to add up nor a
+        # moment to bucket, whatever its values look like: "Customer ID"
+        # full of 2024-01-01 is not the file's date. The reader kept these
+        # as text by the same test, so what it preserved is not undone here.
+        protected = is_identifier_name(column)
         if named_like_a_date:
-            parsed_dates, ordering = _read_dates(cleaned[column])
-            if parsed_dates.notna().sum() / non_null_before >= named_date_ratio:
-                unreadable = int(non_null_before - parsed_dates.notna().sum())
+            parsed_dates, ordering, offsets = _read_dates(cleaned[column])
+            if parsed_dates.notna().sum() / non_null >= named_date_ratio:
+                unreadable = int(non_null - parsed_dates.notna().sum())
                 if unreadable:
                     unparsed_date_cells += unreadable
                     notes.append(f"{unreadable} {column} values could not be read as dates.")
                 if ordering:
                     notes.append(_ordering_note(column, ordering))
+                if offsets:
+                    notes.append(OFFSETS_DROPPED_NOTE)
                 cleaned[column] = _drop_timezone(parsed_dates)
                 datetime_columns_inferred += 1
                 continue
 
-        if not any(token in normalized_name for token in protected_numeric_tokens):
-            parsed_numeric = pd.to_numeric(cleaned[column], errors="coerce")
-            if parsed_numeric.notna().sum() < non_null_before:
-                # Whatever plain parsing could not read, try again allowing the
-                # punctuation a finance export writes: grouping separators, a
-                # currency symbol, parentheses for a negative. The values that
-                # need it are the large ones, so leaving them out biases every
-                # total downwards. Only the gaps are filled -- a value plain
-                # parsing already read ("1e3") is never replaced.
-                gaps = parsed_numeric.isna() & cleaned[column].notna()
-                if gaps.any():
-                    formatted = _numeric_from_text(cleaned[column].where(gaps))
-                    parsed_numeric = parsed_numeric.astype("float64").fillna(formatted)
-            if parsed_numeric.notna().sum() / non_null_before >= numeric_ratio:
+        if not protected:
+            # Whatever plain parsing could not read is tried again allowing
+            # the punctuation a finance export writes: grouping separators, a
+            # currency symbol, parentheses for a negative. The values that
+            # need it are the large ones, so leaving them out biases every
+            # total downwards.
+            parsed_numeric, formatted_used = _infer_numeric(cleaned[column])
+            infinite = np.isinf(parsed_numeric)
+            parsed_numeric = parsed_numeric.mask(infinite)
+            readable = int(parsed_numeric.notna().sum())
+            if readable / non_null >= numeric_ratio:
+                unreadable = non_null - readable - int(infinite.sum())
+                if unreadable:
+                    numeric_cells_unreadable += unreadable
+                    notes.append(
+                        f"{unreadable} {column} values could not be read as numbers and were left missing."
+                    )
+                if infinite.any():
+                    non_finite_cells += int(infinite.sum())
+                    notes.append(_non_finite_note(column, int(infinite.sum())))
+                if formatted_used and bool((parsed_numeric.abs() >= EXACT_FLOAT_LIMIT).any()):
+                    notes.append(
+                        f"{column} holds whole numbers that would not fit exactly in a decimal, "
+                        "which reading its formatted values required; the last few digits are "
+                        "approximate."
+                    )
                 cleaned[column] = parsed_numeric
                 numeric_columns_inferred += 1
                 continue
 
-        if not named_like_a_date:
+        if not named_like_a_date and not protected:
             # A column holds dates whatever it happens to be called -- "Month",
             # "Period", "FY". Numbers were tried first, so a column of bare years
             # stays numeric instead of becoming the 1st of January in each of
@@ -384,12 +536,20 @@ def clean_dataframe(
             # them.
             sample = cleaned[column].dropna().head(date_sample_size)
             if len(sample) and _speculative_dates(sample).notna().mean() >= unnamed_date_ratio:
-                parsed_dates, ordering = _read_dates(cleaned[column])
-                if parsed_dates.notna().sum() / non_null_before >= unnamed_date_ratio:
+                parsed_dates, ordering, offsets = _read_dates(cleaned[column])
+                if parsed_dates.notna().sum() / non_null >= unnamed_date_ratio:
                     if ordering:
                         notes.append(_ordering_note(column, ordering))
+                    if offsets:
+                        notes.append(OFFSETS_DROPPED_NOTE)
                     cleaned[column] = _drop_timezone(parsed_dates)
                     datetime_columns_inferred += 1
+
+    # A column the file already delivered as numbers can carry inf too;
+    # read_csv reads the text "inf" as one before cleaning ever sees it.
+    for column, count in _drop_non_finite(cleaned).items():
+        non_finite_cells += count
+        notes.append(_non_finite_note(column, count))
 
     # Inference can produce a new int64 column, so the overflow check runs
     # once everything that will be numeric already is.
@@ -426,6 +586,8 @@ def clean_dataframe(
         datetime_columns_inferred=datetime_columns_inferred,
         duplicate_rows_found=duplicate_rows,
         unparsed_date_cells=unparsed_date_cells,
+        numeric_cells_unreadable=numeric_cells_unreadable,
+        non_finite_cells=non_finite_cells,
         notes=tuple(dict.fromkeys(notes)),
     )
     return cleaned, report

--- a/anomalies.py
+++ b/anomalies.py
@@ -28,7 +28,7 @@ from dataclasses import dataclass
 import numpy as np
 import pandas as pd
 
-from timeseries import fit_trendline, robust_scale
+from timeseries import fit_trendline, observed_periods, robust_scale
 
 MIN_PERIODS = 8
 FALSE_ALARM_RATE = 0.05
@@ -88,7 +88,12 @@ def detect_anomalies(
     sensitivity, which is occasionally the right call but should be a
     deliberate one.
     """
-    if trend.empty or not {"Period", "Value"}.issubset(trend.columns) or len(trend) < min_periods:
+    if trend.empty or not {"Period", "Value"}.issubset(trend.columns):
+        return ()
+    # As in build_forecast: a period with no observation is not evidence, and
+    # one NaN makes the residual scale NaN, which silently flags nothing.
+    trend = observed_periods(trend)
+    if len(trend) < min_periods:
         return ()
 
     periods = pd.DatetimeIndex(pd.to_datetime(trend["Period"]))

--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ import importlib
 import os
 import secrets
 import sys
+import threading
 from pathlib import Path
 
 import pandas as pd
@@ -30,6 +31,9 @@ _LOCAL_MODULES = (  # dependency order: a module lists only modules above it
     "analysis", "autovis", "file_io", "demo_data", "business_insights", "nlq",
     "pipeline", "ai_insights", "ui",
 )
+# The product is whole without these. A deploy that breaks one must degrade
+# the page the way a cold start without it does, not take the page down.
+_OPTIONAL_MODULES = ("ai_insights",)
 
 
 def _source_digest(name: str) -> str:
@@ -37,54 +41,96 @@ def _source_digest(name: str) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest() if path.exists() else ""
 
 
+def _git_short_sha(root: Path = _HERE) -> str:
+    """The checked-out commit, or "" where there is no checkout to read."""
+    try:
+        ref = (root / ".git" / "HEAD").read_text().strip()
+        if ref.startswith("ref: "):
+            ref = (root / ".git" / ref[5:]).read_text().strip()
+    except OSError:
+        return ""
+    return ref[:7] if len(ref) >= 7 else ""
+
+
 @st.cache_resource(show_spinner=False)
 def _loaded_digests() -> dict[str, str]:
-    """What each local module looked like when this process first loaded it."""
+    """What each local module looked like when this process last loaded it."""
     return {}
 
 
-def _refresh_stale_modules() -> None:
-    loaded = _loaded_digests()
-    stale = [
-        name
-        for name in _LOCAL_MODULES
-        if name in sys.modules and loaded.get(name) not in ("", None, _source_digest(name))
-    ]
-    if stale:
-        # Reload the whole chain from the first stale module onwards, so a
-        # module that imported a name from it is rebound rather than left
-        # holding the old object.
-        first = min(_LOCAL_MODULES.index(name) for name in stale)
-        for name in _LOCAL_MODULES[first:]:
-            if name in sys.modules:
-                importlib.reload(sys.modules[name])
-    for name in _LOCAL_MODULES:
-        loaded[name] = _source_digest(name)
-
-
-_refresh_stale_modules()
+@st.cache_resource(show_spinner=False)
+def _refresh_lock() -> threading.Lock:
+    # Every session reruns this file in its own thread against the one
+    # sys.modules. The lock lives in the cache so it is the same object for
+    # all of them, and only one session performs a reload; the rest wait and
+    # find nothing stale.
+    return threading.Lock()
 
 
 @st.cache_resource(show_spinner=False)
 def build_identifier() -> str:
-    """The revision this process is serving, so a mixed deploy is visible.
+    """The revision this process is serving, so a mixed or stale deploy is visible.
 
-    Prefers the git commit; falls back to a digest of the source files, which
-    also changes if any one of them differs from the rest of the checkout.
+    The label is a digest of the source files, because that is what actually
+    runs: it changes the moment any one of them is out of step with the rest,
+    and it is cleared below whenever a file changes under a live process. The
+    git commit, where there is a checkout to read it from, is appended so the
+    label can be matched to history -- but never stands in for the digest,
+    since a checkout can be ahead of what a long-lived process has loaded.
     """
-    head = _HERE / ".git" / "HEAD"
-    try:
-        ref = head.read_text().strip()
-        if ref.startswith("ref: "):
-            ref = (_HERE / ".git" / ref[5:]).read_text().strip()
-        if len(ref) >= 7:
-            return ref[:7]
-    except OSError:
-        pass
     digest = hashlib.sha256()
     for name in _LOCAL_MODULES + ("app",):
         digest.update(_source_digest(name).encode())
-    return "src-" + digest.hexdigest()[:7]
+    label = digest.hexdigest()[:7]
+    sha = _git_short_sha()
+    return f"{label}@{sha}" if sha else label
+
+
+def _reload_module(name: str) -> None:
+    try:
+        importlib.reload(sys.modules[name])
+    except Exception as error:  # noqa: BLE001 - a deploy can break a module in any way
+        if name in _OPTIONAL_MODULES:
+            # Drop it so the guarded import below meets the failure afresh and
+            # records it, instead of this reload raising ahead of that guard.
+            sys.modules.pop(name, None)
+            return
+        # The hosted browser redacts tracebacks, so name the module and the
+        # failure on the page; then let it propagate, because a page served
+        # from a half-reloaded module would be wrong without saying so.
+        st.error(
+            f"ADA could not load the deployed {name}.py into the running server: "
+            f"{type(error).__name__}: {error}. The page will not render until the "
+            "file is fixed or the server is restarted."
+        )
+        raise
+
+
+def _refresh_stale_modules() -> None:
+    with _refresh_lock():
+        loaded = _loaded_digests()
+        # app.py is tracked too: it is re-executed on every rerun, so it is
+        # never reloaded here, but it is part of the build label.
+        on_disk = {name: _source_digest(name) for name in _LOCAL_MODULES + ("app",)}
+        changed = [name for name, digest in on_disk.items() if loaded.get(name) not in ("", None, digest)]
+        stale = [name for name in changed if name in sys.modules and name in _LOCAL_MODULES]
+        if stale:
+            # Reload the whole chain from the first stale module onwards, so a
+            # module that imported a name from it is rebound rather than left
+            # holding the old object.
+            first = min(_LOCAL_MODULES.index(name) for name in stale)
+            for name in _LOCAL_MODULES[first:]:
+                if name in sys.modules:
+                    _reload_module(name)
+        if changed:
+            # The label describes what is served, and what is served just changed.
+            build_identifier.clear()
+        # A reload that raised never reaches this line, so the next rerun
+        # tries again rather than recording code it does not run.
+        loaded.update(on_disk)
+
+
+_refresh_stale_modules()
 
 
 from analysis import column_profile  # noqa: E402 - the refresh above must run first
@@ -166,7 +212,14 @@ st.set_page_config(
 
 
 @st.cache_data(show_spinner=False, max_entries=8, ttl=3600)
-def read_uploaded_file(contents: bytes, filename: str, sheet_name: str | None = None) -> pd.DataFrame:
+def read_uploaded_file(
+    contents: bytes, filename: str, sheet_name: str | None, revision: str
+) -> pd.DataFrame:
+    # The cache outlives a module refresh, and a reader reloaded by one must
+    # not be answered from the old reader's results. The revision is not read;
+    # it is part of the key, so a new build is a miss. Callers pass
+    # build_identifier() rather than the function reading it, so the key is
+    # visible at the call site.
     return read_tabular_file(contents, filename, sheet_name)
 
 
@@ -309,11 +362,13 @@ def dataset_fingerprint(dataframe: pd.DataFrame, roles, source_name: str) -> str
     different segment -- and an answer, or a pending model plan, carried across
     that boundary is a wrong number with a confident sentence under it. The
     content is hashed, and the roles with it, because changing which column is
-    the measure changes what every answer means.
+    the measure changes what every answer means. So is the build: a code
+    revision changes what a question computes, and an answer or pending plan
+    made by the previous revision must not survive it.
     """
     content = int(pd.util.hash_pandas_object(dataframe, index=False).sum())
     parts = (source_name, str(dataframe.shape), ",".join(map(str, dataframe.columns)),
-             str(content), repr(roles))
+             str(content), repr(roles), build_identifier())
     return hashlib.sha256("|".join(parts).encode()).hexdigest()
 
 
@@ -456,7 +511,7 @@ try:
         business_context = "Two years of orders across products, regions, and sales channels."
     elif source_mode == "Try a sample dataset" and selected_sample is not None:
         sample_path = sample_datasets[selected_sample]
-        raw_dataframe = read_uploaded_file(sample_path.read_bytes(), sample_path.name)
+        raw_dataframe = read_uploaded_file(sample_path.read_bytes(), sample_path.name, None, build_identifier())
         source_name = f"{selected_sample} · sample"
         business_context = SAMPLE_NOTES.get(selected_sample, "")
     elif uploaded_file is not None:
@@ -472,7 +527,7 @@ try:
                 worksheets,
                 help="The workbook has several sheets; ADA analyzes one at a time.",
             )
-        raw_dataframe = read_uploaded_file(contents, uploaded_file.name, selected_sheet)
+        raw_dataframe = read_uploaded_file(contents, uploaded_file.name, selected_sheet, build_identifier())
         source_name = (
             f"{uploaded_file.name} · {selected_sheet}" if selected_sheet else uploaded_file.name
         )

--- a/app.py
+++ b/app.py
@@ -139,6 +139,7 @@ from demo_data import make_demo_data  # noqa: E402
 from file_io import list_excel_sheets, list_sample_datasets, read_tabular_file, safe_csv  # noqa: E402
 from nlq import QueryPlan, answer_question, suggested_questions  # noqa: E402
 from pipeline import (  # noqa: E402
+    NO_SELECTION,
     apply_focus,
     apply_role_selection,
     cleaning_audit_frame,
@@ -559,16 +560,18 @@ for note in prepared.cleaning_report.notes:
 
 dataframe = prepared.dataframe
 detected = prepared.detected_roles
+# A column can be called "None"; the choice of no column is a string no
+# export produces, so the two can never be confused.
 date_options = [
-    "None",
+    NO_SELECTION,
     *[
         column
         for column in dataframe.columns
         if pd.api.types.is_datetime64_any_dtype(dataframe[column])
     ],
 ]
-measure_options = ["None", *detected.numeric]
-dimension_options = ["None", *detected.dimensions]
+measure_options = [NO_SELECTION, *detected.numeric]
+dimension_options = [NO_SELECTION, *detected.dimensions]
 
 with st.expander("Tune ADA's schema detection", expanded=False):
     st.caption("ADA selected these roles automatically. Override them only when the source schema needs context.")
@@ -634,6 +637,11 @@ with executive_tab:
     with executive_columns[1]:
         st.markdown('<div class="section-label">What the data says</div>', unsafe_allow_html=True)
         render_evidence(brief, limit=4)
+        if len(brief.evidence) > 4:
+            st.caption(
+                f"Showing 4 of {len(brief.evidence)} findings. The Evidence tab has every one, "
+                "and the export carries them all."
+            )
         st.markdown(
             '<div class="trust-note"><strong>Trust contract:</strong> evidence cards are calculations. Recommendations are interpretations—not causal proof.</div>',
             unsafe_allow_html=True,

--- a/business_insights.py
+++ b/business_insights.py
@@ -674,17 +674,19 @@ def _recommendations(evidence: list[Evidence], roles: ColumnRoles) -> tuple[Reco
             )
         )
     elif trend and trend.tone == "positive":
-        improvement = "increase" if increase_is_welcome(roles.measure) else "reduction"
+        favourable = increase_is_welcome(roles.measure)
+        improvement = "increase" if favourable else "reduction"
+        levers = "volume, pricing, and mix" if favourable else "volume, unit cost, and mix"
         recommendations.append(
             Recommendation(
                 "Now",
                 (
-                    f"Make {driver.subject}'s improvement repeatable"
+                    f"Make {driver.subject}'s {improvement} repeatable"
                     if driver and driver.subject
                     else "Protect what improved"
                 ),
                 (
-                    f"Break {driver.subject}'s improvement into volume, pricing, and mix; preserve the "
+                    f"Break {driver.subject}'s {improvement} into {levers}; preserve the "
                     "repeatable driver and test it in the next-best segment."
                     if driver and driver.subject
                     else f"Identify which {roles.dimension or 'operating segment'} created the "
@@ -696,14 +698,23 @@ def _recommendations(evidence: list[Evidence], roles: ColumnRoles) -> tuple[Reco
 
     concentration = by_kind.get("concentration")
     leader = by_kind.get("leader")
+    segment = roles.dimension or "segment"
+    # The largest slice of revenue is a leader to learn from; the largest
+    # slice of cost is where a reduction starts. "Build a growth plan for
+    # the next two cost segments" was revenue wording on a cost metric.
+    favourable = increase_is_welcome(roles.measure)
     if concentration and concentration.tone == "warning":
         recommendations.append(
             Recommendation(
                 "Next",
-                "Reduce concentration risk",
+                "Reduce concentration risk" if favourable else "Check where the cost concentrates",
                 (
-                    f"Stress-test the business if the leading {roles.dimension or 'segment'} "
+                    f"Stress-test the business if the leading {segment} "
                     "falls 10–20%, and build a growth plan for the next two segments."
+                    if favourable
+                    else f"Confirm the concentration in the largest {segment} is intended -- one "
+                    "supplier, site or team -- and whether the next two segments can take on the "
+                    "same work at a lower unit cost."
                 ),
                 concentration.statement,
             )
@@ -712,10 +723,13 @@ def _recommendations(evidence: list[Evidence], roles: ColumnRoles) -> tuple[Reco
         recommendations.append(
             Recommendation(
                 "Next",
-                "Replicate the leader's playbook",
+                "Replicate the leader's playbook" if favourable else "Start with the largest segment",
                 (
-                    f"Compare the leading {roles.dimension or 'segment'} with the median on "
+                    f"Compare the leading {segment} with the median on "
                     "pricing, volume, and mix; scale the difference that is operationally controllable."
+                    if favourable
+                    else f"Compare the largest {segment} with the median on volume, unit cost, and "
+                    "mix; the controllable difference is where a reduction starts."
                 ),
                 leader.statement,
             )

--- a/business_insights.py
+++ b/business_insights.py
@@ -20,10 +20,13 @@ from formatting import (
     format_number,
     format_percentage,
     format_period,
+    format_rate_change,
     is_percentage,
     normalized_name,
     percentage_outranks_currency,
+    rate_scale,
 )
+from metrics import increase_is_welcome, resolve_metric
 from schema import TIME_PART_TOKENS, ColumnRoles, detect_roles, looks_like_identifier
 from timeseries import robust_scale
 
@@ -68,43 +71,27 @@ class BusinessBrief:
 MIN_PERIODS_FOR_VOLATILITY = 5
 
 
-def _period_changes(values: np.ndarray) -> np.ndarray:
-    """Period-over-period percentage changes, skipping divisions by zero."""
+def _period_changes(values: np.ndarray, *, points: bool = False) -> np.ndarray:
+    """Period-over-period changes: relative %, or point differences for a rate.
+
+    Division by zero is skipped in the relative case.
+    """
     previous, current = values[:-1], values[1:]
+    if points:
+        return current - previous
     usable = previous != 0
     return (current[usable] - previous[usable]) / np.abs(previous[usable]) * 100
 
 
-# A measure where going up is bad. Whole-word, head-noun style: "Cost" and
-# "Refund Amount" count, "Cost Savings" does not.
-ADVERSE_MEASURE_TOKENS = frozenset({
-    "cost", "costs", "expense", "expenses", "spend", "churn", "refund", "refunds",
-    "returns", "loss", "losses", "overdue", "delay", "delays", "hours", "tickets",
-    "complaints", "defects", "errors", "bounce", "debt", "outstanding",
-})
-FAVOURABLE_OVERRIDES = frozenset({"savings", "saved", "recovered"})
-
-
-def increase_is_welcome(measure: str | None) -> bool:
-    """Whether a rise in this measure is good news."""
-    if not measure:
-        return True
-    words = normalized_name(measure).split()
-    if not words or any(word in FAVOURABLE_OVERRIDES for word in words):
-        return True
-    # The head noun decides, and so does a leading one: "Refund Amount" is a
-    # refund before it is an amount. A word in the middle -- "Revenue After
-    # Returns" -- is a qualifier and does not flip the reading.
-    return words[-1] not in ADVERSE_MEASURE_TOKENS and words[0] not in ADVERSE_MEASURE_TOKENS
-
-
-def _movement_in_context(values: np.ndarray, change: float) -> str:
+def _movement_in_context(values: np.ndarray, change: float, *, points: bool = False) -> str:
     """Say whether the latest movement is unusual for this particular series.
 
     A metric that routinely swings 30% has not told you anything by swinging
     30% again. Without that context every movement reads as a development.
+    For a rate the series and the change are in percentage points, and so is
+    the "typically moves" figure -- a rate's own history is in points.
     """
-    prior = _period_changes(values[:-1])
+    prior = _period_changes(values[:-1], points=points)
     if len(prior) < MIN_PERIODS_FOR_VOLATILITY:
         return ""
 
@@ -128,7 +115,8 @@ def _movement_in_context(values: np.ndarray, change: float) -> str:
             if moved_more
             else "This is an unusually quiet period for this series"
         )
-    return f" {verdict} — this series typically moves about {format_percentage(typical)} per period."
+    unit = f"{typical:.1f} percentage points" if points else format_percentage(typical)
+    return f" {verdict} — this series typically moves about {unit} per period."
 
 
 def _growth_evidence(dataframe: pd.DataFrame, roles: ColumnRoles) -> Evidence | None:
@@ -142,7 +130,17 @@ def _growth_evidence(dataframe: pd.DataFrame, roles: ColumnRoles) -> Evidence | 
     current = float(values[-1])
     if previous == 0 or not np.isfinite(previous) or not np.isfinite(current):
         return None
-    change = (current - previous) / abs(previous) * 100
+    metric = resolve_metric(roles.measure)
+    measure_values = dataframe[roles.measure].dropna() if roles.measure else None
+    if metric.unit == "rate":
+        # A rate moves in percentage points. 10% to 20% is ten points; the
+        # "100% increase" reading is what the relative formula would say.
+        scale = 100.0 if rate_scale(measure_values, current) == "fraction" else 1.0
+        values = values * scale
+        previous, current = previous * scale, current * scale
+        change = current - previous
+    else:
+        change = (current - previous) / abs(previous) * 100
     # A quarter is "Q4 2023", not "Oct 2023" -- which the anomaly card and the
     # chart axis already knew, so the brief was contradicting its own page.
     period = format_period(trend.iloc[-1]["Period"], series.frequency)
@@ -151,31 +149,48 @@ def _growth_evidence(dataframe: pd.DataFrame, roles: ColumnRoles) -> Evidence | 
     # was reporting a 50% collapse as settled fact.
     completeness = "complete period" if series.completeness_checked else "period so far"
     measure = roles.measure or "Records"
-    measure_values = dataframe[roles.measure].dropna() if roles.measure else None
-    direction = "increased" if change >= 0 else "decreased"
+    direction = "was unchanged" if change == 0 else ("increased" if change > 0 else "decreased")
+    is_rate = metric.unit == "rate"
+    if change == 0:
+        moved = ""
+    elif is_rate:
+        moved = f" by {abs(change):.1f} percentage points"
+    else:
+        moved = " " + format_percentage(abs(change))
     # A rising cost is not good news. Tone follows what the movement means
     # for the business, and recommendations follow tone.
     welcome = increase_is_welcome(roles.measure)
-    context = _movement_in_context(values, change)
+    context = _movement_in_context(values, change, points=is_rate)
     if series.short_coverage:
         context += (
             f" The last period only reaches {series.short_coverage}, so part of this may be "
             "missing data rather than a real move."
         )
+    if is_rate:
+        shown_previous, shown_current = f"{previous:.1f}%", f"{current:.1f}%"
+        value = f"{'+' if change > 0 else ('−' if change < 0 else '')}{abs(change):.1f} pp"
+        calculation = (
+            "Latest period average − previous period average, in percentage points, set "
+            "against the spread of past period-over-period point changes"
+        )
+    else:
+        shown_previous = format_number(previous, roles.measure, column_values=measure_values)
+        shown_current = format_number(current, roles.measure, column_values=measure_values)
+        value = format_percentage(change, signed=True)
+        calculation = (
+            "(Latest period − previous period) ÷ |previous period|, set against the spread "
+            "of past period-over-period changes"
+        )
     return Evidence(
         kind="trend",
         title=f"Latest {measure.lower()} movement",
-        value=format_percentage(change, signed=True),
+        value=value,
         statement=(
-            f"{measure} {direction} {format_percentage(abs(change))} in the latest {completeness} "
-            f"({period}), from {format_number(previous, roles.measure, column_values=measure_values)} to "
-            f"{format_number(current, roles.measure, column_values=measure_values)}.{context}"
+            f"{measure} {direction}{moved} in the latest {completeness} "
+            f"({period}), from {shown_previous} to {shown_current}.{context}"
         ),
-        calculation=(
-            "(Latest period − previous period) ÷ |previous period|, set against the spread "
-            "of past period-over-period changes"
-        ),
-        tone="positive" if (change >= 0) == welcome else "negative",
+        calculation=calculation,
+        tone="neutral" if change == 0 else ("positive" if (change > 0) == welcome else "negative"),
     )
 
 
@@ -201,6 +216,35 @@ def _change_driver_evidence(dataframe: pd.DataFrame, roles: ColumnRoles) -> Evid
     driver_change = float(grouped.loc[driver_key, "Change"])
     direction = "increased" if driver_change > 0 else "decreased"
     sign = "+" if driver_change > 0 else "−"
+    metric = resolve_metric(roles.measure)
+    welcome = metric.increase_is_welcome
+    tone = "positive" if (driver_change > 0) == welcome else "negative"
+
+    if not metric.additive:
+        # Changes in segment averages do not add up to the change in the
+        # overall average -- a shift in mix moves the whole with no segment
+        # moving at all -- so no share of "the net movement" may be quoted.
+        # The change itself is in percentage points, which is not the same
+        # thing as a percentage.
+        return Evidence(
+            kind="driver",
+            title="Largest change by segment",
+            value=f"{sign}{format_rate_change(driver_change, measure_values)}",
+            statement=(
+                f"{driver_name} moved the most of any {roles.dimension.lower()}: average "
+                f"{roles.measure} {direction} by {format_rate_change(driver_change, measure_values)}, "
+                f"from {format_number(previous_value, roles.measure, column_values=measure_values)} to "
+                f"{format_number(current_value, roles.measure, column_values=measure_values)}. "
+                "Segment averages do not add up to the overall average, so no share of the "
+                "movement is quoted."
+            ),
+            calculation=(
+                f"latest mean {roles.measure} − previous mean, per {roles.dimension}; ranked by "
+                "absolute change in percentage points; not decomposable into a total"
+            ),
+            tone=tone,
+            subject=driver_name,
+        )
 
     movement = (
         f"{driver_name} moved the most of any {roles.dimension.lower()}: "
@@ -240,7 +284,7 @@ def _change_driver_evidence(dataframe: pd.DataFrame, roles: ColumnRoles) -> Evid
         value=f"{sign}{format_number(abs(driver_change), roles.measure, column_values=measure_values)}",
         statement=statement,
         calculation=calculation,
-        tone="positive" if driver_change > 0 else "negative",
+        tone=tone,
         subject=driver_name,
     )
 
@@ -248,7 +292,9 @@ def _change_driver_evidence(dataframe: pd.DataFrame, roles: ColumnRoles) -> Evid
 def _anomaly_evidence(dataframe: pd.DataFrame, roles: ColumnRoles) -> Evidence | None:
     if not roles.date:
         return None
-    anomalies = detect_anomalies(trend_frame(dataframe, roles))
+    # Every anomaly is counted; only the sharpest few are shown. The card
+    # used to report the display limit as the total.
+    anomalies = detect_anomalies(trend_frame(dataframe, roles), limit=10_000)
     if not anomalies:
         return None
     grain = preferred_frequency(dataframe[roles.date])
@@ -267,7 +313,8 @@ def _anomaly_evidence(dataframe: pd.DataFrame, roles: ColumnRoles) -> Evidence |
             f"{worst.direction} the expected "
             f"{format_number(worst.expected_low, roles.measure, column_values=measure_values)}–"
             f"{format_number(worst.expected_high, roles.measure, column_values=measure_values)} range. "
-            f"{len(anomalies)} {plural} outside the trendline band."
+            f"{len(anomalies)} {plural} outside the trendline band"
+            + (f" (showing the sharpest {min(5, len(anomalies))})." if len(anomalies) > 5 else ".")
         ),
         calculation=(
             "Period totals vs Theil–Sen trendline ± a band calibrated so that only "
@@ -316,6 +363,30 @@ def _segment_evidence(dataframe: pd.DataFrame, roles: ColumnRoles) -> tuple[Evid
     if segments.empty:
         return ()
 
+    metric = resolve_metric(roles.measure)
+    measure_values = dataframe[roles.measure].dropna() if roles.measure else None
+    if not metric.additive:
+        # Segment averages are ranked, not shared out: 22% of "total
+        # conversion rate" is a share of a number that does not exist.
+        segments = segments.sort_values("Value", ascending=False).reset_index(drop=True)
+        leader = segments.iloc[0]
+        dimension = roles.dimension or "segment"
+        amount = format_number(float(leader["Value"]), roles.measure, column_values=measure_values)
+        return (
+            Evidence(
+                kind="leader",
+                title=f"Highest average {(roles.measure or 'value').lower()}",
+                value=amount,
+                statement=(
+                    f"{leader['Segment']} has the highest average {(roles.measure or 'value').lower()} "
+                    f"of any {dimension.lower()}, at {amount}. A rate is an average, so no segment "
+                    "holds a share of it and no concentration can be measured."
+                ),
+                calculation=f"mean({roles.measure}) by {dimension}, ranked",
+                tone="neutral",
+                subject=str(leader["Segment"]),
+            ),
+        )
     total = float(segments["Value"].sum())
     if total == 0 or not np.isfinite(total):
         return ()
@@ -338,7 +409,6 @@ def _segment_evidence(dataframe: pd.DataFrame, roles: ColumnRoles) -> tuple[Evid
     )
     effective = _effective_segments(segments["Value"].to_numpy(dtype=float), total)
     measure = roles.measure or "records"
-    measure_values = dataframe[roles.measure].dropna() if roles.measure else None
     dimension = roles.dimension or "segment"
     leader_amount = format_number(
         float(leader["Value"]), roles.measure, column_values=measure_values
@@ -366,6 +436,7 @@ def _segment_evidence(dataframe: pd.DataFrame, roles: ColumnRoles) -> tuple[Evid
                 else f"largest |{measure}| by {dimension}; share undefined on mixed signs"
             ),
             tone="positive" if shares_hold else "warning",
+            subject=str(leader["Segment"]),
         ),
         # Concentration is a statement about shares. Without shares there is
         # nothing to say, so the card is left out rather than printed as nan%.
@@ -552,18 +623,22 @@ def _quality_evidence(dataframe: pd.DataFrame) -> Evidence | None:
     )
 
 
-def _shown_evidence(evidence: list[Evidence], limit: int = 6) -> list[Evidence]:
-    """The executive preview, with a data-quality card never squeezed out.
+def preview_evidence(evidence, limit: int = 6) -> list[Evidence]:
+    """A reading-budget preview that never squeezes out a data-quality card.
 
-    Six cards is the reading budget. A quality warning past the sixth slot
-    was silently gone -- the one card that says the other five may be built
-    on incomplete data.
+    The brief keeps every finding; this chooses what a pane shows. A quality
+    warning past the last slot is the one card saying the others may rest on
+    incomplete data, so it always makes the cut.
     """
-    shown = list(evidence[:limit])
+    evidence = list(evidence)
+    shown = evidence[:limit]
     quality = next((item for item in evidence[limit:] if item.kind == "quality"), None)
     if quality is not None:
         shown = shown[: limit - 1] + [quality]
     return shown
+
+
+_shown_evidence = preview_evidence
 
 
 def _recommendations(evidence: list[Evidence], roles: ColumnRoles) -> tuple[Recommendation, ...]:
@@ -598,7 +673,8 @@ def _recommendations(evidence: list[Evidence], roles: ColumnRoles) -> tuple[Reco
                 f"{trend.statement} {driver.statement}" if driver else trend.statement,
             )
         )
-    elif trend:
+    elif trend and trend.tone == "positive":
+        improvement = "increase" if increase_is_welcome(roles.measure) else "reduction"
         recommendations.append(
             Recommendation(
                 "Now",
@@ -608,11 +684,11 @@ def _recommendations(evidence: list[Evidence], roles: ColumnRoles) -> tuple[Reco
                     else "Protect what improved"
                 ),
                 (
-                    f"Break {driver.subject}'s lift into volume, pricing, and mix; preserve the "
+                    f"Break {driver.subject}'s improvement into volume, pricing, and mix; preserve the "
                     "repeatable driver and test it in the next-best segment."
                     if driver and driver.subject
                     else f"Identify which {roles.dimension or 'operating segment'} created the "
-                    "latest increase, then test whether that lift is repeatable rather than one-off."
+                    f"latest {improvement}, then test whether it is repeatable rather than one-off."
                 ),
                 f"{trend.statement} {driver.statement}" if driver else trend.statement,
             )
@@ -713,7 +789,14 @@ def _recommendations(evidence: list[Evidence], roles: ColumnRoles) -> tuple[Reco
                 "The current schema does not expose enough business structure for a specific recommendation.",
             )
         )
-    return tuple(recommendations[:4])
+    # Four is the reading budget, but a measurement-gap action past the
+    # fourth slot is the one saying the other three may be built on missing
+    # data, so it always makes the cut.
+    shown = recommendations[:4]
+    gap = next((item for item in recommendations[4:] if "measurement gap" in item.title.lower()), None)
+    if gap is not None:
+        shown = shown[:3] + [gap]
+    return tuple(shown)
 
 
 def analyze_business(dataframe: pd.DataFrame, roles: ColumnRoles | None = None) -> BusinessBrief:
@@ -802,7 +885,20 @@ def analyze_business(dataframe: pd.DataFrame, roles: ColumnRoles | None = None) 
     recommendations = _recommendations(evidence, roles)
     growth_text = growth.statement if growth else None
     leader = next((item for item in evidence if item.kind == "leader"), None)
-    if growth and leader:
+    if growth and leader and leader.kind == "leader" and not resolve_metric(roles.measure).additive:
+        # The leader card for a rate carries an average, not a share, so
+        # "36.5% coming from the leading region" would be a share of nothing.
+        headline = (
+            f"{growth.value} latest movement; {leader.subject} has the highest average "
+            f"{(roles.measure or 'value').lower()} at {leader.value}."
+        )
+    elif growth and leader and leader.tone == "warning":
+        # Mixed-sign segments: the leader's value is an amount, not a share.
+        headline = (
+            f"{growth.value} latest movement; {leader.subject} is the largest "
+            f"{roles.dimension.lower()} at {leader.value}."
+        )
+    elif growth and leader:
         headline = (
             f"{growth.value} latest movement, with {leader.value} coming from the leading "
             f"{roles.dimension.lower()}."
@@ -843,7 +939,7 @@ def analyze_business(dataframe: pd.DataFrame, roles: ColumnRoles | None = None) 
         summary=" ".join(summary_parts),
         roles=roles,
         kpis=tuple(kpis),
-        evidence=tuple(_shown_evidence(evidence)),
+        evidence=tuple(evidence),
         recommendations=recommendations,
     )
 

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,67 @@
+# The exact set of packages CI tests against, produced by "pip freeze" from a
+# clean install of requirements-dev.txt. requirements.txt states the ranges ADA
+# supports; this file pins the one resolution of those ranges that is known to
+# pass the suite, so a green run means the same thing tomorrow as it did today.
+# It is a pip constraints file: nothing here is installed unless something in
+# requirements-dev.txt asks for it. To refresh, see docs/development.md.
+#
+# Frozen 2026-09-07 on CPython 3.11.
+altair==6.2.2
+annotated-types==0.8.0
+anyio==4.15.1
+attrs==26.1.0
+blinker==1.9.0
+cachetools==7.1.8
+certifi==2026.7.22
+charset-normalizer==3.5.1
+click==8.5.0
+distro==1.9.0
+et_xmlfile==2.0.0
+gitdb==4.0.12
+GitPython==3.1.62
+h11==0.16.0
+httpcore==1.0.9
+httptools==0.8.0
+httpx==0.28.1
+idna==3.19
+itsdangerous==2.2.0
+Jinja2==3.1.6
+jiter==0.16.0
+jsonschema==4.26.0
+jsonschema-specifications==2025.9.1
+MarkupSafe==3.0.3
+narwhals==2.25.0
+numpy==2.4.6
+openai==2.54.0
+openpyxl==3.1.5
+packaging==26.3
+pandas==2.3.3
+pillow==12.3.0
+plotly==6.9.0
+protobuf==7.36.1
+pyarrow==24.0.0
+pydantic==2.13.5
+pydantic_core==2.46.5
+pydeck==0.9.3
+python-dateutil==2.9.0.post0
+python-multipart==0.0.32
+pytz==2026.3.post1
+referencing==0.37.0
+requests==2.34.2
+rpds-py==2026.6.3
+ruff==0.16.6
+six==1.17.0
+smmap==5.0.3
+sniffio==1.3.1
+starlette==1.6.0
+streamlit==1.59.2
+tenacity==9.1.4
+toml==0.10.2
+tqdm==4.70.0
+typing-inspection==0.4.4
+typing_extensions==4.16.0
+tzdata==2026.3
+urllib3==2.7.0
+uvicorn==0.52.4
+watchdog==6.0.0
+websockets==17.1

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -58,8 +58,10 @@ drag it around the way an ordinary best-fit line can.
 A period whose distance from the trendline is bigger than a calibrated band.
 
 "Calibrated" means the band width was *measured* by simulation, not picked by
-hand, so that a genuinely stable series raises a false alarm about once in
-twenty analyses. See [Anomalies](reference/anomalies.md).
+hand, so that a genuinely stable series with continuous, roughly normal noise
+raises a false alarm about once in twenty analyses. See
+[Anomalies](reference/anomalies.md) and
+[what that rate assumes](reference/anomalies.md#what-the-5-assumes).
 
 ## Evidence vs recommendation
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -11,19 +11,53 @@ python -m pip install -r requirements-dev.txt
 streamlit run app.py
 ```
 
-Python **3.11+**. No API key needed — the app opens with a built-in demo
-dataset.
+Python: tested on 3.11, 3.12 and 3.13 (the CI matrix); `requires-python` is
+`>=3.11`. No API key needed — the app opens with a built-in demo dataset.
+
+To reproduce CI's environment exactly rather than whatever resolves today, add
+the pin file to the install line:
+
+```bash
+python -m pip install -r requirements-dev.txt -c constraints.txt
+```
+
+## Dependencies: ranges and the tested set
+
+Two files describe the dependencies, and they answer different questions.
+
+- `requirements.txt` states the **supported ranges** — what ADA is written
+  against and expected to keep working with.
+- `constraints.txt` states the **tested set** — the exact versions a clean
+  `pip install -r requirements-dev.txt` resolved to when the file was last
+  refreshed, and therefore the versions the suite is known to pass on. CI
+  installs with `-c constraints.txt`, so a green run always refers to this set.
+
+A constraints file only pins; it never adds a package. Installing without it is
+supported, it is just not what CI checked.
+
+Refresh it when a range in `requirements.txt` changes, or deliberately, to pick
+up newer releases:
+
+```bash
+python -m venv /tmp/lockenv
+/tmp/lockenv/bin/pip install -r requirements-dev.txt -q
+/tmp/lockenv/bin/pip freeze > constraints.txt
+```
+
+Then put the header comment back, drop any editable or `file://` lines, run the
+checks below against the new set, and commit the file in the same pull request
+as the change that motivated it. The date and interpreter in the header say
+when and where it was produced; keep them current.
 
 ## Checks
 
-Run all three before opening a pull request. CI runs exactly these.
+Run these before opening a pull request. CI runs exactly these.
 
 ```bash
 ruff check .
 python -m unittest discover -s tests -v
-python -m compileall -q aggregation.py analysis.py ai_insights.py anomalies.py \
-  business_insights.py demo_data.py file_io.py forecasting.py formatting.py \
-  nlq.py pipeline.py schema.py timeseries.py ui.py app.py tools tests
+python -m compileall -q *.py tools tests
+python -c "import app"
 ```
 
 Ruff config lives in `pyproject.toml`: line length 110, rule sets `E`, `F`, `I`,
@@ -60,8 +94,25 @@ and no API credits.
 ## CI
 
 `.github/workflows/ci.yml` runs on every push to `main` and every pull request:
-install, `ruff check .`, the full unit suite, then `compileall`. Python 3.11 on
-Ubuntu.
+install with `-c constraints.txt`, `ruff check .`, the full unit suite,
+`compileall` over every top-level module, then `import app`. The whole job runs
+once per interpreter in the matrix — Python 3.11, 3.12 and 3.13 — on Ubuntu.
+
+### What a green CI run does and does not establish
+
+A green run establishes that, on the pinned dependency set and on each of the
+three interpreters, the code lints clean, every unit test passes, every module
+compiles, and the app imports. Those are real guarantees and they catch most of
+what breaks.
+
+It does not measure whether the product answers human questions correctly. The
+suite pins behaviours that were found and fixed — a parse, an aggregation, a
+threshold — but no test asks a few hundred realistic business questions and
+scores the answers against what an analyst would say. That semantic evaluation
+set is a separate, open item: the [roadmap](../ROADMAP.md) lists an evaluation
+corpus, and until
+it exists, "CI is green" means "nothing we already check has regressed", not
+"the answers are right".
 
 ## Conventions
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -40,9 +40,10 @@ chart says so. See [Periods](reference/periods.md).
 
 **Why is nothing flagged as an anomaly?**
 Either you have fewer than 8 periods, or nothing is far enough from the
-trendline. The band is calibrated so a stable series raises a false alarm about
-once in twenty analyses — quiet is the intended behavior. See
-[Anomalies](reference/anomalies.md).
+trendline. The band is calibrated so a stable series with continuous, roughly
+normal noise raises a false alarm about once in twenty analyses — quiet is the
+intended behavior. See [Anomalies](reference/anomalies.md) and
+[what that rate assumes](reference/anomalies.md#what-the-5-assumes).
 
 **Can I self-host it?**
 Yes. It is a standard Streamlit app:

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -11,13 +11,19 @@ evidence card and every Ask ADA answer are computed in-process with pandas, and
 without an API key ADA makes no network call at all.
 
 **On the hosted demo, your upload reaches a Streamlit server.** That is what
-uploading to a website is. It lives in memory for the session and is never
-written to a database. Run ADA locally if that matters for your data.
+uploading to a website is. The parsed file is held in that server process's
+memory — in a bounded cache of at most eight files for up to an hour, which
+belongs to the process rather than to your browser session — and is never
+written to disk or to a database. Run ADA locally if that matters for your
+data.
 
-**With an API key, two optional calls become available.** Both send column
-schema and already-computed evidence. **Neither sends your rows.** An evidence
-sentence names the segment it describes, so a segment label — a customer name,
-a product name — can travel inside it. No other cell value does.
+**With an API key, two optional calls become available.** The query planner
+receives only the question you typed and the column schema — names, types and
+detected roles — and nothing that was computed from your values. The strategic
+read receives the schema plus the already-computed evidence. **Neither sends
+your rows.** An evidence sentence names the segment it describes, so in the
+strategic read a segment label — a customer name, a product name — can travel
+inside it. No other cell value does, in either call.
 
 ## What stays local, always
 

--- a/docs/reference/ai-layer.md
+++ b/docs/reference/ai-layer.md
@@ -86,16 +86,25 @@ Tests pass a fake client and assert on the exact payload. That is how the
 privacy contract is enforced by the test suite rather than by good intentions:
 
 ```python
-def test_payload_contains_no_row_values():
-    fake = FakeClient()
-    generate_ai_narrative(brief, api_key="test", config=..., client=fake, ...)
-    assert "some-customer-name" not in fake.last_input
+def test_no_value_from_a_non_segment_column_reaches_the_narrative_payload(self):
+    frame = self._frame()          # a Notes column holding "SECRET-NOTE-<n>"
+    brief = analyze_business(frame, detect_roles(frame))
+    payload = build_ai_payload(brief, context="review")
+    self.assertNotIn("SECRET-NOTE", payload)
 ```
+
+A companion test asserts the opposite for the segment column — that a customer
+name *does* appear in the payload — so the documented exception is pinned from
+both sides.
 
 ## Changing this
 
-Any change here needs a privacy test proving no cell values enter the payload.
-The invariants are:
+Any change here needs a privacy test of the same shape as the one above: put
+a distinctive value in a non-segment column and prove it reaches neither
+payload, and keep the segment-label exception exactly as documented — an
+evidence sentence still names the segment it describes, and a test asserts
+that it does, so the boundary cannot move silently in either direction. The
+invariants are:
 
 1. Payloads are built from schema and computed evidence only
 2. Output is parsed into a typed schema

--- a/docs/reference/anomalies.md
+++ b/docs/reference/anomalies.md
@@ -41,7 +41,13 @@ stable series. That is a detector nobody trusts by the third dashboard.
 So ADA measures the multiplier instead. `tools/calibrate_anomalies.py` simulates
 stable series — a straight line plus normal noise, containing nothing to find —
 at each history length, and records the multiplier that keeps the false-alarm
-rate at **5%** (`FALSE_ALARM_RATE`). One stable series in twenty raises a flag.
+rate at **5%** (`FALSE_ALARM_RATE`). On a series like the ones simulated, one
+stable series in twenty raises a flag.
+
+That qualifier matters. The 5% is a calibration against a stated model of
+noise, not a property of every file; the section on
+[what it assumes](#what-the-5-assumes) says where it holds and where it is
+known not to.
 
 ## The calibrated table
 
@@ -75,20 +81,37 @@ rate. Paste the output back into `CRITICAL_VALUES`. The script is not imported
 by the app — it exists so the numbers in the table are reproducible rather than
 folklore.
 
-## Known limitation: heavy tails
+## What the 5% assumes
 
-The 5% guarantee assumes roughly normal noise. A spiky measure — one where a
-couple of large deals genuinely dominate a month — will exceed the band more
-often than one series in twenty, because for that measure those periods are
-ordinary rather than anomalous.
+The calibration simulates residuals that are **roughly normal** and
+**continuous** — real-valued noise around a straight line, with no two periods
+sharing a value. The multipliers hold the false-alarm rate at 5% for series of
+that kind, and only for series of that kind. ADA does not promise a universal
+one-in-twenty rate, and the two ways a real measure departs from the model are
+known:
 
+**Heavy tails.** A spiky measure — one where a couple of large deals genuinely
+dominate a month — will exceed the band more often than one series in twenty,
+because for that measure those periods are ordinary rather than anomalous.
 Calibration for heavy-tailed measures is on the [roadmap](../../ROADMAP.md).
 
-## Trading the guarantee for sensitivity
+**Near-two-valued series.** A measure that mostly reads one of two values — a
+count that sits at 20 or 21 every period, say — breaks the continuity
+assumption. Most residuals are identical, the median absolute deviation
+collapses to zero, and `robust_scale` falls back to the mean absolute
+deviation. Putting that fallback on the same footing as the median estimator
+(see the history of `timeseries.robust_scale`) brought a stable 20-or-21
+series down from being flagged 84% of the time to 72%, which is a real
+improvement and not a fix: such a series still over-flags well beyond 5%. An
+abstention rule was tried and rejected because it also silenced a genuine
+four-fold spike, a worse trade, so the limitation stands and is stated here
+rather than papered over.
+
+## Trading the calibration for sensitivity
 
 `detect_anomalies(trend, threshold=3.0)` overrides the calibrated multiplier.
-That is occasionally the right call, but it gives up the false-alarm guarantee,
-so it should be a deliberate decision rather than a default.
+That is occasionally the right call, but it gives up the calibrated false-alarm
+rate, so it should be a deliberate decision rather than a default.
 
 ## Edge cases
 

--- a/docs/reference/cleaning.md
+++ b/docs/reference/cleaning.md
@@ -44,9 +44,21 @@ assumed **and the assumption is reported**, because a year of monthly figures
 collapsing into twelve days of January is the one error no later step can
 detect.
 
-Timezone offsets are dropped at this point, keeping the wall clock the file was
-written in. Converting to UTC first would move rows east of Greenwich into the
-previous calendar day, changing which period they belong to.
+## Timezone offsets
+
+The policy is **per-row wall clock, always**. The offset text on each value
+(`+01:00`, `+0100`, `+01`, `Z`) is removed before parsing, so every row keeps
+the local time it was written in, and one note says that offsets were
+dropped. A column that arrives already timezone-aware is localised to naive
+the same way.
+
+Why not convert to UTC? Because every downstream calculation compares a date
+against a period boundary built without a timezone, so UTC moves rows east of
+Greenwich into the previous calendar day. And why never *sometimes* UTC? An
+earlier version kept wall clocks when every row shared one offset and fell
+back to UTC once the offsets were mixed -- so appending a single summer row
+to a winter file moved every existing row an hour, some of them into the
+previous month. What a row means must not depend on the rows after it.
 
 ## The exported-index rule
 
@@ -73,17 +85,61 @@ any other name is also tried, because dates arrive in columns called `Month`,
 bare years stays numeric instead of becoming the 1st of January in each.
 
 **Numbers** — converted when **at least 95%** of non-missing values parse.
-Whatever plain parsing cannot read is retried allowing the punctuation a
-finance export writes: thousands separators, a currency symbol, and
-parentheses for a negative. `$1,203.55` and `(48.10)` are numbers; the values
-that need this are the large ones, so leaving them out biases every total
-downwards. A value holding a slash is never read this way, so a date cannot
-become a very large integer. Skipped entirely when the name contains `id`,
-`code`, `zip`, `postal`, or `phone`.
+The denominator is counted *after* trimming, so a whitespace-only cell is a
+blank and not a value that failed. Whatever plain parsing cannot read is
+retried with the business-number grammar below. The values that need it are
+the large ones, so leaving them out biases every total downwards.
+
+Once a column is converted, every non-missing cell that still could not be
+read is **counted** (`numeric_cells_unreadable`) and a note names the column
+and the count. `inf` and `-inf` -- which pandas reads as numbers -- are
+treated as missing, counted separately (`non_finite_cells`), and noted.
 
 Why the difference in thresholds? Dates arrive in mixed formats and a stricter
 bar would reject real date columns. Numbers are unambiguous, so a column that is
 5% unparseable is probably not really numeric.
+
+### The business-number grammar
+
+A value is read as a number when it is, in this order: at most one sign, at
+most one currency symbol (`$ € £ ¥ ₹`), and at most one pair of accounting
+parentheses, in any order (`-$100`, `$-100`, `($100)`, `-(100)` are all a
+hundred owed), followed by digits with grouping marks. A slash or a letter
+anywhere means it is not a number, so a date cannot become a very large
+integer and `1e3` is left to plain parsing, which reads it.
+
+The digits must satisfy the grammar, or the value is refused and counted:
+
+- Marks between digit groups are `,` `.` space and `'`. Each mark sits between
+  two digits; a doubled mark, or a mark at either end, is malformed.
+- When both `,` and `.` appear, the one that comes last is the decimal mark
+  and the other is grouping: `1,234.50` and `1.234,50` are both 1234.5.
+- With one mark appearing once: `1,000` is a thousand and `1234,50` is a
+  decimal (one or two digits after a comma); a single `.` is always a decimal,
+  as `pd.to_numeric` reads it, so `1.234` is 1.234. A space or an apostrophe
+  is only ever grouping.
+- Grouping marks must delimit groups of **exactly three digits** after the
+  first group, and there is at most one decimal mark. `1,2,3`, `1.2.3`,
+  `12 34` and `1,000.000,50` are refused; the old parser read them as 123,
+  123, 1234 and something else again.
+- Parentheses must balance: `(100` and `100)` are refused.
+
+When the formatted reader contributed values, the column is a float whatever
+the plain values were, and a whole number at or past 2^53 has lost its last
+digits. A note says so, in the same words as the overflow-widening note.
+
+### Columns that are keys
+
+A column whose name says it holds a key is never converted -- neither to a
+number nor, in the unnamed date pass, to a date. `Customer ID` full of
+`2024-01-01` values is a batch of ids, not the file's date. The test is
+`schema.is_identifier_name`: the **last word** (or the whole name) is one of
+`id`, `ids`, `code`, `codes`, `zip`, `postal`, `phone`, `sku`, `number`, `no`,
+`key`, `uuid`, matched as a whole word. `Order No` and `Account Number` are
+keys; `Paid Amount`, `Grid Value` and `Valid Amount` are not, although each
+contains the letters `id`. The same function decides which columns
+`file_io` reads as text, so an account number written `00042` is `00042` from
+upload to chart, and nothing the reader preserved is undone here.
 
 Why protect `zip` and `phone`? Because `01234` is a postcode, and converting it
 to `1234` destroys it.
@@ -93,7 +149,10 @@ to `1234` destroys it.
 `CleaningReport` records original and final row/column counts plus a count for
 every operation: duplicates removed, empty rows removed, empty columns removed,
 index columns removed, text columns trimmed, numeric columns inferred, datetime
-columns inferred.
+columns inferred, date cells that could not be read (`unparsed_date_cells`),
+numeric cells coerced to missing (`numeric_cells_unreadable`), and infinite
+values made missing (`non_finite_cells`). Each of the last three also gets a
+note naming the column.
 
 `pipeline.cleaning_audit_frame` turns it into the table shown in the app. Nothing
 is changed without a number appearing here.
@@ -106,7 +165,15 @@ is changed without a number appearing here.
 | Everything dropped by cleaning | `ValueError` — "No analyzable data remained" |
 | Column that is 90% numeric | Left as text — below the 95% bar |
 | `Order Date` that is 85% parseable | Converted — above the 80% bar |
-| Column named `Customer ID` holding numbers | Left as text — protected token |
+| `["$100", "$200", "  "]` | Converted — the blank is not counted against the bar |
+| Column named `Customer ID` holding numbers | Left as text — its name says key |
+| Column named `Customer ID` holding `2024-01-01` values | Left as text — never the date |
+| Column named `Paid Amount` holding `$1,000` | Converted — `id` inside a word is not a word |
+| `$-100` among `$200` values | −100, sign after the currency is read |
+| `(100` among `200` values | Missing, counted in `numeric_cells_unreadable`, noted |
+| `inf` among numbers | Missing, counted in `non_finite_cells`, noted |
+| Nineteen `9007199254740993` and one `$1` | Float column; note says the last digits are approximate |
+| `+01:00` rows, then a `+02:00` row appended | Existing rows unchanged — every row keeps its wall clock |
 
 ## Changing this
 

--- a/docs/reference/evidence.md
+++ b/docs/reference/evidence.md
@@ -81,6 +81,12 @@ It ships with a 95% confidence interval via the Fisher transform and the sample
 size. If the interval spans zero, the card says the sample cannot rule out no
 relationship at all.
 
+The pair shown is the **largest of a search** across every eligible numeric
+pair, and the interval is **not adjusted for that search**. Picking the biggest
+of many correlations makes a chance result likelier than a single interval
+suggests, so the card says so in its own text and its calculation string, and
+asks to be read as a lead to test rather than a result.
+
 There is also a rank check: when Pearson and rank correlation diverge by more
 than **0.25** (`RANK_DIVERGENCE`), the relationship is likely driven by a few
 outliers, and the card says so.

--- a/docs/reference/forecasting.md
+++ b/docs/reference/forecasting.md
@@ -42,23 +42,53 @@ Every forecast ships with one. The last stretch of history is held out, the
 model is refitted on what is left, and the held-out periods are scored — so the
 error is measured on periods the fit never saw.
 
-Two numbers come back:
+The held-out periods are scored at their own calendar positions, the same
+positions the trendline is fitted on. A month missing from inside the holdout
+leaves a hole rather than shifting every later prediction one period early.
+And the scored forecast is the one the page shows: a series that never goes
+negative is clipped at zero in the backtest exactly as it is on the chart.
+
+Three numbers come back:
 
 | Metric | Meaning |
 |---|---|
-| **MAPE** | Mean absolute percentage error on the holdout |
-| **MASE** | Holdout error ÷ the error of assuming no change |
+| **MAPE** | Mean absolute percentage error of the model on the holdout |
+| **holdout_naive_mape** | The same percentage error for a no-change forecast (the last training value carried across the holdout) |
+| **MASE** | Holdout error ÷ the mean one-step movement of the training history |
 
-**MASE is the one that matters.** Below 1.0, the forecast beat "assume next
-period equals this period". At or above 1.0, it did not — and `describe_backtest`
-says so in the interface instead of hiding it.
+**MASE and the no-change contest answer different questions.** MASE is the
+textbook mean absolute scaled error: its denominator is how far the series
+moved from one period to the next over the training history, so a MASE of 0.5
+means the holdout misses were half the size of a typical period-to-period
+change. That says how large the error is in the series' own units. It does
+*not* say whether assuming no change would have done better on the held-out
+periods, because no-change was never scored there.
+
+So the backtest also runs that contest. The last training value is carried
+across the holdout and scored on exactly the same periods as the model, and
+`beats_naive_on_holdout` says who won. A zig-zag history whose holdout sits at
+the last training value gets a MASE of 0.5 and still loses: the earlier note,
+which read the verdict off MASE alone, would have called that "better than
+assuming no change".
+
+`describe_backtest` reports both, in words that say what each measured:
+
+> average error of 1.7% on the last 4 held-out periods, assuming no change
+> would have erred 4.9% on the same periods, so the model beat it, MASE 0.72
+> (error relative to a one-step no-change baseline on the training history)
+
+The percentage is an average of past misses, so it is never written as
+"±1.7%". That sign reads as an uncertainty interval, which MAPE is not. The
+band on the chart has its own description in the `method` string, kept
+separate from the error note.
 
 A forecast that cannot beat no-change is not automatically useless, but the user
 deserves to know before planning around it.
 
 `periods_without_mape` counts holdout periods too near zero for a percentage
-error to be meaningful. Those are excluded from MAPE rather than allowed to
-produce a huge meaningless number.
+error to be meaningful. Those are excluded from both percentage errors rather
+than allowed to produce a huge meaningless number; when every held-out period
+is zero, the note says so and only MASE is reported.
 
 ## Edge cases
 
@@ -77,7 +107,8 @@ Two rules survive any model change:
 
 1. **Refuse rather than guess.** Thin history returns `None`.
 2. **Ship the honest error.** Whatever replaces the current backtest must still
-   be able to say "this was no better than assuming no change."
+   score a no-change forecast on the same held-out periods and be able to say
+   "the model did not beat it." MASE alone cannot say that.
 
 Rolling-origin backtesting and a seasonal-naive comparison are on the
 [roadmap](../../ROADMAP.md) — both make better use of short histories than the

--- a/docs/reference/reading-files.md
+++ b/docs/reference/reading-files.md
@@ -32,17 +32,45 @@ selected by the detected date column where there is one, and from the end of
 the file where there is not. Cleaning runs before the cut, so the skipped count
 is the real number of rows dropped.
 
+## Columns kept as text
+
+Both readers peek at the header first and read as **text** every column whose
+name says it holds a key, so an account number written `00042` stays `00042`
+instead of becoming `42`. The test is `schema.is_identifier_name`: the last
+word (or the whole name) is one of `id`, `ids`, `code`, `codes`, `zip`,
+`postal`, `phone`, `sku`, `number`, `no`, `key`, `uuid`, as a whole word.
+`Customer ID`, `Account Number`, `SKU`, `Order No` and `ZIP` are kept;
+`Paid Amount` is not, although it contains the letters `id`. Cleaning uses the
+same function to decide what it leaves alone, so what is preserved here is
+still there after `prepare_analysis`.
+
+`NA` is read as a value, not as missing: in business data it is North America.
+Every other default missing-value marker is kept.
+
 ## How CSV parsing works
 
 1. Try encodings in order: `utf-8-sig`, then `utf-8`, then `latin-1`.
    `utf-8-sig` goes first so a Windows byte-order mark does not end up glued to
    the first column name.
 2. Parse with the default comma separator.
-3. If that produces exactly **one** column and the first 4 KB contains a `;` or
-   a tab, re-parse with separator sniffing. The single-column result is the
-   tell-tale sign of a semicolon-separated European export.
+3. If that produces exactly **one** column and the header line contains a `;`,
+   a tab or a `|`, re-parse with that separator. The single-column result is
+   the tell-tale sign of a semicolon-separated European export.
+4. If the first line is a report title over a real header, use the second line
+   as the header.
 
 If every encoding fails, you get "The file could not be parsed as CSV."
+
+### Rows wider than the header
+
+`Region,Revenue` followed by `West,100,999` is refused: "Line 2 of the file
+holds 3 values, but the header names 2 columns." pandas would otherwise read
+it without complaint, taking the first column as an index and shifting every
+other value one column left, so `Region` arrives full of revenue figures. The
+reader spots the invented index (nothing here asks for one) and names the
+first line whose width does not match. A trailing delimiter on every row is
+the same mistake and gets the same message. A row wider than the header
+further down the file was already a parse error and still is.
 
 ## How Excel parsing works
 
@@ -51,7 +79,22 @@ workbook has more than one sheet, `app.py` shows a picker and passes the choice
 through. With no choice, sheet index `0` is read.
 
 A file with an Excel extension that is not really a workbook raises "The file is
-not a valid Excel workbook" rather than a raw `BadZipFile`.
+not a valid Excel workbook" rather than a raw `BadZipFile`. A workbook that is
+a zip but whose XML stops mid-element -- a truncated upload, a broken export --
+raises "The workbook is damaged and could not be read" from both readers,
+instead of the `ParseError` openpyxl produces. Nothing else is caught: an
+unexpected exception is still a bug to look at, not a message to show.
+
+### Formulas without saved results
+
+A workbook written by a library (openpyxl among them) holds formulas with no
+cached value; Excel computes on open, pandas does not. Such a column reads back
+entirely missing, cleaning would drop it, and a different metric would be
+chosen in silence. So when any column comes back all-missing the sheet is
+opened once more with formulas visible; if that column's cells are formulas,
+the file is refused with "The workbook contains formulas without saved
+results (Revenue)" and the advice to re-save it from Excel or export values. A
+column that is simply empty is not a formula, and is read as before.
 
 ## Edge cases
 
@@ -60,8 +103,13 @@ not a valid Excel workbook" rather than a raw `BadZipFile`.
 | Empty file | `ValueError` — "The uploaded file is empty." |
 | Multi-sheet workbook, no sheet chosen | First sheet |
 | `.xlsx` that is not a zip | Clear error, not a traceback |
+| `.xlsx` with truncated XML inside | "The workbook is damaged and could not be read" |
+| Formula cells with no saved value | Refused, naming the column |
 | CSV with a BOM | Handled by `utf-8-sig` |
 | Semicolon CSV | Detected on the retry pass |
+| A data row wider than the header | Refused, naming the line and both widths |
+| `Customer ID` of `00042` | Read as text, zeros kept |
+| `NA` in a region column | North America, not missing |
 
 ## Changing this
 

--- a/docs/reference/schema-detection.md
+++ b/docs/reference/schema-detection.md
@@ -25,7 +25,32 @@ Considers only real datetime columns (after cleaning has done its inference).
 Ranks them by:
 
 1. Name contains `date`, `time`, or `created` — this wins
-2. Then: most non-missing values
+2. Then: the event that produced the row outranks what happened to it
+   afterwards. `order`, `transaction`, `sale`, `invoice`, `posting`,
+   `created`, `booking` beat a plain date, which beats `ship`, `delivery`,
+   `due`, `updated`, `modified`, `closed`
+3. Then: most non-missing values
+4. Then: the **full normalized name**, alphabetically first
+
+The last step is what makes the choice independent of column order. The
+candidates are sorted by their whole name before ranking, and `max()` returns
+the first of equal elements, so `Transaction Date A` beats `Transaction Date
+B` whichever the file wrote first. An earlier tiebreak compared only the
+first eight bytes of the name, which is not enough to separate two long names
+that share a prefix, and the two columns swapped when the file's column order
+was reversed.
+
+## Identifier names
+
+`is_identifier_name(name)` is the one function that says a column *name*
+denotes a key: its last word, or the whole name, is one of `id`, `ids`,
+`code`, `codes`, `zip`, `postal`, `phone`, `sku`, `number`, `no`, `key`,
+`uuid`, matched as a whole word on the normalized name. `Order No` and `id`
+are keys; `Paid Amount` is not. `file_io` uses it to read such columns as
+text, and `analysis.clean_dataframe` uses it to skip them in both the numeric
+and the unnamed-date pass, so an identifier is preserved from upload to chart
+by one rule rather than by two lists that drift apart. It looks at the name
+alone; `looks_like_identifier` below adds the data.
 
 ## Picking the measure
 

--- a/file_io.py
+++ b/file_io.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
+import csv
 from io import BytesIO
 from pathlib import Path
+from xml.etree.ElementTree import ParseError
 from zipfile import BadZipFile
 
+import openpyxl
 import pandas as pd
+from openpyxl.utils.exceptions import InvalidFileException
 from pandas.io.parsers.readers import STR_NA_VALUES
 
-from formatting import normalized_name
+from schema import is_identifier_name
 
 SUPPORTED_SUFFIXES = {".csv", ".xlsx", ".xlsm"}
 SAMPLES_DIRECTORY = Path(__file__).parent / "samples"
@@ -63,6 +67,13 @@ def _validate(contents: bytes, filename: str) -> str:
     return suffix
 
 
+NOT_A_WORKBOOK = "The file is not a valid Excel workbook."
+DAMAGED_WORKBOOK = (
+    "The workbook is damaged and could not be read. Open it in Excel, save it "
+    "again, and upload the new copy."
+)
+
+
 def list_excel_sheets(contents: bytes, filename: str) -> list[str]:
     """Worksheet names of a workbook; empty for CSV files."""
     suffix = _validate(contents, filename)
@@ -74,31 +85,64 @@ def list_excel_sheets(contents: bytes, filename: str) -> list[str]:
     except (BadZipFile, KeyError) as error:
         # A zip that is not a workbook -- no [Content_Types].xml -- surfaces
         # from openpyxl as a KeyError, which the app did not catch.
-        raise ValueError("The file is not a valid Excel workbook.") from error
+        raise ValueError(NOT_A_WORKBOOK) from error
+    except (ParseError, InvalidFileException) as error:
+        # A workbook whose XML stops mid-element is a zip, so the check above
+        # passes it, and the parser error it raises instead is not one the
+        # app catches.
+        raise ValueError(DAMAGED_WORKBOOK) from error
 
 
 # pandas reads "NA" as missing by default. In business data it is North
 # America, and a region code was being turned into a blank before cleaning
 # ever saw it. Every other default marker is kept.
 NA_VALUES = sorted(STR_NA_VALUES - {"NA"})
-# A column whose last word says it holds a key is read as text, so an
-# account number written 00042 keeps its zeros instead of becoming 42.
-TEXT_HEAD_WORDS = frozenset({"id", "ids", "code", "codes", "zip", "postal", "phone", "sku", "number", "no"})
 
 
 def _kept_as_text(columns) -> dict[str, type]:
-    kept = {}
-    for column in columns:
-        words = normalized_name(str(column)).split()
-        if words and (words[-1] in TEXT_HEAD_WORDS or words == ["id"]):
-            kept[column] = str
-    return kept
+    """Columns read as text because their name says they hold a key.
+
+    An account number written 00042 must stay 00042. The cleaner consults
+    the same test before it infers numbers, so nothing kept here is undone
+    a step later.
+    """
+    return {column: str for column in columns if is_identifier_name(str(column))}
+
+
+class RowWidthError(ValueError):
+    """A data row holds more values than the header names.
+
+    pandas reads such a file without complaint, taking the first column as an
+    index and shifting every other value one column to the left, so a Region
+    column arrives full of revenue figures. The header width is kept so the
+    title-row rescue can tell this apart from a report title above the table.
+    """
+
+    def __init__(self, header_width: int, line_number: int, row_width: int) -> None:
+        self.header_width = header_width
+        super().__init__(
+            f"Line {line_number} of the file holds {row_width} values, but the header names "
+            f"{header_width} columns. Check that line for a stray delimiter, or the header "
+            "for a missing column name."
+        )
+
+
+def _row_width_error(contents: bytes, encoding: str, header_width: int, **options) -> RowWidthError:
+    delimiter = options.get("sep", ",")
+    skipped = options.get("header", 0)
+    text = contents.decode(encoding, errors="replace")
+    for line_number, row in enumerate(csv.reader(text.splitlines(), delimiter=delimiter), start=1):
+        if line_number > skipped + 1 and len(row) > header_width:
+            return RowWidthError(header_width, line_number, len(row))
+    # Nothing wider was found by counting, so pandas saw the mismatch in a
+    # form the count does not -- name the first data line rather than none.
+    return RowWidthError(header_width, skipped + 2, header_width + 1)
 
 
 def _read_csv(contents: bytes, encoding: str, **options) -> pd.DataFrame:
     """read_csv with the header peeked first, so id columns stay text."""
     header = pd.read_csv(BytesIO(contents), encoding=encoding, nrows=0, **options)
-    return pd.read_csv(
+    parsed = pd.read_csv(
         BytesIO(contents),
         encoding=encoding,
         dtype=_kept_as_text(header.columns),
@@ -107,6 +151,11 @@ def _read_csv(contents: bytes, encoding: str, **options) -> pd.DataFrame:
         low_memory=False,
         **options,
     )
+    if not isinstance(parsed.index, pd.RangeIndex):
+        # Nothing here asks for an index column, so any other index means
+        # pandas built one out of rows wider than the header.
+        raise _row_width_error(contents, encoding, len(header.columns), **options)
+    return parsed
 
 
 def _candidate_encodings(contents: bytes) -> tuple[str, ...]:
@@ -148,25 +197,85 @@ def _resplit_single_column(parsed: pd.DataFrame, contents: bytes, encoding: str)
     return parsed
 
 
-def _skip_title_row(parsed: pd.DataFrame, contents: bytes, encoding: str) -> pd.DataFrame:
+def _skip_title_row(contents: bytes, encoding: str) -> pd.DataFrame | None:
     """Use the second line as the header when the first is a report title.
 
     Exported reports often carry a title above the table. Read as a header it
-    yields one column, and every real column is silently discarded.
+    yields one column over rows wider than it -- the very shape of a
+    malformed file -- so this runs when that shape is seen, and the file is
+    refused only when the title reading does not hold up either.
     """
-    if len(parsed.columns) > 1 or parsed.empty:
-        return parsed
     lines = contents.split(b"\n")[:3]
     if len(lines) < 3:
-        return parsed
+        return None
     title, header, first_row = (line.decode(encoding, errors="replace") for line in lines)
     # Only a comma is treated as the delimiter here. A one-column file of
     # sentences containing semicolons is a real file, and re-reading it as a
     # table would shred it -- the mistake this rescue is meant to prevent.
     if "," in title or not header.count(",") or header.count(",") != first_row.count(","):
-        return parsed
+        return None
     candidate = _read_csv(contents, encoding, header=1)
-    return candidate if len(candidate.columns) > 1 else parsed
+    return candidate if len(candidate.columns) > 1 else None
+
+
+def _parse_csv(contents: bytes, encoding: str) -> pd.DataFrame:
+    try:
+        parsed = _read_csv(contents, encoding)
+    except RowWidthError as error:
+        rescued = _skip_title_row(contents, encoding) if error.header_width == 1 else None
+        if rescued is None:
+            raise
+        return rescued
+    return _resplit_single_column(parsed, contents, encoding)
+
+
+def _formula_columns_without_values(
+    contents: bytes, sheet: str | int, blank: list[tuple[int, str]]
+) -> list[str]:
+    """Which of the all-missing columns are formulas with no saved result.
+
+    openpyxl writes formulas without evaluating them, and a workbook saved
+    that way reads back as blanks. Cleaning would then drop the column and
+    pick a different metric without a word. Only columns that came back
+    entirely missing are looked at, so an ordinary workbook never pays for
+    the second open.
+    """
+    book = openpyxl.load_workbook(BytesIO(contents), data_only=False, read_only=True)
+    try:
+        worksheet = book[sheet] if isinstance(sheet, str) else book.worksheets[sheet]
+        flagged = []
+        for position, column in blank:
+            cells = worksheet.iter_rows(min_row=2, min_col=position, max_col=position)
+            if any(cell.data_type == "f" for row in cells for cell in row):
+                flagged.append(column)
+        return flagged
+    finally:
+        book.close()
+
+
+def _read_excel(contents: bytes, sheet: str | int) -> pd.DataFrame:
+    header = pd.read_excel(BytesIO(contents), engine="openpyxl", sheet_name=sheet, nrows=0)
+    parsed = pd.read_excel(
+        BytesIO(contents),
+        engine="openpyxl",
+        sheet_name=sheet,
+        dtype=_kept_as_text(header.columns),
+        keep_default_na=False,
+        na_values=NA_VALUES,
+    )
+    blank = [
+        (position, str(column))
+        for position, column in enumerate(parsed.columns, start=1)
+        if parsed[column].isna().all()
+    ]
+    unevaluated = _formula_columns_without_values(contents, sheet, blank) if blank else []
+    if unevaluated:
+        raise ValueError(
+            f"The workbook contains formulas without saved results ({', '.join(unevaluated)}), "
+            "so their values cannot be read. Open it in Excel and save it again, or export "
+            "the values, and upload the new copy."
+        )
+    return parsed
 
 
 def read_tabular_file(
@@ -178,25 +287,16 @@ def read_tabular_file(
     suffix = _validate(contents, filename)
     if suffix in EXCEL_SUFFIXES:
         try:
-            sheet = sheet_name if sheet_name is not None else 0
-            header = pd.read_excel(BytesIO(contents), engine="openpyxl", sheet_name=sheet, nrows=0)
-            return pd.read_excel(
-                BytesIO(contents),
-                engine="openpyxl",
-                sheet_name=sheet,
-                dtype=_kept_as_text(header.columns),
-                keep_default_na=False,
-                na_values=NA_VALUES,
-            )
+            return _read_excel(contents, sheet_name if sheet_name is not None else 0)
         except (BadZipFile, KeyError) as error:
-            raise ValueError("The file is not a valid Excel workbook.") from error
+            raise ValueError(NOT_A_WORKBOOK) from error
+        except (ParseError, InvalidFileException) as error:
+            raise ValueError(DAMAGED_WORKBOOK) from error
 
     parse_errors: list[Exception] = []
     for encoding in _candidate_encodings(contents):
         try:
-            parsed = _read_csv(contents, encoding)
-            parsed = _resplit_single_column(parsed, contents, encoding)
-            return _skip_title_row(parsed, contents, encoding)
+            return _parse_csv(contents, encoding)
         except (UnicodeDecodeError, pd.errors.ParserError) as error:
             parse_errors.append(error)
     raise ValueError("The file could not be parsed as CSV.") from parse_errors[-1]

--- a/forecasting.py
+++ b/forecasting.py
@@ -14,9 +14,14 @@ prediction-interval shape with a robust scale, which is an approximation
 for a median-based fit -- close enough to keep the shape honest, which is
 why the backtest, not the band, is the number to trust.
 
-The backtest reports a scaled error next to the percentage one. A MAPE of
-12% means nothing on its own; a MASE below 1 means the forecast beat simply
-assuming next period looks like this one, and above 1 means it did not.
+The backtest reports two comparisons next to the percentage error. A MAPE
+of 12% means nothing on its own. MASE scales the holdout error by how much
+the series moved from one period to the next over the training history --
+the textbook denominator, a one-step no-change baseline measured on the
+periods the fit saw. It is not a race on the holdout, so the backtest also
+runs that race: the last training value is carried across the held-out
+periods and scored on exactly the same periods as the model, and only that
+contest can say whether the model beat assuming no change.
 """
 
 from __future__ import annotations
@@ -26,7 +31,7 @@ from dataclasses import dataclass
 import numpy as np
 import pandas as pd
 
-from timeseries import fit_trendline, period_grain, robust_scale
+from timeseries import fit_trendline, period_grain, period_positions, robust_scale
 
 MIN_PERIODS = 8
 MIN_SEASONAL_PERIODS = 18
@@ -38,13 +43,19 @@ class Backtest:
     """Honest error, measured on periods the fit never saw."""
 
     mape: float | None  # mean absolute % error on the holdout
-    mase: float | None  # holdout error ÷ error of a no-change forecast
+    mase: float | None  # holdout error ÷ one-step no-change error on the training history
     holdout_periods: int
     periods_without_mape: int  # holdout periods too near zero for a percentage
+    # The same percentage error for carrying the last training value across
+    # the holdout. This is the only number that compares the model with a
+    # no-change forecast on the same periods; MASE does not.
+    holdout_naive_mape: float | None = None
 
     @property
-    def beats_no_change(self) -> bool | None:
-        return None if self.mase is None else self.mase < 1.0
+    def beats_naive_on_holdout(self) -> bool | None:
+        if self.mape is None or self.holdout_naive_mape is None:
+            return None
+        return self.mape < self.holdout_naive_mape
 
 
 @dataclass(frozen=True)
@@ -62,19 +73,33 @@ def describe_backtest(backtest: Backtest) -> str:
     if not backtest.holdout_periods:
         return "history is too thin for a backtest"
 
-    parts = [f"held out the last {backtest.holdout_periods} periods"]
+    # MAPE is an average of past misses, not an interval, so it is never
+    # written with a plus-minus sign; the band on the chart carries its own
+    # description in the method string.
+    count = backtest.holdout_periods
+    parts: list[str] = []
     if backtest.mape is not None:
-        note = f"±{backtest.mape:.1f}% average error"
+        note = f"average error of {backtest.mape:.1f}% on the last {count} held-out periods"
         if backtest.periods_without_mape:
-            measurable = backtest.holdout_periods - backtest.periods_without_mape
-            note += f" across the {measurable} of them above zero"
+            measurable = count - backtest.periods_without_mape
+            note += f" (the {measurable} of them above zero)"
         parts.append(note)
-    elif backtest.periods_without_mape:
-        parts.append("every held-out period was zero, so a percentage error says nothing")
+        if backtest.holdout_naive_mape is not None:
+            verdict = "beat it" if backtest.beats_naive_on_holdout else "did not beat it"
+            parts.append(
+                f"assuming no change would have erred {backtest.holdout_naive_mape:.1f}%"
+                f" on the same periods, so the model {verdict}"
+            )
+    else:
+        parts.append(f"held out the last {count} periods")
+        if backtest.periods_without_mape:
+            parts.append("every held-out period was zero, so a percentage error says nothing")
 
     if backtest.mase is not None:
-        verdict = "better" if backtest.beats_no_change else "no better"
-        parts.append(f"MASE {backtest.mase:.2f}, {verdict} than assuming no change")
+        parts.append(
+            f"MASE {backtest.mase:.2f}"
+            " (error relative to a one-step no-change baseline on the training history)"
+        )
 
     return ", ".join(parts)
 
@@ -208,8 +233,12 @@ def _backtest(periods: pd.DatetimeIndex, values: np.ndarray, *, monthly: bool) -
     )
 
     holdout_periods = periods[-holdout:]
-    horizon_positions = line.future_positions(holdout)
-    predicted = line.at(horizon_positions) + _seasonal_adjustment(
+    # The held-out periods sit where the calendar puts them, not at the next
+    # consecutive slots after training: a missing month inside the holdout
+    # would otherwise shift every later prediction one period early. The
+    # positions share the training origin because both start at periods[0].
+    holdout_positions = period_positions(periods)[-holdout:]
+    predicted = line.at(holdout_positions) + _seasonal_adjustment(
         holdout_periods.month.to_numpy(), seasonal
     )
     if float(train_values.min()) >= 0:
@@ -220,19 +249,31 @@ def _backtest(periods: pd.DatetimeIndex, values: np.ndarray, *, monthly: bool) -
     errors = np.abs(predicted - actual)
 
     measurable = np.abs(actual) > 1e-9
-    mape = (
-        round(float(np.mean(errors[measurable] / np.abs(actual[measurable])) * 100), 1)
-        if measurable.any()
-        else None
-    )
+    mape = _percentage_error(errors, actual, measurable)
 
-    # A no-change forecast is the bar any baseline has to clear.
+    # The textbook MASE denominator: how far the series moved between
+    # consecutive periods over the training history. It says how large the
+    # holdout error is in the series' own units of movement, not whether a
+    # no-change forecast would have done better on these particular periods.
     no_change_error = float(np.mean(np.abs(np.diff(train_values))))
     mase = round(float(np.mean(errors) / no_change_error), 2) if no_change_error > 0 else None
+
+    # The contest MASE is often mistaken for: carry the last training value
+    # across the holdout and score it on exactly the same periods.
+    naive_errors = np.abs(np.full(holdout, train_values[-1]) - actual)
+    holdout_naive_mape = _percentage_error(naive_errors, actual, measurable)
 
     return Backtest(
         mape=mape,
         mase=mase,
         holdout_periods=holdout,
         periods_without_mape=int((~measurable).sum()),
+        holdout_naive_mape=holdout_naive_mape,
     )
+
+
+def _percentage_error(errors: np.ndarray, actual: np.ndarray, measurable: np.ndarray) -> float | None:
+    """Mean absolute percentage error over the periods far enough from zero to have one."""
+    if not measurable.any():
+        return None
+    return round(float(np.mean(errors[measurable] / np.abs(actual[measurable])) * 100), 1)

--- a/forecasting.py
+++ b/forecasting.py
@@ -31,7 +31,13 @@ from dataclasses import dataclass
 import numpy as np
 import pandas as pd
 
-from timeseries import fit_trendline, period_grain, period_positions, robust_scale
+from timeseries import (
+    fit_trendline,
+    observed_periods,
+    period_grain,
+    period_positions,
+    robust_scale,
+)
 
 MIN_PERIODS = 8
 MIN_SEASONAL_PERIODS = 18
@@ -154,7 +160,13 @@ def build_forecast(
     min_periods: int = MIN_PERIODS,
 ) -> Forecast | None:
     """Forecast the next periods, or return None when history is too thin."""
-    if trend.empty or not {"Period", "Value"}.issubset(trend.columns) or len(trend) < min_periods:
+    if trend.empty or not {"Period", "Value"}.issubset(trend.columns):
+        return None
+    # Unobserved periods are NaN by design (see aggregation's calendar rules).
+    # Dropped BEFORE the length check, so "enough history" counts periods that
+    # were actually measured rather than blanks the fit cannot use anyway.
+    trend = observed_periods(trend)
+    if len(trend) < min_periods:
         return None
 
     periods = pd.DatetimeIndex(pd.to_datetime(trend["Period"]))

--- a/formatting.py
+++ b/formatting.py
@@ -97,6 +97,24 @@ def percentage_outranks_currency(column: str | None) -> bool:
     return bool(words) and words[-1] in PERCENTAGE_TOKENS
 
 
+def rate_scale(column_values: pd.Series | None, value: float = 0.0) -> str:
+    """Whether a rate column stores fractions (0.25) or points (25)."""
+    return "fraction" if _percentage_uses_fraction_scale(value, column_values) else "points"
+
+
+def format_rate_change(delta: float, column_values: pd.Series | None) -> str:
+    """A change in a rate is a number of percentage points, not a percentage.
+
+    20% to 40% is twenty points, or a hundred percent relative. Saying
+    "increased by 20%" for that is ambiguous at best and wrong on the relative
+    reading, so the unit is always spelt out.
+    """
+    if not np.isfinite(delta):
+        return "an unmeasurable amount"
+    points = delta * 100 if rate_scale(column_values, delta) == "fraction" else delta
+    return f"{abs(points):.1f} percentage points"
+
+
 def _column_reads_as_percentage(value: float, column_values: pd.Series | None) -> bool:
     """Judge plausibility once for the column, not once per value.
 

--- a/metrics.py
+++ b/metrics.py
@@ -1,0 +1,88 @@
+"""What a measure is, decided once and consumed everywhere.
+
+The rate change fixed the headline, then the trend, then chat, and each
+surface disagreed with the next about whether a rate adds up. It does not:
+two months of conversion rate do not sum to anything, a segment's share of
+"total conversion rate" is not a share of anything, and a waterfall of
+changes in segment averages does not reconcile to the change in the overall
+average. So the decision is made here, once, and every surface asks for it
+rather than inferring it again from the column name.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from formatting import is_percentage, normalized_name, percentage_outranks_currency
+
+# A measure where going up is bad. Whole-word: "Cost" and "Refund Amount"
+# count, "Cost Savings" does not.
+ADVERSE_MEASURE_TOKENS = frozenset({
+    "cost", "costs", "expense", "expenses", "spend", "churn", "refund", "refunds",
+    "returns", "loss", "losses", "overdue", "delay", "delays", "hours", "tickets",
+    "complaints", "defects", "errors", "bounce", "debt", "outstanding",
+})
+# A measure whose first word settles it as good news whatever follows:
+# "Revenue After Returns" is revenue.
+FAVOURABLE_MEASURE_TOKENS = frozenset({
+    "revenue", "sales", "profit", "income", "margin", "bookings", "mrr", "arr", "gmv",
+    "orders", "units", "conversion", "conversions", "retention", "signups", "leads",
+})
+FAVOURABLE_OVERRIDES = frozenset({"savings", "saved", "recovered", "avoided"})
+
+
+def increase_is_welcome(measure: str | None) -> bool:
+    """Whether a rise in this measure is good news.
+
+    The first word decides when it is itself a known measure -- "Revenue After
+    Returns" is revenue, "Refund Amount" is a refund. Otherwise the head noun
+    decides: "Customer Acquisition Cost" is a cost. A word in the middle is a
+    qualifier and does not flip the reading.
+    """
+    if not measure:
+        return True
+    words = normalized_name(measure).split()
+    if not words or any(word in FAVOURABLE_OVERRIDES for word in words):
+        return True
+    first, last = words[0], words[-1]
+    if first in FAVOURABLE_MEASURE_TOKENS:
+        return True
+    if first in ADVERSE_MEASURE_TOKENS:
+        return False
+    return last not in ADVERSE_MEASURE_TOKENS
+
+
+@dataclass(frozen=True)
+class MetricSpec:
+    """How a measure combines, and what may be said about it."""
+
+    name: str | None
+    aggregation: str  # sum | mean | count
+    unit: str  # amount | rate | count
+    increase_is_welcome: bool
+
+    @property
+    def additive(self) -> bool:
+        """Whether parts add up to the whole.
+
+        Only then do shares of a total, a concentration index or a waterfall
+        of segment changes mean anything. A rate is an average of averages.
+        """
+        return self.aggregation != "mean"
+
+    @property
+    def combines_as(self) -> str:
+        return {"sum": "total", "mean": "average", "count": "count"}[self.aggregation]
+
+
+def resolve_metric(name: str | None) -> MetricSpec:
+    """The one place a column name becomes a decision about arithmetic."""
+    if not name:
+        return MetricSpec(name=None, aggregation="count", unit="count", increase_is_welcome=True)
+    if is_percentage(name) and percentage_outranks_currency(name):
+        return MetricSpec(
+            name=name, aggregation="mean", unit="rate", increase_is_welcome=increase_is_welcome(name)
+        )
+    return MetricSpec(
+        name=name, aggregation="sum", unit="amount", increase_is_welcome=increase_is_welcome(name)
+    )

--- a/nlq.py
+++ b/nlq.py
@@ -389,11 +389,21 @@ def _take_mentions(
         pattern = rf"\b{re.escape(normalized)}\b"
         if kind == "value" and len(normalized) < SHORT_VALUE:
             pattern = rf"\b(?:{'|'.join(GROUNDING_WORDS)}) {re.escape(normalized)}\b"
-        if kind == "value" and normalized in claimed_values and claimed_values[normalized] != column:
-            # The same label lives in two columns; whichever this question
-            # means, filtering the other is wrong, and both is wrong too.
-            if re.search(pattern, spans.text):
-                return columns, None
+        if kind == "value" and normalized in claimed_values:
+            if claimed_values[normalized] != column:
+                # The same label lives in two columns; whichever this question
+                # means, filtering the other is wrong, and both is wrong too.
+                if re.search(pattern, spans.text):
+                    return columns, None
+                continue
+            # SAME column, different raw spelling: "West" and "west" are two
+            # values that normalize to one word. The first took the span, so
+            # the second finds nothing left to claim and used to be dropped -
+            # which filtered half the matching rows and reported the answer as
+            # though it were the whole. The word was already claimed FOR this
+            # column, so every raw spelling behind it belongs in the filter.
+            if column in values and value is not None and value not in values[column]:
+                values[column].append(value)
             continue
         if kind == "column" and normalized in GRAMMAR_WORDS:
             # "how many rows by Rows": the column called Rows is the one

--- a/nlq.py
+++ b/nlq.py
@@ -13,10 +13,12 @@ import re
 from dataclasses import dataclass
 from typing import Literal
 
+import numpy as np
 import pandas as pd
 
 from aggregation import TrendSeries, build_trend, measure_aggregation, preferred_frequency, unlabelled_label
-from formatting import format_number
+from formatting import format_number, format_period, rate_scale
+from metrics import resolve_metric
 from schema import ColumnRoles
 
 Intent = Literal["aggregate", "count", "rank", "breakdown", "trend", "growth"]
@@ -135,6 +137,8 @@ class QueryPlan:
     filters: tuple[ValueFilter, ...] = ()
     year: int | None = None
     month: int | None = None
+    day: int | None = None
+    quarter: int | None = None
     grain: str | None = None
     source: str = "rules"
 
@@ -152,6 +156,7 @@ class QueryAnswer:
 def _norm(text: str) -> str:
     lowered = str(text).lower().replace("’", "'")
     lowered = re.sub(r"\b([a-z]+)'(s|re|ve|ll|d|m|t)\b", r"\1", lowered)
+    lowered = re.sub(r"\b(\d{1,2})(st|nd|rd|th)\b", r"\1", lowered)
     cleaned = re.sub(r"[^0-9a-z]+", " ", lowered)
     return " ".join(cleaned.split())
 
@@ -160,6 +165,9 @@ def _word_variants(normalized_name: str) -> set[str]:
     variants = {normalized_name, f"{normalized_name}s", f"{normalized_name}es"}
     if normalized_name.endswith("s"):
         variants.add(normalized_name[:-1])
+    if normalized_name.endswith("y"):
+        # "how many countries" asks about the Country column.
+        variants.add(f"{normalized_name[:-1]}ies")
     return variants
 
 
@@ -171,67 +179,306 @@ def _mentioned(normalized_name: str, question: str) -> bool:
     )
 
 
-def _match_column(question: str, columns: list[str]) -> str | None:
-    """Return the column with the longest name mentioned in the question."""
-    matches = [column for column in columns if _mentioned(_norm(column), question)]
-    return max(matches, key=lambda column: len(_norm(column))) if matches else None
-
-
 def _named_like_a_key(name: str) -> bool:
     words = _norm(name).split()
     return bool(words) and (words[-1] in KEY_WORDS or words == ["id"])
 
 
-def _match_countable(question: str, roles: ColumnRoles, dataframe: pd.DataFrame | None = None) -> str | None:
-    """Match 'how many <entities>' to an identifier, key-named or dimension column.
+class _Spans:
+    """The stretches of a normalized question that something has claimed.
+
+    A plan is accepted only once every meaningful span is claimed: by a
+    column, a value, a date, a number the plan uses, or a word of the
+    grammar. What is left over is what the plan would have silently
+    ignored, and a question with an ignored part is refused rather than
+    answered as a different, easier question.
+    """
+
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.taken: list[tuple[int, int]] = []
+
+    def _free(self, start: int, end: int) -> bool:
+        return all(end <= taken_start or start >= taken_end for taken_start, taken_end in self.taken)
+
+    def take(self, pattern: str) -> re.Match[str] | None:
+        """Claim the first free match of the pattern, or None."""
+        for match in re.finditer(pattern, self.text):
+            if match.end() > match.start() and self._free(*match.span()):
+                self.taken.append(match.span())
+                return match
+        return None
+
+    def take_all(self, pattern: str) -> list[re.Match[str]]:
+        found: list[re.Match[str]] = []
+        while (match := self.take(pattern)) is not None:
+            found.append(match)
+        return found
+
+    def leftover(self) -> str:
+        characters = list(self.text)
+        for start, end in self.taken:
+            characters[start:end] = " " * (end - start)
+        return " ".join("".join(characters).split())
+
+
+BREAKDOWN_PATTERN = r"\b(by|per|across|breakdown|split|each)\b"
+COUNT_PATTERN = r"\b(how many|count|number of)\b"
+TOP_PATTERN = r"\b(top|bottom)\s+(\d{1,3})\b"
+# A one- or two-character value ("UK", "A") is only read as a filter when a
+# preposition grounds it; on its own it is as likely to be a stray word.
+SHORT_VALUE = 3
+GROUNDING_WORDS = ("for", "in", "of", "at", "from", "to", "on", "within", "is", "equals")
+YEAR_PATTERN = r"(1[89]\d{2}|2[0-2]\d{2})"
+MONTH_PATTERN = "|".join(re.escape(name) for name in MONTH_NAMES)
+ORDINAL_QUARTERS = {"first": 1, "second": 2, "third": 3, "fourth": 4}
+
+# Words the grammar itself supplies. Anything else left unclaimed in a
+# question is a part of it the plan cannot carry.
+GRAMMAR_WORDS = frozenset(
+    set(QUERY_STOPWORDS)
+    | set(AGGREGATION_WORDS)
+    | set(ASCENDING_WORDS)
+    | set(SUPERLATIVE_WORDS)
+    | set(DECLINE_WORDS)
+    | set(GROWTH_WORDS)
+    | set(GRAIN_WORDS)
+    | set(MONTH_NAMES)
+    | {word for phrase in TREND_WORDS for word in phrase.split()}
+    | {
+        "amount", "any", "as", "been", "breakdown", "count", "did", "different", "distinct",
+        "down", "fastest", "few", "figure", "figures", "find", "get", "give", "group", "grouped",
+        "groups", "had", "has", "list", "most", "much", "number", "only", "order", "ordered", "over",
+        "per", "rank", "ranked", "ranking", "record", "records", "row", "rows", "sells", "so",
+        "sold", "sort", "sorted", "split", "those", "these", "them", "their", "its", "time",
+        "top", "trajectory", "trend", "unique", "up", "value", "values", "was", "were",
+    }
+)
+
+
+@dataclass(frozen=True)
+class TimeScope:
+    year: int | None = None
+    month: int | None = None
+    day: int | None = None
+    quarter: int | None = None
+
+
+@dataclass(frozen=True)
+class Mentions:
+    """Everything in the question that names a part of the dataset."""
+
+    measure: str | None
+    dimension: str | None
+    countable: str | None
+    # An entity named without "how many": the customers in "top 5 customers
+    # by revenue", ranked one per identifier.
+    entity: str | None
+    filters: tuple[ValueFilter, ...]
+    when: TimeScope
+    date_mentioned: bool
+    wants_count: bool
+
+
+def _take_time_scope(spans: _Spans) -> TimeScope | None:
+    """Claim the dates in the question, or None when they cannot be one scope."""
+    year = month = day = quarter = None
+    iso = spans.take(rf"\b{YEAR_PATTERN} (\d{{1,2}}) (\d{{1,2}})\b")
+    if iso:
+        year, month, day = int(iso.group(1)), int(iso.group(2)), int(iso.group(3))
+    named = spans.take(rf"\b({MONTH_PATTERN}) (\d{{1,2}})\b") or spans.take(
+        rf"\b(\d{{1,2}}) (?:of )?({MONTH_PATTERN})\b"
+    )
+    if named:
+        if month is not None:
+            return None
+        first, second = named.groups()
+        name, number = (first, second) if first.isalpha() else (second, first)
+        month, day = MONTH_NAMES[name], int(number)
+    months = spans.take_all(rf"\b({MONTH_PATTERN})\b")
+    if months:
+        if month is not None or len(months) > 1:
+            return None
+        month = MONTH_NAMES[months[0].group(1)]
+    for pattern in (r"\bq([1-4])\b", r"\bquarter ([1-4])\b", r"\b([1-4]) quarter\b"):
+        found = spans.take(pattern)
+        if found:
+            if quarter is not None:
+                return None
+            quarter = int(found.group(1))
+    ordinal = spans.take(r"\b(first|second|third|fourth) quarter\b")
+    if ordinal:
+        if quarter is not None:
+            return None
+        quarter = ORDINAL_QUARTERS[ordinal.group(1)]
+    years = spans.take_all(rf"\b{YEAR_PATTERN}\b")
+    if years:
+        if year is not None or len(years) > 1:
+            return None
+        year = int(years[0].group(1))
+    if month is not None and not 1 <= month <= 12:
+        return None
+    if day is not None and (month is None or not 1 <= day <= 31):
+        return None
+    if quarter is not None and month is not None:
+        return None
+    return TimeScope(year=year, month=month, day=day, quarter=quarter)
+
+
+def _take_countable(spans: _Spans, roles: ColumnRoles, dataframe: pd.DataFrame) -> str | None:
+    """Claim 'customers' in "how many customers" for a Customer ID column.
 
     A Customer ID that repeats is not unique enough to be the identifier
     role, but "how many customers" still means distinct customers.
     """
-    keyed = [
-        column for column in (dataframe.columns if dataframe is not None else ())
-        if _named_like_a_key(str(column))
-    ]
+    keyed = [column for column in dataframe.columns if _named_like_a_key(str(column))]
     candidates = [column for column in (roles.identifier, *keyed, *roles.dimensions) if column]
     for column in candidates:
-        tokens = {_norm(column), _norm(column).split(" ")[0]}
-        if any(_mentioned(token, question) for token in tokens if token):
-            return column
+        normalized = _norm(column)
+        first_word = normalized.split(" ")[0]
+        for token in (normalized, first_word):
+            if not token or token in KEY_WORDS:
+                continue
+            for variant in sorted(_word_variants(token), key=len, reverse=True):
+                if spans.take(rf"\b{re.escape(variant)}\b"):
+                    return column
     return None
 
 
-def _detect_value_filters(
-    question: str,
-    dataframe: pd.DataFrame,
-    roles: ColumnRoles,
-    *,
-    exclude: tuple[str | None, ...] = (),
-) -> tuple[ValueFilter, ...]:
-    filters: list[ValueFilter] = []
+def _take_mentions(
+    spans: _Spans, dataframe: pd.DataFrame, roles: ColumnRoles
+) -> tuple[list[tuple[str, int]], tuple[ValueFilter, ...] | None]:
+    """Claim every column name and dimension value, longest span first.
+
+    "New York" is claimed before "York" can be, and "West Region" before
+    "Region", so a shorter name never steals part of a longer one. Returns
+    the columns with where they were found, and the value filters -- or
+    None for the filters when one value belongs to two columns and the
+    question does not say which.
+    """
+    candidates: list[tuple[str, str, str, str | None]] = []
+    for column in dataframe.columns:
+        name = _norm(column)
+        if name:
+            for variant in _word_variants(name):
+                candidates.append((variant, "column", str(column), None))
     for column in roles.dimensions:
-        if column in exclude or column not in dataframe.columns:
+        if column not in dataframe.columns:
             continue
         uniques = dataframe[column].dropna().unique()
         if len(uniques) > MAX_FILTER_CANDIDATES:
             continue
-        matched = [
-            str(value)
-            for value in uniques
-            if len(_norm(value)) >= 3 and _mentioned(_norm(value), question)
-        ]
-        if matched:
-            filters.append(ValueFilter(column=column, values=tuple(matched)))
-    return tuple(filters)
+        for value in uniques:
+            normalized = _norm(value)
+            if normalized and normalized not in GRAMMAR_WORDS:
+                candidates.append((normalized, "value", column, str(value)))
+    # Columns named after a grammar word ("Total", "Count", "Year") are matched
+    # last, so they only claim the word when nothing else in the question does.
+    candidates.sort(key=lambda item: (item[1] == "column" and item[0] in GRAMMAR_WORDS, -len(item[0])))
+
+    columns: list[tuple[str, int]] = []
+    seen: set[str] = set()
+    values: dict[str, list[str]] = {}
+    claimed_values: dict[str, str] = {}
+    for normalized, kind, column, value in candidates:
+        pattern = rf"\b{re.escape(normalized)}\b"
+        if kind == "value" and len(normalized) < SHORT_VALUE:
+            pattern = rf"\b(?:{'|'.join(GROUNDING_WORDS)}) {re.escape(normalized)}\b"
+        if kind == "value" and normalized in claimed_values and claimed_values[normalized] != column:
+            # The same label lives in two columns; whichever this question
+            # means, filtering the other is wrong, and both is wrong too.
+            if re.search(pattern, spans.text):
+                return columns, None
+            continue
+        matches = spans.take_all(pattern)
+        if not matches:
+            continue
+        if kind == "column":
+            if column not in seen:
+                seen.add(column)
+                columns.append((column, matches[0].start()))
+        else:
+            claimed_values[normalized] = column
+            values.setdefault(column, []).append(value)  # type: ignore[arg-type]
+    filters = tuple(ValueFilter(column=column, values=tuple(found)) for column, found in values.items())
+    return columns, filters
 
 
-def _detect_time_filter(question: str) -> tuple[int | None, int | None]:
-    year_match = re.search(r"\b(19|20)\d{2}\b", question)
-    year = int(year_match.group()) if year_match else None
-    month = next(
-        (number for name, number in MONTH_NAMES.items() if re.search(rf"\b{name}\b", question)),
-        None,
+def _resolve_mentions(
+    spans: _Spans, dataframe: pd.DataFrame, roles: ColumnRoles
+) -> Mentions | None:
+    """Decide what the question's columns, values and dates refer to.
+
+    None means the question names more than the plan can hold -- two
+    metrics, two grouping columns, two months -- and must not be answered
+    as though it named one.
+    """
+    q = spans.text
+    columns, filters = _take_mentions(spans, dataframe, roles)
+    if filters is None:
+        return None
+    when = _take_time_scope(spans)
+    if when is None:
+        return None
+
+    numeric_columns = set(roles.numeric)
+    dimension_columns = set(roles.dimensions)
+    measures = [column for column, _ in columns if column in numeric_columns]
+    if len(measures) > 1:
+        # "total Revenue" in a file with a Total column: the grammar word wins.
+        measures = [column for column in measures if _norm(column) not in GRAMMAR_WORDS]
+    if len(measures) > 1:
+        return None
+    measure = measures[0] if measures else None
+    date_mentioned = any(column == roles.date for column, _ in columns)
+
+    breakdown = re.search(BREAKDOWN_PATTERN, q)
+    grouped = [
+        column for column, start in columns
+        if column in dimension_columns and breakdown is not None and start > breakdown.start()
+    ]
+    leading = [
+        column for column, start in columns
+        if column in dimension_columns and (breakdown is None or start < breakdown.start())
+    ]
+    wants_count = bool(re.search(COUNT_PATTERN, q))
+    if not wants_count and leading and grouped and measure is None:
+        # "customers by region" with no metric is a count of one by the other.
+        wants_count = True
+    countable = entity = None
+    if wants_count:
+        if leading:
+            countable, leading = leading[0], leading[1:]
+        else:
+            countable = _take_countable(spans, roles, dataframe)
+    else:
+        entity = _take_countable(spans, roles, dataframe)
+        if entity is not None and measure is None and (breakdown is not None or not (grouped or leading)):
+            # "customers by region" is a count of one by the other.
+            wants_count, countable, entity = True, entity, None
+    dimensions = grouped + leading
+    if len(dimensions) > 1:
+        return None
+    return Mentions(
+        measure=measure,
+        dimension=dimensions[0] if dimensions else None,
+        countable=countable,
+        entity=entity if entity not in dimensions else None,
+        filters=filters,
+        when=when,
+        date_mentioned=date_mentioned,
+        wants_count=wants_count,
     )
-    return year, month
+
+
+def _scope_grain(when: TimeScope) -> str | None:
+    if when.quarter is not None:
+        return "quarter"
+    if when.month is not None:
+        return "month"
+    if when.year is not None:
+        return "year"
+    return None
 
 
 def _detect_grain(question: str) -> str | None:
@@ -241,64 +488,13 @@ def _detect_grain(question: str) -> str | None:
     return None
 
 
-def _unrecognized_query_tokens(
-    question: str, dataframe: pd.DataFrame, roles: ColumnRoles
-) -> set[str]:
-    """Return content words that cannot refer to this dataset or query grammar."""
-    allowed = set(QUERY_STOPWORDS)
-    allowed.update(AGGREGATION_WORDS)
-    allowed.update(ASCENDING_WORDS)
-    allowed.update(SUPERLATIVE_WORDS)
-    allowed.update(DECLINE_WORDS)
-    allowed.update(GROWTH_WORDS)
-    allowed.update(GRAIN_WORDS)
-    allowed.update(MONTH_NAMES)
-    allowed.update(
-        {
-            "bottom",
-            "count",
-            "breakdown",
-            "fastest",
-            "history",
-            "number",
-            "per",
-            "rows",
-            "sells",
-            "split",
-            "sold",
-            "top",
-            "trajectory",
-            "trend",
-            "over",
-            "time",
-            "timeline",
-        }
-    )
-
-    for column in dataframe.columns:
-        normalized = _norm(column)
-        allowed.update(normalized.split())
-        allowed.update(_word_variants(normalized))
-        first_word = normalized.split(" ", 1)[0]
-        allowed.update(_word_variants(first_word))
-
-    for column in roles.dimensions:
-        if column not in dataframe.columns:
-            continue
-        unique_values = dataframe[column].dropna().astype(str).unique()
-        if len(unique_values) <= MAX_FILTER_CANDIDATES:
-            for value in unique_values:
-                allowed.update(_norm(value).split())
-
-    return {token for token in question.split() if token.isalpha() and token not in allowed}
-
-
 # Phrasings the grammar cannot represent. Answering them with the nearest
 # supported question -- "revenue > 200" as the total of everything, "January
-# and February" as January -- is a precise answer to a question nobody asked.
-# Refusing hands them to the optional planner, or to the suggestion chips.
-# Comparison operators are checked on the raw text, because _norm strips them.
-UNSUPPORTED_OPERATORS = re.compile(r"[<>=\u2265\u2264\u2260]")
+# and February" as January, "Revenue / Profit" as Revenue -- is a precise
+# answer to a question nobody asked. Refusing hands them to the optional
+# planner, or to the suggestion chips. Operators are checked on the raw text,
+# because _norm strips them.
+UNSUPPORTED_OPERATORS = re.compile(r"[<>=≥≤≠+*×÷]|\s-\s|(?<=[A-Za-z)])\s*/\s*(?=[A-Za-z(])")
 UNSUPPORTED_PHRASES = re.compile(
     r"\b(?:"
     r"greater than|less than|more than \d+|fewer than|at least \d+|at most \d+|"
@@ -306,6 +502,8 @@ UNSUPPORTED_PHRASES = re.compile(
     r"this (?:year|month|quarter|week)|last (?:year|month|quarter|week|\d+ (?:days|weeks|months|years))|"
     r"next (?:year|month|quarter|week)|previous (?:year|month|quarter|week)|"
     r"year to date|ytd|today|yesterday|past \d+|"
+    r"minus|plus|divided by|multiplied by|times|ratio of|difference between|"
+    r"versus|vs|compared (?:to|with)|comparison|"
     r"or"
     r")\b"
 )
@@ -314,7 +512,7 @@ UNSUPPORTED_PHRASES = re.compile(
 def _asks_for_several_periods(q: str) -> bool:
     """Two months or two years in one question is a set the plan cannot hold."""
     months = {MONTH_NAMES[name] for name in MONTH_NAMES if re.search(rf"\b{name}\b", q)}
-    years = set(re.findall(r"\b(?:19|20)\d{2}\b", q))
+    years = set(re.findall(rf"\b{YEAR_PATTERN}\b", q))
     return len(months) >= 2 or len(years) >= 2
 
 
@@ -327,76 +525,140 @@ def unsupported_phrasing(question: str) -> bool:
     )
 
 
+def question_is_representable(question: str, dataframe: pd.DataFrame, roles: ColumnRoles) -> bool:
+    """Whether any QueryPlan could hold this question at all.
+
+    The optional planner is asked only questions the plan shape can carry.
+    Otherwise it picks one of two metrics, or one of two months, and the
+    approval sentence describes a different question from the one asked.
+    """
+    q = _norm(question)
+    if not q or unsupported_phrasing(question):
+        return False
+    return _resolve_mentions(_Spans(q), dataframe, roles) is not None
+
+
+def plan_accounts_for_numbers(question: str, plan: QueryPlan) -> bool:
+    """Every number in the question has to show up somewhere in the plan.
+
+    A plan that reads "Revenue 2024-01-31" as January 2024 has dropped the
+    31, and with it the question.
+    """
+    q = _norm(question)
+    numbers = {int(token) for token in re.findall(r"\b\d+\b", q)}
+    quarters = {int(token) for token in re.findall(r"\bq([1-4])\b", q)}
+    known = {plan.year, plan.month, plan.day, plan.quarter, plan.top_n}
+    for value_filter in plan.filters:
+        for value in value_filter.values:
+            known.update(int(token) for token in re.findall(r"\b\d+\b", _norm(value)))
+    return numbers <= {number for number in known if number is not None} and (
+        not quarters or plan.quarter in quarters
+    )
+
+
 def parse_question(question: str, dataframe: pd.DataFrame, roles: ColumnRoles) -> QueryPlan | None:
     """Turn a plain-English question into an explicit plan, or None if unsupported."""
     q = _norm(question)
     if not q or unsupported_phrasing(question):
         return None
 
-    numeric_columns = [column for column in roles.numeric if column in dataframe.columns]
-    dimension_columns = [column for column in roles.dimensions if column in dataframe.columns]
-
-    measure = _match_column(q, numeric_columns)
-    dimension = _match_column(q, dimension_columns)
-    if _unrecognized_query_tokens(q, dataframe, roles):
+    spans = _Spans(q)
+    mentions = _resolve_mentions(spans, dataframe, roles)
+    if mentions is None:
         return None
-    year, month = _detect_time_filter(q)
-    grain = _detect_grain(q)
-    # For a grouped answer the matched dimension is the thing being grouped,
-    # so its values are not read as filters. For a plain total they are:
-    # "revenue for Region West" is a filter, and naming the column must not
-    # steal the value from it -- that answered with the all-region total.
-    filters = _detect_value_filters(q, dataframe, roles, exclude=(dimension,))
-    filters_including_dimension = _detect_value_filters(q, dataframe, roles)
+    top_match = spans.take(TOP_PATTERN)
+    if top_match and int(top_match.group(2)) < 1:
+        # "top 0" is not a ranking; it was showing the fallback twelve.
+        return None
+    # Whatever is left must be grammar. A number nobody claimed, or a word
+    # that is neither a column, a value nor part of the grammar, is a part
+    # of the question the plan would have ignored.
+    for token in spans.leftover().split():
+        if not token.isalpha() or token not in GRAMMAR_WORDS:
+            return None
 
+    measure, dimension, when = mentions.measure, mentions.dimension, mentions.when
+    if dimension is None and top_match and mentions.entity:
+        # "top 5 customers by revenue" ranks one row per customer.
+        dimension = mentions.entity
+    grain = _detect_grain(q)
+    if grain is not None and grain == {"quarter": "Q", "month": "M", "year": "Y"}.get(_scope_grain(when)):
+        # "first quarter" names a period to look inside, not a grain to
+        # draw a timeline at.
+        grain = None
     aggregation: Aggregation | None = next(
         (AGGREGATION_WORDS[word] for word in AGGREGATION_WORDS if re.search(rf"\b{word}\b", q)),
         None,
     )
-    top_match = re.search(r"\b(top|bottom)\s+(\d{1,3})\b", q)
-    if top_match and int(top_match.group(2)) < 1:
-        # "top 0" is not a ranking; it was showing the fallback twelve.
-        return None
     # "highest" and "largest" rank; only the literal words ask for an extreme
     # per group. Both live in AGGREGATION_WORDS as max, so they are told apart
     # here rather than by silently downgrading every min/max to a sum.
     explicit_extreme = bool(re.search(r"\b(min|minimum|max|maximum)\b", q))
     superlative = any(re.search(rf"\b{word}\b", q) for word in SUPERLATIVE_WORDS)
-    wants_breakdown = bool(re.search(r"\b(by|per|across|breakdown|split|each)\b", q))
-    wants_count = bool(re.search(r"\b(how many|count|number of)\b", q))
+    wants_breakdown = bool(re.search(BREAKDOWN_PATTERN, q))
     wants_growth = any(re.search(rf"\b{word}\b", q) for word in GROWTH_WORDS)
-    wants_trend = grain is not None or any(phrase in q for phrase in TREND_WORDS)
+    wants_trend = (
+        grain is not None
+        or any(phrase in q for phrase in TREND_WORDS)
+        or (mentions.date_mentioned and wants_breakdown and dimension is None)
+    )
+    if dimension is not None and dimension == measure:
+        return None
 
     base = {
         "measure": measure or roles.measure,
-        "filters": filters,
-        "year": year,
-        "month": month,
+        "filters": mentions.filters,
+        "year": when.year,
+        "month": when.month,
+        "day": when.day,
+        "quarter": when.quarter,
         "grain": grain,
     }
-
-    ungrouped = {**base, "filters": filters_including_dimension}
     # Chat combines a measure the way the dashboard does: rates average,
     # amounts add. Saying "total" or "sum" out loud still gets a sum.
     default_aggregation = measure_aggregation(base["measure"])
 
-    if wants_count and not wants_growth:
-        countable = _match_countable(q, roles, dataframe)
-        if dimension and wants_breakdown:
+    if (wants_growth or wants_trend) and not roles.date and not mentions.wants_count:
+        # Not a total in disguise: the executor explains that there is no
+        # timeline to measure this over.
+        return QueryPlan(intent="growth" if wants_growth else "trend", **base)
+
+    if mentions.wants_count and not wants_growth:
+        countable = mentions.countable
+        counted = {**base, "measure": None}
+        if wants_trend and roles.date:
+            return QueryPlan(intent="trend", aggregation="count", count_column=countable, **counted)
+        if dimension and top_match:
+            return QueryPlan(
+                intent="rank", aggregation="count", dimension=dimension,
+                top_n=int(top_match.group(2)), ascending=top_match.group(1) == "bottom",
+                count_column=countable if countable != dimension else None, **counted,
+            )
+        if dimension and (wants_breakdown or superlative):
             return QueryPlan(
                 intent="breakdown", aggregation="count", dimension=dimension,
-                count_column=countable if countable != dimension else None, **base,
+                count_column=countable if countable != dimension else None, **counted,
             )
-        return QueryPlan(intent="count", aggregation="count", count_column=countable, **ungrouped)
+        return QueryPlan(intent="count", aggregation="count", count_column=countable, **counted)
 
     if wants_growth and roles.date:
+        if aggregation not in (None, default_aggregation):
+            # Growth is measured on periods combined the way the measure
+            # combines. "Average revenue growth" would be growth of sums.
+            return None
         wants_ranked_growth = superlative or any(word in q for word in ("which", "fastest", "slowest"))
         rank_dimension = dimension or (roles.dimension if wants_ranked_growth else None)
         ascending = bool(re.search(ASCENDING_PATTERN, q))
         top_n = int(top_match.group(2)) if top_match else None
         return QueryPlan(
-            intent="growth", dimension=rank_dimension, ascending=ascending, top_n=top_n, **base
+            intent="growth", aggregation=default_aggregation, dimension=rank_dimension,
+            ascending=ascending, top_n=top_n, **base,
         )
+
+    if top_match and not dimension:
+        # "top 2 Revenue" ranks nothing: rows or groups, the question does
+        # not say, and the all-time total is neither.
+        return None
 
     if (top_match or superlative) and dimension:
         if top_match:
@@ -421,7 +683,7 @@ def parse_question(question: str, dataframe: pd.DataFrame, roles: ColumnRoles) -
             # so it is not answered here; "average conversion rate monthly"
             # is exactly what the executor does, so it is.
             return None
-        return QueryPlan(intent="trend", aggregation=default_aggregation, **ungrouped)
+        return QueryPlan(intent="trend", aggregation=default_aggregation, **base)
 
     if dimension and (wants_breakdown or not measure):
         return QueryPlan(
@@ -432,7 +694,7 @@ def parse_question(question: str, dataframe: pd.DataFrame, roles: ColumnRoles) -
         )
 
     if base["measure"] and (aggregation or measure):
-        return QueryPlan(intent="aggregate", aggregation=aggregation or default_aggregation, **ungrouped)
+        return QueryPlan(intent="aggregate", aggregation=aggregation or default_aggregation, **base)
 
     return None
 
@@ -464,9 +726,18 @@ MONTH_LABELS = {
 
 
 def _when_label(plan: QueryPlan) -> str:
-    month = MONTH_LABELS.get(plan.month) if plan.month else None
+    if plan.quarter:
+        within = f"Q{plan.quarter}"
+    elif plan.month:
+        within = MONTH_LABELS[plan.month] + (f" {plan.day}" if plan.day else "")
+    else:
+        within = None
     year = str(plan.year) if plan.year else None
-    return " ".join(part for part in (month, year) if part)
+    return " ".join(part for part in (within, year) if part)
+
+
+def _has_time_scope(plan: QueryPlan) -> bool:
+    return any(part is not None for part in (plan.year, plan.month, plan.day, plan.quarter))
 
 
 def _apply_filters(
@@ -480,7 +751,7 @@ def _apply_filters(
         mask = working[value_filter.column].astype(str).isin(value_filter.values)
         working = working.loc[mask]
         applied.append(f"{value_filter.column} in ({', '.join(value_filter.values)})")
-    if plan.year or plan.month:
+    if _has_time_scope(plan):
         if not roles.date or roles.date not in working.columns:
             # Returning the all-time figure under a sentence that names a year
             # is the worst available answer, so the scope is reported as
@@ -490,8 +761,14 @@ def _apply_filters(
         if plan.year:
             working = working.loc[dates.dt.year == plan.year]
             dates = working[roles.date]
+        if plan.quarter:
+            working = working.loc[dates.dt.quarter == plan.quarter]
+            dates = working[roles.date]
         if plan.month:
             working = working.loc[dates.dt.month == plan.month]
+            dates = working[roles.date]
+        if plan.day:
+            working = working.loc[dates.dt.day == plan.day]
         applied.append(f"{roles.date} in {_when_label(plan)}")
     return working, applied
 
@@ -582,6 +859,19 @@ def execute_plan(plan: QueryPlan, dataframe: pd.DataFrame, roles: ColumnRoles) -
     for column in (plan.measure, plan.dimension, plan.count_column):
         if column is not None and column not in dataframe.columns:
             raise ValueError(f"Unknown column in plan: {column}")
+
+    if plan.intent in ("trend", "growth") and not roles.date:
+        subject = plan.measure or "the row count"
+        return QueryAnswer(
+            question="",
+            plan=plan,
+            answer=(
+                f"This file has no date column, so there is no timeline to measure {subject} "
+                "over. If one of the columns holds dates, pick it as the date in the sidebar "
+                "and ask again."
+            ),
+            calculation="no date column; a trend or growth rate needs one",
+        )
 
     try:
         working, applied = _apply_filters(dataframe, plan, roles)
@@ -689,16 +979,19 @@ def execute_plan(plan: QueryPlan, dataframe: pd.DataFrame, roles: ColumnRoles) -
 
     if plan.intent == "trend":
         assert roles.date is not None
+        counted = plan.aggregation == "count"
         scoped_roles = ColumnRoles(
             date=roles.date,
-            measure=plan.measure,
+            measure=None if counted else plan.measure,
             dimension=None,
             identifier=roles.identifier,
             numeric=roles.numeric,
             dimensions=roles.dimensions,
         )
         grain = plan.grain or preferred_frequency(working[roles.date])
-        series = build_trend(working, scoped_roles, frequency=grain)
+        series = build_trend(
+            working, scoped_roles, frequency=grain, count_column=plan.count_column if counted else None
+        )
         trend = series.frame
         if len(trend) < 2:
             return QueryAnswer(
@@ -716,18 +1009,24 @@ def execute_plan(plan: QueryPlan, dataframe: pd.DataFrame, roles: ColumnRoles) -
             if first
             else f"across {len(trend)} {grain_name}s, from a starting period of zero"
         )
+        if counted and plan.count_column:
+            subject, shown_measure = f"Distinct {plan.count_column}", None
+            counted_as = f"count distinct {plan.count_column}"
+        elif counted or not plan.measure:
+            subject, shown_measure, counted_as = "Records", None, "row count"
+        else:
+            subject, shown_measure = plan.measure, plan.measure
+            counted_as = f"{plan.aggregation}({plan.measure})"
         answer = (
-            f"{plan.measure or 'Records'} per {grain_name}{_phrase(applied)} moved from "
-            f"{_shown(first, plan.measure, dataframe)} to {_shown(last, plan.measure, dataframe)} "
+            f"{subject} per {grain_name}{_phrase(applied)} moved from "
+            f"{_shown(first, shown_measure, dataframe)} to {_shown(last, shown_measure, dataframe)} "
             f"({movement})."
         )
         return QueryAnswer(
             question="",
             plan=plan,
             answer=answer,
-            calculation=_with_notes(
-                f"{plan.aggregation}({plan.measure or 'rows'}) grouped per {grain_name}{scope}", series
-            ),
+            calculation=_with_notes(f"{counted_as} grouped per {grain_name}{scope}", series),
             table=trend,
             chart="line",
         )
@@ -766,6 +1065,12 @@ def _execute_growth(
         )
     previous_period, current_period = trend.iloc[-2]["Period"], trend.iloc[-1]["Period"]
 
+    metric = resolve_metric(measure)
+    is_rate = bool(measure) and metric.unit == "rate"
+    # A rate moves in percentage points: 10% to 20% is ten points, and the
+    # "100% growth" the relative formula gives is what nobody means by it.
+    scale = 100.0 if is_rate and rate_scale(working[measure].dropna()) == "fraction" else 1.0
+
     if plan.dimension:
         grain = plan.grain or preferred_frequency(working[roles.date])
         picked = [roles.date, plan.dimension] + ([measure] if measure and measure != plan.dimension else [])
@@ -776,34 +1081,52 @@ def _execute_growth(
         frame = frame.assign(__period=frame["__date"].dt.to_period(grain).dt.to_timestamp())
         frame = frame[frame["__period"].isin([previous_period, current_period])]
         if measure:
-            pivot = (
-                frame.groupby(["__segment", "__period"])["__measure"]
-                .agg(measure_aggregation(measure))
-                .unstack(fill_value=0.0)
-            )
+            pivot = frame.groupby(["__segment", "__period"])["__measure"].agg(metric.aggregation).unstack()
         else:
-            pivot = frame.groupby(["__segment", "__period"]).size().unstack(fill_value=0)
-        if previous_period not in pivot.columns or current_period not in pivot.columns:
+            pivot = frame.groupby(["__segment", "__period"]).size().unstack()
+        if current_period not in pivot.columns:
             return QueryAnswer(
                 question="",
                 plan=plan,
-                answer="The latest two periods do not overlap across segments, so growth cannot be ranked.",
+                answer="The latest period has no rows with a segment label, so growth cannot be ranked.",
                 calculation=f"per-{plan.dimension} growth unavailable{scope}",
             )
+        # A previous period with no rows at all is still a period: the
+        # timeline showed it, so the ranking is measured against it too.
+        pivot = pivot.reindex(columns=[previous_period, current_period])
+        if metric.additive:
+            # No rows in a period is a period of nothing sold: zero.
+            pivot = pivot.fillna(0.0)
+        else:
+            # No rows in a period is no average for that period. A segment
+            # has to be present on both sides to have moved at all.
+            pivot = pivot.dropna(subset=[previous_period, current_period])
+        # The result's own column names are chosen against the dimension's:
+        # a dimension the file calls "Latest" was being overwritten by the
+        # latest-period column, and "100.0 moved fastest" replaced Alpha.
+        taken = {plan.dimension}
+        previous_name = distinct_label("Previous", taken)
+        taken.add(previous_name)
+        latest_name = distinct_label("Latest", taken)
+        taken.add(latest_name)
+        change_name = distinct_label("Change (pp)" if is_rate else "Change %", taken)
         result = pd.DataFrame(
             {
                 plan.dimension: pivot.index,
-                "Previous": pivot[previous_period].to_numpy(dtype=float),
-                "Latest": pivot[current_period].to_numpy(dtype=float),
+                previous_name: pivot[previous_period].to_numpy(dtype=float),
+                latest_name: pivot[current_period].to_numpy(dtype=float),
             }
         )
-        # A percentage from zero is undefined, but a segment that went from
-        # nothing to something is usually the most newsworthy row in the file.
-        # It leaves the ranking and keeps its sentence.
-        from_nothing = result[(result["Previous"] == 0) & (result["Latest"] != 0)]
-        result = result[result["Previous"] != 0]
+        if is_rate:
+            from_nothing = result.iloc[0:0]
+        else:
+            # A percentage from zero is undefined, but a segment that went from
+            # nothing to something is usually the most newsworthy row in the file.
+            # It leaves the ranking and keeps its sentence.
+            from_nothing = result[(result[previous_name] == 0) & (result[latest_name] != 0)]
+            result = result[result[previous_name] != 0]
         if result.empty and not from_nothing.empty:
-            newest = from_nothing.loc[from_nothing["Latest"].abs().idxmax()]
+            newest = from_nothing.loc[from_nothing[latest_name].abs().idxmax()]
             return QueryAnswer(
                 question="",
                 plan=plan,
@@ -811,7 +1134,7 @@ def _execute_growth(
                     f"No {plan.dimension} has a growth rate this period, because every one "
                     f"of them started from zero. The largest new arrival is "
                     f"{newest[plan.dimension]} at "
-                    f"{_shown(float(newest['Latest']), measure, working)}."
+                    f"{_shown(float(newest[latest_name]), measure, working)}."
                 ),
                 calculation=(
                     f"per-{plan.dimension} growth undefined from a zero base; "
@@ -822,60 +1145,108 @@ def _execute_growth(
             return QueryAnswer(
                 question="",
                 plan=plan,
-                answer="Every segment starts from zero in the prior period, so growth rates are undefined.",
+                answer=(
+                    "No segment is present in both of the latest two periods, so there is "
+                    "nothing to compare."
+                    if is_rate
+                    else "Every segment starts from zero in the prior period, so growth rates are undefined."
+                ),
                 calculation=f"per-{plan.dimension} growth undefined{scope}",
             )
-        change = (result["Latest"] - result["Previous"]) / result["Previous"].abs() * 100
-        result["Change %"] = change.round(1)
-        result = result.sort_values("Change %", ascending=plan.ascending).reset_index(drop=True)
+        if is_rate:
+            change = (result[latest_name] - result[previous_name]) * scale
+        else:
+            change = (result[latest_name] - result[previous_name]) / result[previous_name].abs() * 100
+        result[change_name] = change.round(1)
+        result = result.sort_values(change_name, ascending=plan.ascending).reset_index(drop=True)
         if plan.top_n:
             result = result.head(plan.top_n)
         leader = result.iloc[0]
         direction = "slowest" if plan.ascending else "fastest"
+        moved = (
+            f"{leader[change_name]:+.1f} percentage points" if is_rate else f"{leader[change_name]:+.1f}%"
+        )
         answer = (
-            f"{leader[plan.dimension]} moved {direction}{_phrase(applied)}: {leader['Change %']:+.1f}% "
-            f"({_shown(float(leader['Previous']), measure, working)} → "
-            f"{_shown(float(leader['Latest']), measure, working)}) in the latest period."
+            f"{leader[plan.dimension]} moved {direction}{_phrase(applied)}: {moved} "
+            f"({_shown(float(leader[previous_name]), measure, working)} → "
+            f"{_shown(float(leader[latest_name]), measure, working)}) in the latest period."
         )
         if not from_nothing.empty:
-            newest = from_nothing.loc[from_nothing["Latest"].abs().idxmax()]
+            newest = from_nothing.loc[from_nothing[latest_name].abs().idxmax()]
             names = ", ".join(str(name) for name in from_nothing[plan.dimension])
             answer += (
                 f" {len(from_nothing)} segment(s) are left out of the ranking because they "
                 f"started from zero ({names}); the largest is {newest[plan.dimension]} at "
-                f"{_shown(float(newest['Latest']), measure, working)}."
+                f"{_shown(float(newest[latest_name]), measure, working)}."
             )
+        combined = metric.combines_as if measure else "count"
+        ranked_by = "change in percentage points" if is_rate else "% change"
         return QueryAnswer(
             question="",
             plan=plan,
             answer=answer,
             calculation=(
-                f"per-{plan.dimension} {measure or 'row count'}: latest vs previous period, "
-                f"ranked by % change{scope}"
+                f"per-{plan.dimension} {measure or 'row count'} ({combined} per period): latest vs "
+                f"previous period, ranked by {ranked_by}{scope}"
             ),
             table=result.head(BREAKDOWN_LIMIT),
             chart="bar",
         )
 
     previous, current = float(trend.iloc[-2]["Value"]), float(trend.iloc[-1]["Value"])
-    if previous == 0:
+    previous_period = trend.iloc[-2]["Period"]
+    if not (np.isfinite(previous) and np.isfinite(current)):
         return QueryAnswer(
             question="",
             plan=plan,
-            answer="The previous period is zero, so a growth rate is undefined.",
-            calculation=f"growth undefined for zero base{scope}",
+            answer="One of the latest two periods has no measured value, so a change cannot be calculated.",
+            calculation=f"growth undefined: a period is missing its value{scope}",
         )
-    change = (current - previous) / abs(previous) * 100
-    direction = "up" if change >= 0 else "down"
-    answer = (
-        f"{measure or 'Records'}{_phrase(applied)} is {direction} {abs(change):.1f}% versus the prior "
-        f"period ({_shown(previous, measure, working)} → {_shown(current, measure, working)})."
-    )
+    previous_label = format_period(previous_period, series.frequency)
+    if previous == 0 and not is_rate and (
+        working[roles.date].dt.to_period(series.frequency).dt.to_timestamp() == previous_period
+    ).sum() == 0:
+        # The zero is a period with no rows, which the timeline filled in
+        # as zero for an additive metric. Growth from it is undefined, and
+        # the sentence should say why rather than call it a measured zero.
+        return QueryAnswer(
+            question="",
+            plan=plan,
+            answer=(
+                f"{previous_label} has no rows{_phrase(applied)}, so there is no previous value to "
+                f"measure the latest period against."
+            ),
+            calculation=f"growth undefined: {previous_label} is an empty period{scope}",
+        )
+    if is_rate:
+        change = (current - previous) * scale
+        direction = "up" if change >= 0 else "down"
+        answer = (
+            f"{measure}{_phrase(applied)} is {direction} {abs(change):.1f} percentage points versus "
+            f"the prior period ({_shown(previous, measure, working)} → {_shown(current, measure, working)})."
+        )
+        calculation = "latest period average − previous period average, in percentage points"
+    else:
+        if previous == 0:
+            return QueryAnswer(
+                question="",
+                plan=plan,
+                answer="The previous period is zero, so a growth rate is undefined.",
+                calculation=f"growth undefined for zero base{scope}",
+            )
+        change = (current - previous) / abs(previous) * 100
+        direction = "up" if change >= 0 else "down"
+        answer = (
+            f"{measure or 'Records'}{_phrase(applied)} is {direction} {abs(change):.1f}% versus the prior "
+            f"period ({_shown(previous, measure, working)} → {_shown(current, measure, working)})."
+        )
+        combined = "period counts" if not measure else f"period {metric.combines_as}s"
+        calculation = f"(latest − previous) ÷ |previous| on {combined}"
     return QueryAnswer(
         question="",
         plan=plan,
         answer=answer,
-        calculation=_with_notes(f"(latest − previous) ÷ |previous| on period sums{scope}", series),
+        calculation=_with_notes(f"{calculation}{scope}", series),
         table=trend,
         chart="line",
     )

--- a/nlq.py
+++ b/nlq.py
@@ -105,6 +105,9 @@ MONTH_NAMES = {
 
 MAX_FILTER_CANDIDATES = 200
 BREAKDOWN_LIMIT = 12
+KEY_WORDS = frozenset({
+    "id", "ids", "code", "codes", "zip", "postal", "phone", "sku", "number", "no", "key", "uuid",
+})
 
 QUERY_STOPWORDS = {
     "a", "about", "across", "all", "and", "are", "by", "can", "do", "does", "each",
@@ -174,9 +177,22 @@ def _match_column(question: str, columns: list[str]) -> str | None:
     return max(matches, key=lambda column: len(_norm(column))) if matches else None
 
 
-def _match_countable(question: str, roles: ColumnRoles) -> str | None:
-    """Match 'how many <entities>' to an identifier or dimension column."""
-    candidates = [column for column in (roles.identifier, *roles.dimensions) if column]
+def _named_like_a_key(name: str) -> bool:
+    words = _norm(name).split()
+    return bool(words) and (words[-1] in KEY_WORDS or words == ["id"])
+
+
+def _match_countable(question: str, roles: ColumnRoles, dataframe: pd.DataFrame | None = None) -> str | None:
+    """Match 'how many <entities>' to an identifier, key-named or dimension column.
+
+    A Customer ID that repeats is not unique enough to be the identifier
+    role, but "how many customers" still means distinct customers.
+    """
+    keyed = [
+        column for column in (dataframe.columns if dataframe is not None else ())
+        if _named_like_a_key(str(column))
+    ]
+    candidates = [column for column in (roles.identifier, *keyed, *roles.dimensions) if column]
     for column in candidates:
         tokens = {_norm(column), _norm(column).split(" ")[0]}
         if any(_mentioned(token, question) for token in tokens if token):
@@ -365,9 +381,12 @@ def parse_question(question: str, dataframe: pd.DataFrame, roles: ColumnRoles) -
     default_aggregation = measure_aggregation(base["measure"])
 
     if wants_count and not wants_growth:
+        countable = _match_countable(q, roles, dataframe)
         if dimension and wants_breakdown:
-            return QueryPlan(intent="breakdown", aggregation="count", dimension=dimension, **base)
-        countable = _match_countable(q, roles)
+            return QueryPlan(
+                intent="breakdown", aggregation="count", dimension=dimension,
+                count_column=countable if countable != dimension else None, **base,
+            )
         return QueryPlan(intent="count", aggregation="count", count_column=countable, **ungrouped)
 
     if wants_growth and roles.date:
@@ -422,7 +441,9 @@ def _grouped_aggregation(
     aggregation: Aggregation | None, explicit_extreme: bool, default: Aggregation
 ) -> Aggregation:
     """What a rank or breakdown computes per group."""
-    if aggregation in ("mean", "median"):
+    if aggregation in ("sum", "mean", "median"):
+        # Said out loud, so honoured -- including a sum of a rate, which the
+        # ungrouped path already allows; the two must agree.
         return aggregation
     if aggregation in ("min", "max") and explicit_extreme:
         return aggregation
@@ -483,35 +504,77 @@ def _aggregate_series(series: pd.Series, aggregation: Aggregation) -> float:
     return float(getattr(series.dropna(), aggregation)())
 
 
+def distinct_label(wanted: str, taken) -> str:
+    """A display column name that is not already one of the user's columns."""
+    present = {str(name) for name in taken}
+    label, suffix = wanted, 2
+    while label in present:
+        label = f"{wanted} ({suffix})"
+        suffix += 1
+    return label
+
+
 def _grouped_frame(
     dataframe: pd.DataFrame, plan: QueryPlan, value_label: str
-) -> pd.DataFrame:
+) -> tuple[pd.DataFrame, str, str | None]:
+    """Group, and return the frame with the display names it actually used.
+
+    Everything is computed on private column names, so a dimension the file
+    calls "Share %" or "Rows" cannot be overwritten by the columns built here.
+    The display names are then chosen not to collide with the dimension's own.
+    """
     assert plan.dimension is not None
+    dimension, measure = plan.dimension, plan.measure
+    columns = [dimension]
+    if measure and measure != dimension:
+        columns.append(measure)
+    if plan.count_column and plan.count_column not in columns:
+        columns.append(plan.count_column)
+    working = dataframe[columns].copy()
+    private = {name: f"__{index}" for index, name in enumerate(columns)}
+    working.columns = [private[name] for name in columns]
+    segment = private[dimension]
     # Rows with no label are a group, not a rounding error. Dropping them and
     # then taking percentages against what is left reports a share of a total
     # the reader never saw.
-    labelled = dataframe.copy()
-    labelled[plan.dimension] = labelled[plan.dimension].astype(object).where(
-        labelled[plan.dimension].notna(),
-        unlabelled_label(labelled[plan.dimension].dropna().unique()),
+    working[segment] = working[segment].astype(object).where(
+        working[segment].notna(), unlabelled_label(working[segment].dropna().unique())
     )
-    working = labelled
-    if plan.aggregation == "count" or not plan.measure:
-        grouped = working.groupby(plan.dimension, as_index=False).size()
-        grouped.columns = [plan.dimension, value_label]
+    if plan.aggregation == "count" and plan.count_column:
+        # "How many customers by region" counts customers, not rows.
+        grouped = working.groupby(segment, as_index=False)[private[plan.count_column]].nunique()
+    elif plan.aggregation == "count" or not measure:
+        grouped = working.groupby(segment, as_index=False).size()
     else:
-        grouped = working.groupby(plan.dimension, as_index=False)[plan.measure].agg(plan.aggregation)
-        grouped.columns = [plan.dimension, value_label]
-    grouped = grouped.sort_values(value_label, ascending=plan.ascending)
+        grouped = working.groupby(segment, as_index=False)[private[measure]].agg(plan.aggregation)
+    grouped.columns = [segment, "__value"]
+    grouped = grouped.sort_values("__value", ascending=plan.ascending)
+    share_name = None
     if plan.aggregation in ("sum", "count"):
-        values = grouped[value_label].to_numpy(dtype=float)
+        values = grouped["__value"].to_numpy(dtype=float)
         total = float(values.sum())
         # A share is only a share when every part carries the same sign as the
         # whole. Mixed signs give 500% and -250% from arithmetic that is
         # working exactly as written.
         if total and ((values >= 0).all() or (values <= 0).all()):
-            grouped["Share %"] = (grouped[value_label] / total * 100).round(1)
-    return grouped.reset_index(drop=True)
+            grouped["__share"] = (grouped["__value"] / total * 100).round(1)
+    value_name = distinct_label(value_label, {dimension})
+    names = {segment: dimension, "__value": value_name}
+    if "__share" in grouped.columns:
+        share_name = distinct_label("Share %", {dimension, value_name})
+        names["__share"] = share_name
+    return grouped.rename(columns=names).reset_index(drop=True), value_name, share_name
+
+
+def _shown(value: float, measure: str | None, frame: pd.DataFrame) -> str:
+    """Format a chat figure against the whole column it came from.
+
+    A rate column of [0.5, 2.0] is in percentage points; formatting the scalar
+    0.5 on its own reads it as a fraction and prints 50.0% where the brief
+    beside it prints 0.5%. The column settles the scale, once.
+    """
+    values = frame[measure].dropna() if measure and measure in frame.columns else None
+    return format_number(value, measure, column_values=values)
 
 
 def execute_plan(plan: QueryPlan, dataframe: pd.DataFrame, roles: ColumnRoles) -> QueryAnswer:
@@ -579,7 +642,7 @@ def execute_plan(plan: QueryPlan, dataframe: pd.DataFrame, roles: ColumnRoles) -
             plan=plan,
             answer=(
                 f"{label} {plan.measure}{_phrase(applied)} is "
-                f"{format_number(value, plan.measure)}, calculated from {rows:,} rows."
+                f"{_shown(value, plan.measure, dataframe)}, calculated from {rows:,} rows."
             ),
             calculation=f"{plan.aggregation}({plan.measure}){scope}",
         )
@@ -587,20 +650,26 @@ def execute_plan(plan: QueryPlan, dataframe: pd.DataFrame, roles: ColumnRoles) -
     if plan.intent in ("rank", "breakdown"):
         assert plan.dimension is not None
         label = AGGREGATION_LABELS[plan.aggregation]
-        value_label = f"{label} {plan.measure}" if plan.measure and plan.aggregation != "count" else "Rows"
-        grouped = _grouped_frame(working, plan, value_label)
+        counted = plan.aggregation == "count" or not plan.measure
+        if counted and plan.count_column:
+            value_label = f"Distinct {plan.count_column}"
+        elif counted:
+            value_label = "Rows"
+        else:
+            value_label = f"{label} {plan.measure}"
+        grouped, value_name, share_name = _grouped_frame(working, plan, value_label)
         limit = plan.top_n if plan.intent == "rank" else BREAKDOWN_LIMIT
         table = grouped.head(limit or BREAKDOWN_LIMIT)
         leader = table.iloc[0]
-        leader_value = float(leader[value_label])
+        leader_value = float(leader[value_name])
         direction = "lowest" if plan.ascending else "leading"
-        share_note = f" ({leader['Share %']:.1f}% of the total)" if "Share %" in table.columns else ""
+        share_note = f" ({leader[share_name]:.1f}% of the total)" if share_name else ""
         # A row count is not money, whatever the measure column is called.
         counted = value_label == "Rows"
         answer = (
             f"{leader[plan.dimension]} is the {direction} {plan.dimension} by {value_label.lower()}"
             f"{_phrase(applied)} at "
-            f"{format_number(leader_value, None if counted else plan.measure)}{share_note}."
+            f"{_shown(leader_value, None if counted else plan.measure, dataframe)}{share_note}."
         )
         order = "ascending" if plan.ascending else "descending"
         return QueryAnswer(
@@ -649,7 +718,7 @@ def execute_plan(plan: QueryPlan, dataframe: pd.DataFrame, roles: ColumnRoles) -
         )
         answer = (
             f"{plan.measure or 'Records'} per {grain_name}{_phrase(applied)} moved from "
-            f"{format_number(first, plan.measure)} to {format_number(last, plan.measure)} "
+            f"{_shown(first, plan.measure, dataframe)} to {_shown(last, plan.measure, dataframe)} "
             f"({movement})."
         )
         return QueryAnswer(
@@ -699,15 +768,21 @@ def _execute_growth(
 
     if plan.dimension:
         grain = plan.grain or preferred_frequency(working[roles.date])
-        frame = working[[roles.date, plan.dimension] + ([measure] if measure else [])].dropna(
-            subset=[roles.date, plan.dimension]
-        )
-        frame = frame.assign(__period=frame[roles.date].dt.to_period(grain).dt.to_timestamp())
+        picked = [roles.date, plan.dimension] + ([measure] if measure and measure != plan.dimension else [])
+        frame = working[picked].dropna(subset=[roles.date, plan.dimension]).copy()
+        # Private names from here on: a measure or dimension the file calls
+        # "__period" was being overwritten by the buckets built next.
+        frame.columns = ["__date", "__segment"] + (["__measure"] if len(picked) == 3 else [])
+        frame = frame.assign(__period=frame["__date"].dt.to_period(grain).dt.to_timestamp())
         frame = frame[frame["__period"].isin([previous_period, current_period])]
         if measure:
-            pivot = frame.groupby([plan.dimension, "__period"])[measure].sum().unstack(fill_value=0.0)
+            pivot = (
+                frame.groupby(["__segment", "__period"])["__measure"]
+                .agg(measure_aggregation(measure))
+                .unstack(fill_value=0.0)
+            )
         else:
-            pivot = frame.groupby([plan.dimension, "__period"]).size().unstack(fill_value=0)
+            pivot = frame.groupby(["__segment", "__period"]).size().unstack(fill_value=0)
         if previous_period not in pivot.columns or current_period not in pivot.columns:
             return QueryAnswer(
                 question="",
@@ -736,7 +811,7 @@ def _execute_growth(
                     f"No {plan.dimension} has a growth rate this period, because every one "
                     f"of them started from zero. The largest new arrival is "
                     f"{newest[plan.dimension]} at "
-                    f"{format_number(float(newest['Latest']), measure)}."
+                    f"{_shown(float(newest['Latest']), measure, working)}."
                 ),
                 calculation=(
                     f"per-{plan.dimension} growth undefined from a zero base; "
@@ -759,8 +834,8 @@ def _execute_growth(
         direction = "slowest" if plan.ascending else "fastest"
         answer = (
             f"{leader[plan.dimension]} moved {direction}{_phrase(applied)}: {leader['Change %']:+.1f}% "
-            f"({format_number(float(leader['Previous']), measure)} → "
-            f"{format_number(float(leader['Latest']), measure)}) in the latest period."
+            f"({_shown(float(leader['Previous']), measure, working)} → "
+            f"{_shown(float(leader['Latest']), measure, working)}) in the latest period."
         )
         if not from_nothing.empty:
             newest = from_nothing.loc[from_nothing["Latest"].abs().idxmax()]
@@ -768,7 +843,7 @@ def _execute_growth(
             answer += (
                 f" {len(from_nothing)} segment(s) are left out of the ranking because they "
                 f"started from zero ({names}); the largest is {newest[plan.dimension]} at "
-                f"{format_number(float(newest['Latest']), measure)}."
+                f"{_shown(float(newest['Latest']), measure, working)}."
             )
         return QueryAnswer(
             question="",
@@ -794,7 +869,7 @@ def _execute_growth(
     direction = "up" if change >= 0 else "down"
     answer = (
         f"{measure or 'Records'}{_phrase(applied)} is {direction} {abs(change):.1f}% versus the prior "
-        f"period ({format_number(previous, measure)} → {format_number(current, measure)})."
+        f"period ({_shown(previous, measure, working)} → {_shown(current, measure, working)})."
     )
     return QueryAnswer(
         question="",

--- a/nlq.py
+++ b/nlq.py
@@ -19,7 +19,7 @@ import pandas as pd
 from aggregation import TrendSeries, build_trend, measure_aggregation, preferred_frequency, unlabelled_label
 from formatting import format_number, format_period, rate_scale
 from metrics import resolve_metric
-from schema import ColumnRoles
+from schema import IDENTIFIER_NAME_WORDS, ColumnRoles, is_identifier_name
 
 Intent = Literal["aggregate", "count", "rank", "breakdown", "trend", "growth"]
 Aggregation = Literal["sum", "mean", "median", "min", "max", "count"]
@@ -107,9 +107,6 @@ MONTH_NAMES = {
 
 MAX_FILTER_CANDIDATES = 200
 BREAKDOWN_LIMIT = 12
-KEY_WORDS = frozenset({
-    "id", "ids", "code", "codes", "zip", "postal", "phone", "sku", "number", "no", "key", "uuid",
-})
 
 QUERY_STOPWORDS = {
     "a", "about", "across", "all", "and", "are", "by", "can", "do", "does", "each",
@@ -179,11 +176,6 @@ def _mentioned(normalized_name: str, question: str) -> bool:
     )
 
 
-def _named_like_a_key(name: str) -> bool:
-    words = _norm(name).split()
-    return bool(words) and (words[-1] in KEY_WORDS or words == ["id"])
-
-
 class _Spans:
     """The stretches of a normalized question that something has claimed.
 
@@ -201,11 +193,12 @@ class _Spans:
     def _free(self, start: int, end: int) -> bool:
         return all(end <= taken_start or start >= taken_end for taken_start, taken_end in self.taken)
 
-    def take(self, pattern: str) -> re.Match[str] | None:
-        """Claim the first free match of the pattern, or None."""
+    def take(self, pattern: str, group: int = 0) -> re.Match[str] | None:
+        """Claim the first free match of the pattern (or of one group), or None."""
         for match in re.finditer(pattern, self.text):
-            if match.end() > match.start() and self._free(*match.span()):
-                self.taken.append(match.span())
+            start, end = match.span(group)
+            if end > start and self._free(start, end):
+                self.taken.append((start, end))
                 return match
         return None
 
@@ -215,11 +208,23 @@ class _Spans:
             found.append(match)
         return found
 
-    def leftover(self) -> str:
+    def release(self, start: int, end: int) -> None:
+        self.taken = [span for span in self.taken if span != (start, end)]
+
+    def blanked(self) -> str:
+        """The text with every claimed span blanked out, positions kept.
+
+        Grammar is read from this: a dimension the file calls "Change (pp)"
+        has claimed its word, so "revenue by change" is a breakdown and not a
+        request for growth.
+        """
         characters = list(self.text)
         for start, end in self.taken:
             characters[start:end] = " " * (end - start)
-        return " ".join("".join(characters).split())
+        return "".join(characters)
+
+    def leftover(self) -> str:
+        return " ".join(self.blanked().split())
 
 
 BREAKDOWN_PATTERN = r"\b(by|per|across|breakdown|split|each)\b"
@@ -331,13 +336,13 @@ def _take_countable(spans: _Spans, roles: ColumnRoles, dataframe: pd.DataFrame) 
     A Customer ID that repeats is not unique enough to be the identifier
     role, but "how many customers" still means distinct customers.
     """
-    keyed = [column for column in dataframe.columns if _named_like_a_key(str(column))]
+    keyed = [column for column in dataframe.columns if is_identifier_name(str(column))]
     candidates = [column for column in (roles.identifier, *keyed, *roles.dimensions) if column]
     for column in candidates:
         normalized = _norm(column)
         first_word = normalized.split(" ")[0]
         for token in (normalized, first_word):
-            if not token or token in KEY_WORDS:
+            if not token or token in IDENTIFIER_NAME_WORDS:
                 continue
             for variant in sorted(_word_variants(token), key=len, reverse=True):
                 if spans.take(rf"\b{re.escape(variant)}\b"):
@@ -347,7 +352,7 @@ def _take_countable(spans: _Spans, roles: ColumnRoles, dataframe: pd.DataFrame) 
 
 def _take_mentions(
     spans: _Spans, dataframe: pd.DataFrame, roles: ColumnRoles
-) -> tuple[list[tuple[str, int]], tuple[ValueFilter, ...] | None]:
+) -> tuple[list[tuple[str, int, int]], tuple[ValueFilter, ...] | None]:
     """Claim every column name and dimension value, longest span first.
 
     "New York" is claimed before "York" can be, and "West Region" before
@@ -376,7 +381,7 @@ def _take_mentions(
     # last, so they only claim the word when nothing else in the question does.
     candidates.sort(key=lambda item: (item[1] == "column" and item[0] in GRAMMAR_WORDS, -len(item[0])))
 
-    columns: list[tuple[str, int]] = []
+    columns: list[tuple[str, int, int]] = []
     seen: set[str] = set()
     values: dict[str, list[str]] = {}
     claimed_values: dict[str, str] = {}
@@ -390,13 +395,24 @@ def _take_mentions(
             if re.search(pattern, spans.text):
                 return columns, None
             continue
-        matches = spans.take_all(pattern)
-        if not matches:
+        if kind == "column" and normalized in GRAMMAR_WORDS:
+            # "how many rows by Rows": the column called Rows is the one
+            # after "by"; the other "rows" is the grammar's. A grammar-named
+            # column claims one occurrence, the grounded one first.
+            lead_in = "|".join((*GROUNDING_WORDS, "by", "per", "across", "each"))
+            grounded = rf"\b(?:{lead_in}) ({re.escape(normalized)})\b"
+            found = spans.take(grounded, group=1)
+            spans_found = [found.span(1)] if found else []
+            if not found and (found := spans.take(pattern)):
+                spans_found = [found.span()]
+        else:
+            spans_found = [match.span() for match in spans.take_all(pattern)]
+        if not spans_found:
             continue
         if kind == "column":
             if column not in seen:
                 seen.add(column)
-                columns.append((column, matches[0].start()))
+                columns.append((column, *spans_found[0]))
         else:
             claimed_values[normalized] = column
             values.setdefault(column, []).append(value)  # type: ignore[arg-type]
@@ -413,7 +429,6 @@ def _resolve_mentions(
     metrics, two grouping columns, two months -- and must not be answered
     as though it named one.
     """
-    q = spans.text
     columns, filters = _take_mentions(spans, dataframe, roles)
     if filters is None:
         return None
@@ -423,25 +438,30 @@ def _resolve_mentions(
 
     numeric_columns = set(roles.numeric)
     dimension_columns = set(roles.dimensions)
-    measures = [column for column, _ in columns if column in numeric_columns]
+    measures = [column for column, _, _ in columns if column in numeric_columns]
     if len(measures) > 1:
-        # "total Revenue" in a file with a Total column: the grammar word wins.
+        # "total Revenue" in a file with a Total column: the grammar word
+        # wins, and gets its span back so the grammar can read it.
+        for column, start, end in columns:
+            if column in measures and _norm(column) in GRAMMAR_WORDS:
+                spans.release(start, end)
         measures = [column for column in measures if _norm(column) not in GRAMMAR_WORDS]
     if len(measures) > 1:
         return None
     measure = measures[0] if measures else None
-    date_mentioned = any(column == roles.date for column, _ in columns)
+    date_mentioned = any(column == roles.date for column, _, _ in columns)
 
-    breakdown = re.search(BREAKDOWN_PATTERN, q)
+    grammar = spans.blanked()
+    breakdown = re.search(BREAKDOWN_PATTERN, grammar)
     grouped = [
-        column for column, start in columns
+        column for column, start, _ in columns
         if column in dimension_columns and breakdown is not None and start > breakdown.start()
     ]
     leading = [
-        column for column, start in columns
+        column for column, start, _ in columns
         if column in dimension_columns and (breakdown is None or start < breakdown.start())
     ]
-    wants_count = bool(re.search(COUNT_PATTERN, q))
+    wants_count = bool(re.search(COUNT_PATTERN, grammar))
     if not wants_count and leading and grouped and measure is None:
         # "customers by region" with no metric is a count of one by the other.
         wants_count = True
@@ -469,16 +489,6 @@ def _resolve_mentions(
         date_mentioned=date_mentioned,
         wants_count=wants_count,
     )
-
-
-def _scope_grain(when: TimeScope) -> str | None:
-    if when.quarter is not None:
-        return "quarter"
-    if when.month is not None:
-        return "month"
-    if when.year is not None:
-        return "year"
-    return None
 
 
 def _detect_grain(question: str) -> str | None:
@@ -581,25 +591,25 @@ def parse_question(question: str, dataframe: pd.DataFrame, roles: ColumnRoles) -
     if dimension is None and top_match and mentions.entity:
         # "top 5 customers by revenue" ranks one row per customer.
         dimension = mentions.entity
-    grain = _detect_grain(q)
-    if grain is not None and grain == {"quarter": "Q", "month": "M", "year": "Y"}.get(_scope_grain(when)):
-        # "first quarter" names a period to look inside, not a grain to
-        # draw a timeline at.
-        grain = None
+    # The grammar is read from what no column, value or date has claimed:
+    # "first quarter" is a period to look inside, not a grain, and a
+    # dimension called "Change (pp)" is not a request for growth.
+    grammar = spans.blanked()
+    grain = _detect_grain(grammar)
     aggregation: Aggregation | None = next(
-        (AGGREGATION_WORDS[word] for word in AGGREGATION_WORDS if re.search(rf"\b{word}\b", q)),
+        (AGGREGATION_WORDS[word] for word in AGGREGATION_WORDS if re.search(rf"\b{word}\b", grammar)),
         None,
     )
     # "highest" and "largest" rank; only the literal words ask for an extreme
     # per group. Both live in AGGREGATION_WORDS as max, so they are told apart
     # here rather than by silently downgrading every min/max to a sum.
-    explicit_extreme = bool(re.search(r"\b(min|minimum|max|maximum)\b", q))
-    superlative = any(re.search(rf"\b{word}\b", q) for word in SUPERLATIVE_WORDS)
-    wants_breakdown = bool(re.search(BREAKDOWN_PATTERN, q))
-    wants_growth = any(re.search(rf"\b{word}\b", q) for word in GROWTH_WORDS)
+    explicit_extreme = bool(re.search(r"\b(min|minimum|max|maximum)\b", grammar))
+    superlative = any(re.search(rf"\b{word}\b", grammar) for word in SUPERLATIVE_WORDS)
+    wants_breakdown = bool(re.search(BREAKDOWN_PATTERN, grammar))
+    wants_growth = any(re.search(rf"\b{word}\b", grammar) for word in GROWTH_WORDS)
     wants_trend = (
         grain is not None
-        or any(phrase in q for phrase in TREND_WORDS)
+        or any(phrase in grammar for phrase in TREND_WORDS)
         or (mentions.date_mentioned and wants_breakdown and dimension is None)
     )
     if dimension is not None and dimension == measure:
@@ -646,9 +656,9 @@ def parse_question(question: str, dataframe: pd.DataFrame, roles: ColumnRoles) -
             # Growth is measured on periods combined the way the measure
             # combines. "Average revenue growth" would be growth of sums.
             return None
-        wants_ranked_growth = superlative or any(word in q for word in ("which", "fastest", "slowest"))
+        wants_ranked_growth = superlative or any(word in grammar for word in ("which", "fastest", "slowest"))
         rank_dimension = dimension or (roles.dimension if wants_ranked_growth else None)
-        ascending = bool(re.search(ASCENDING_PATTERN, q))
+        ascending = bool(re.search(ASCENDING_PATTERN, grammar))
         top_n = int(top_match.group(2)) if top_match else None
         return QueryPlan(
             intent="growth", aggregation=default_aggregation, dimension=rank_dimension,
@@ -666,7 +676,7 @@ def parse_question(question: str, dataframe: pd.DataFrame, roles: ColumnRoles) -
             ascending = top_match.group(1) == "bottom"
         else:
             top_n = 1
-            ascending = bool(re.search(ASCENDING_PATTERN, q))
+            ascending = bool(re.search(ASCENDING_PATTERN, grammar))
         return QueryPlan(
             intent="rank",
             aggregation=_grouped_aggregation(aggregation, explicit_extreme, default_aggregation),
@@ -943,10 +953,13 @@ def execute_plan(plan: QueryPlan, dataframe: pd.DataFrame, roles: ColumnRoles) -
         counted = plan.aggregation == "count" or not plan.measure
         if counted and plan.count_column:
             value_label = f"Distinct {plan.count_column}"
+            counted_as = f"count distinct {plan.count_column}"
         elif counted:
             value_label = "Rows"
+            counted_as = "row count"
         else:
             value_label = f"{label} {plan.measure}"
+            counted_as = f"{plan.aggregation}({plan.measure})"
         grouped, value_name, share_name = _grouped_frame(working, plan, value_label)
         limit = plan.top_n if plan.intent == "rank" else BREAKDOWN_LIMIT
         table = grouped.head(limit or BREAKDOWN_LIMIT)
@@ -970,8 +983,7 @@ def execute_plan(plan: QueryPlan, dataframe: pd.DataFrame, roles: ColumnRoles) -
                 # value_label already records whether rows or the measure were
                 # aggregated; naming count(<measure>) when .size() ran flipped
                 # which group won.
-                f"{'row count' if value_label == 'Rows' else f'{plan.aggregation}({plan.measure})'}"
-                f" by {plan.dimension}, {order}, showing {len(table)}{scope}"
+                f"{counted_as} by {plan.dimension}, {order}, showing {len(table)}{scope}"
             ),
             table=table,
             chart="bar",

--- a/pipeline.py
+++ b/pipeline.py
@@ -83,7 +83,9 @@ NO_SELECTION = "(none)"
 
 
 def _selected(value: str | None) -> str | None:
-    return None if value in (None, NO_SELECTION, "None") else value
+    # Only the sentinel means "no column": a column the file calls "None"
+    # is a column, and choosing it selects it.
+    return None if value in (None, NO_SELECTION) else value
 
 
 def apply_role_selection(
@@ -154,6 +156,8 @@ def cleaning_audit_frame(report: CleaningReport) -> pd.DataFrame:
             ["Numeric columns inferred", report.numeric_columns_inferred],
             ["Datetime columns inferred", report.datetime_columns_inferred],
             ["Date values that could not be read", report.unparsed_date_cells],
+            ["Number values that could not be read", report.numeric_cells_unreadable],
+            ["Infinite values made missing", report.non_finite_cells],
         ],
         columns=["Operation", "Count"],
     )

--- a/pipeline.py
+++ b/pipeline.py
@@ -48,7 +48,17 @@ def _most_recent(dataframe: pd.DataFrame, date_column: str | None, row_limit: in
             buckets = dataframe[date_column].dt.to_period(grain)
             oldest = dates.min().to_period(grain)
             if (buckets[~dataframe.index.isin(kept.index)] == oldest).any():
-                kept = kept[buckets.loc[kept.index] != oldest]
+                whole = kept[buckets.loc[kept.index] != oldest]
+                # Only when something survives it. Every kept row sitting in
+                # one truncated period is the ordinary shape of a big export
+                # from a busy week: dropping it left ZERO rows, and the app
+                # then reported an empty dataset and a $0.00 headline for a
+                # file with a quarter of a million rows in it. A partial
+                # period that is the whole slice is still the only evidence
+                # there is, and `partial_period` in the trend already tells
+                # the reader it is partial.
+                if not whole.empty:
+                    kept = whole
         return kept
     return dataframe.tail(row_limit)
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 
 import pandas as pd
 
+from aggregation import preferred_frequency
 from analysis import CleaningReport, clean_dataframe
 from business_insights import BusinessBrief, analyze_business
 from schema import ColumnRoles, detect_roles
@@ -37,7 +38,18 @@ def _most_recent(dataframe: pd.DataFrame, date_column: str | None, row_limit: in
         return dataframe
     if date_column and date_column in dataframe.columns:
         order = dataframe[date_column].rank(method="first", ascending=False, na_option="bottom")
-        return dataframe.loc[order <= row_limit]
+        kept = dataframe.loc[order <= row_limit]
+        # A cut that lands inside a period leaves that period half-present,
+        # and a half-present first period reads as growth into the next one.
+        # The oldest kept period is dropped whenever any row of it was cut.
+        dates = kept[date_column].dropna()
+        if not dates.empty:
+            grain = preferred_frequency(dates)
+            buckets = dataframe[date_column].dt.to_period(grain)
+            oldest = dates.min().to_period(grain)
+            if (buckets[~dataframe.index.isin(kept.index)] == oldest).any():
+                kept = kept[buckets.loc[kept.index] != oldest]
+        return kept
     return dataframe.tail(row_limit)
 
 
@@ -65,6 +77,15 @@ def prepare_analysis(raw_dataframe: pd.DataFrame, *, row_limit: int) -> Prepared
     )
 
 
+# The option a role selector shows for "no column". A real column can be
+# called "None", so the sentinel is a string no export produces.
+NO_SELECTION = "(none)"
+
+
+def _selected(value: str | None) -> str | None:
+    return None if value in (None, NO_SELECTION, "None") else value
+
+
 def apply_role_selection(
     detected: ColumnRoles,
     *,
@@ -73,9 +94,9 @@ def apply_role_selection(
     dimension: str,
 ) -> ColumnRoles:
     return ColumnRoles(
-        date=None if date == "None" else date,
-        measure=None if measure == "None" else measure,
-        dimension=None if dimension == "None" else dimension,
+        date=_selected(date),
+        measure=_selected(measure),
+        dimension=_selected(dimension),
         identifier=detected.identifier,
         numeric=detected.numeric,
         dimensions=detected.dimensions,

--- a/schema.py
+++ b/schema.py
@@ -80,6 +80,14 @@ MODIFIER_WEIGHT = 2 / 3
 IDENTIFIER_TOKENS = ("id", "uuid", "key", "code", "number", "invoice", "order")
 TIME_PART_TOKENS = ("year", "month", "week", "day", "hour", "minute", "quarter")
 
+# Head words that say a column holds a key rather than a quantity. The reader
+# keeps such a column as text and the cleaner leaves it alone, so an account
+# number written 00042 stays 00042 from upload to chart. Matched as a whole
+# word: "Paid Amount" is not an id because it contains one.
+IDENTIFIER_NAME_WORDS = frozenset(
+    {"id", "ids", "code", "codes", "zip", "postal", "phone", "sku", "number", "no", "key", "uuid"}
+)
+
 
 # A trailing unit or annotation is not the head noun. "Revenue (USD)" is
 # revenue; scoring it on "usd" let an unrelated column take the measure role.
@@ -102,9 +110,16 @@ def _date_preference(name: str) -> int:
     return 1
 
 
-def _ordinal(text: str) -> int:
-    """A stable number for a string, so it can serve as a max() tiebreak."""
-    return int.from_bytes(text.encode()[:8].ljust(8, b"\0"), "big")
+def is_identifier_name(name: str) -> bool:
+    """Whether a column's name says it holds a key: its last word is one of
+    IDENTIFIER_NAME_WORDS, or the whole name is.
+
+    This is the one place that decides, so the reader that keeps "Order No"
+    as text and the cleaner that must not turn it back into a number cannot
+    disagree about which columns those are.
+    """
+    words = _head_words(name)
+    return bool(words) and words[-1] in IDENTIFIER_NAME_WORDS
 
 
 def _named_like_a_date(name: str) -> bool:
@@ -155,17 +170,20 @@ def detect_roles(dataframe: pd.DataFrame) -> ColumnRoles:
         column for column in dataframe.columns if is_datetime64_any_dtype(dataframe[column])
     ]
 
+    # Candidates are sorted by their full name before ranking. max() returns
+    # the first of equal elements, so a tie between "Transaction Date A" and
+    # "Transaction Date B" resolves to the alphabetically first name whatever
+    # order the file wrote them in. An earlier tiebreak compared only the
+    # first eight bytes, which is not enough to separate two long names that
+    # share a prefix.
     date = max(
-        date_columns,
+        sorted(date_columns, key=lambda column: (normalized_name(column), str(column))),
         key=lambda column: (
             1 if any(token in normalized_name(column) for token in ("date", "time", "created")) else 0,
             # The event that produced the row outranks what happened to it
             # afterwards: an order dates a sale, a shipment dates a delivery.
             _date_preference(column),
             int(dataframe[column].notna().sum()),
-            # Name last, so two exports of one table in different column
-            # orders cannot land on different dates.
-            -_ordinal(normalized_name(column)),
         ),
         default=None,
     )

--- a/tests/test_bug_bash.py
+++ b/tests/test_bug_bash.py
@@ -114,7 +114,9 @@ class RateMeasureTests(unittest.TestCase):
         self.assertEqual(measure_aggregation("Margin Amount"), "sum")
 
     def test_the_headline_averages_a_rate_with_a_matching_number(self):
-        brief = analyze_business(pd.DataFrame({"Date": MONTHS[:2], "Conversion Rate": [0.1, 0.2]}))
+        # No date, so no trend card: the fallback headline has to combine the
+        # rate honestly on its own.
+        brief = analyze_business(pd.DataFrame({"Conversion Rate": [0.1, 0.2], "Channel": ["a", "b"]}))
 
         self.assertIn("averages", brief.headline)
         self.assertIn("15.0%", brief.headline)

--- a/tests/test_business_insights.py
+++ b/tests/test_business_insights.py
@@ -133,8 +133,14 @@ class BusinessAnalysisTests(unittest.TestCase):
         # offered for a rate -- only the average, which means something.
         self.assertNotIn("Total Gross Margin", kpi_labels)
         self.assertIn("Average Gross Margin", kpi_labels)
-        self.assertIn("Gross Margin increased 10.7%", report)
+        # A margin that goes from 28% to 31% has moved three points. "Increased
+        # 10.7%" was the relative figure, which reads as a margin of 38.7%.
+        self.assertIn("Gross Margin increased by 3.0 percentage points", report)
         self.assertIn("from 28.0% to 31.0%", report)
+        self.assertNotIn("10.7%", report)
+        # East had no rows in March, so it has no March average to have moved from.
+        self.assertNotIn("from 0.0%", report)
+        self.assertNotIn("coming from the leading", report)
 
     def test_negative_latest_period_prioritizes_diagnosis(self):
         dataframe = pd.DataFrame(

--- a/tests/test_contract_forecast.py
+++ b/tests/test_contract_forecast.py
@@ -1,0 +1,145 @@
+"""The backtest scores the holdout it says it does, and the note says what it measured.
+
+Three defects from an independent review of the forecast contract, one test
+each plus the corners they open up:
+
+* a held-out period was scored at the next consecutive slot after training
+  rather than at its own calendar position, so a gap inside the holdout
+  shifted every later prediction one period early;
+* the note claimed the model was "better than assuming no change" from
+  MASE alone, whose denominator is the training history, not a no-change
+  forecast on the holdout;
+* the percentage error was written with a plus-minus sign, which reads as
+  an uncertainty interval.
+"""
+
+import unittest
+
+import numpy as np
+import pandas as pd
+
+from forecasting import Backtest, build_forecast, describe_backtest
+
+
+def make_trend(values, freq="MS", start="2024-01-01"):
+    periods = pd.date_range(start, periods=len(values), freq=freq)
+    return pd.DataFrame({"Period": periods, "Value": [float(value) for value in values]})
+
+
+class GappedHoldoutTests(unittest.TestCase):
+    def test_a_missing_month_inside_the_holdout_is_scored_at_its_own_position(self):
+        """A perfectly linear series has zero error whatever months are missing."""
+        trend = make_trend([100 + 10 * index for index in range(16)])
+        trend = trend.drop(index=14).reset_index(drop=True)
+
+        forecast = build_forecast(trend)
+
+        assert forecast is not None
+        self.assertEqual(forecast.backtest.holdout_periods, 3)
+        self.assertEqual(forecast.backtest.mape, 0.0)
+        self.assertEqual(forecast.backtest.mase, 0.0)
+
+    def test_a_gapless_holdout_scores_exactly_as_before(self):
+        forecast = build_forecast(make_trend([100 + 10 * index for index in range(16)]))
+
+        assert forecast is not None
+        self.assertEqual(forecast.backtest.mape, 0.0)
+        self.assertEqual(forecast.backtest.mase, 0.0)
+
+
+class HoldoutContestTests(unittest.TestCase):
+    def test_the_no_change_forecast_is_scored_on_the_same_holdout(self):
+        """Training ends at 210; the holdout is 220, 230, 250, so carrying 210 errs 9.7%."""
+        trend = make_trend([100 + 10 * index for index in range(16)])
+        trend = trend.drop(index=14).reset_index(drop=True)
+
+        forecast = build_forecast(trend)
+
+        assert forecast is not None
+        self.assertEqual(forecast.backtest.holdout_naive_mape, 9.7)
+        self.assertIs(forecast.backtest.beats_naive_on_holdout, True)
+
+    def test_mase_and_the_holdout_contest_answer_different_questions(self):
+        """A zig-zag history moves 40 a step, so a 20-point miss is a MASE of 0.5.
+
+        The holdout sits exactly at the last training value, so a no-change
+        forecast is perfect there and the model loses that contest. The old
+        note would have called this "better than assuming no change".
+        """
+        forecast = build_forecast(make_trend([100, 140, 100, 140, 100, 140, 100, 140, 140, 140, 140]))
+
+        assert forecast is not None
+        self.assertEqual(forecast.backtest.mase, 0.5)
+        self.assertEqual(forecast.backtest.mape, 14.3)
+        self.assertEqual(forecast.backtest.holdout_naive_mape, 0.0)
+        self.assertIs(forecast.backtest.beats_naive_on_holdout, False)
+        self.assertIn("so the model did not beat it", describe_backtest(forecast.backtest))
+
+    def test_a_random_walk_loses_the_holdout_contest(self):
+        rng = np.random.default_rng(6)
+        forecast = build_forecast(make_trend(500 + np.cumsum(rng.normal(0, 60, 26))))
+
+        assert forecast is not None
+        self.assertEqual(forecast.backtest.mape, 17.1)
+        self.assertEqual(forecast.backtest.holdout_naive_mape, 11.2)
+        self.assertIs(forecast.backtest.beats_naive_on_holdout, False)
+
+    def test_a_zero_holdout_has_no_contest_to_report(self):
+        forecast = build_forecast(make_trend([40, 44, 39, 41, 45, 38, 42, 40, 43, 0, 0, 0]))
+
+        assert forecast is not None
+        self.assertIsNone(forecast.backtest.holdout_naive_mape)
+        self.assertIsNone(forecast.backtest.beats_naive_on_holdout)
+        self.assertEqual(forecast.backtest.mase, 11.06)
+
+    def test_the_backtest_no_longer_claims_a_contest_from_mase_alone(self):
+        self.assertFalse(hasattr(Backtest, "beats_no_change"))
+
+
+class ErrorNoteWordingTests(unittest.TestCase):
+    def test_the_note_reports_an_average_error_not_an_interval(self):
+        note = describe_backtest(
+            Backtest(mape=1.7, mase=0.72, holdout_periods=4, periods_without_mape=0, holdout_naive_mape=4.9)
+        )
+
+        self.assertEqual(
+            note,
+            "average error of 1.7% on the last 4 held-out periods, "
+            "assuming no change would have erred 4.9% on the same periods, so the model beat it, "
+            "MASE 0.72 (error relative to a one-step no-change baseline on the training history)",
+        )
+        self.assertNotIn("±", note)
+        self.assertNotIn("than assuming no change", note)
+
+    def test_the_note_counts_the_periods_a_percentage_could_be_taken_on(self):
+        note = describe_backtest(
+            Backtest(mape=3.3, mase=0.67, holdout_periods=5, periods_without_mape=2, holdout_naive_mape=10.0)
+        )
+
+        self.assertTrue(
+            note.startswith("average error of 3.3% on the last 5 held-out periods (the 3 of them above zero)")
+        )
+
+    def test_the_note_without_a_percentage_still_names_the_holdout(self):
+        backtest = Backtest(
+            mape=None, mase=11.06, holdout_periods=3, periods_without_mape=3, holdout_naive_mape=None
+        )
+
+        self.assertEqual(
+            describe_backtest(backtest),
+            "held out the last 3 periods, every held-out period was zero, "
+            "so a percentage error says nothing, "
+            "MASE 11.06 (error relative to a one-step no-change baseline on the training history)",
+        )
+
+    def test_the_uncertainty_band_is_described_separately_from_the_error(self):
+        rng = np.random.default_rng(8)
+        forecast = build_forecast(make_trend(600 + 5 * np.arange(20) + rng.normal(0, 30, 20)))
+
+        assert forecast is not None
+        self.assertIn("band = ±", forecast.method)
+        self.assertNotIn("band", describe_backtest(forecast.backtest))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_contract_grammar.py
+++ b/tests/test_contract_grammar.py
@@ -1,0 +1,344 @@
+"""The chat grammar accounts for every part of a question, or refuses it.
+
+A question that names two metrics, an arithmetic expression, a single day, a
+quarter, a year the file does not cover, or a word that names nothing in the
+file must never be answered as the nearest easier question. These are the
+reviewer's fixtures; every expected number was checked by hand.
+"""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+
+import pandas as pd
+
+from ai_insights import AIQueryPlan, plan_query_with_ai
+from nlq import (
+    QueryPlan,
+    ValueFilter,
+    answer_question,
+    parse_question,
+    plan_accounts_for_numbers,
+    question_is_representable,
+    unsupported_phrasing,
+)
+from schema import detect_roles
+
+
+def grammar_fixture() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "Date": pd.to_datetime(["2024-01-15", "2024-01-31", "2024-02-15", "2024-04-30"]),
+            "Revenue": [100, 200, 300, 400],
+            "Profit": [10, 20, 30, 40],
+            "Country": ["UK", "US", "UK", "US"],
+        }
+    )
+
+
+class CountingClient:
+    """A planner client that records whether it was asked anything."""
+
+    def __init__(self, parsed):
+        self.calls = 0
+        self.parsed = parsed
+        self.responses = self
+
+    def parse(self, **kwargs: object) -> object:
+        self.calls += 1
+        return SimpleNamespace(output_parsed=self.parsed)
+
+
+class ScopeTests(unittest.TestCase):
+    def setUp(self):
+        self.frame = grammar_fixture()
+        self.roles = detect_roles(self.frame)
+
+    def ask(self, question: str):
+        return answer_question(question, self.frame, self.roles)
+
+    def test_a_single_day_is_a_scope_of_its_own(self):
+        # D-04: "Revenue 2024-01-31" answered with all of 2024.
+        for question in ("Revenue 2024-01-31", "Revenue on 2024/01/31"):
+            with self.subTest(question=question):
+                result = self.ask(question)
+                self.assertEqual(result.plan.day, 31)
+                self.assertEqual(result.plan.month, 1)
+                self.assertIn("$200.00", result.answer)
+                self.assertIn("calculated from 1 rows", result.answer)
+
+    def test_a_month_and_day_resolve_the_day(self):
+        for question in ("Revenue in January 15", "Revenue on the 15th of January", "Revenue on 15 January"):
+            with self.subTest(question=question):
+                result = self.ask(question)
+                self.assertIn("$100.00", result.answer)
+                self.assertIn("January 15", result.answer)
+
+    def test_a_quarter_is_a_scope(self):
+        for question in (
+            "Revenue in q1",
+            "Revenue in Q1 2024",
+            "Revenue in the first quarter",
+            "revenue in quarter 1",
+        ):
+            with self.subTest(question=question):
+                result = self.ask(question)
+                self.assertEqual(result.plan.intent, "aggregate")
+                self.assertEqual(result.plan.quarter, 1)
+                self.assertIn("$600.00", result.answer)
+                self.assertIn("Q1", result.answer)
+
+    def test_a_year_the_file_does_not_cover_is_not_dropped(self):
+        result = self.ask("Revenue in 2100")
+        self.assertEqual(result.plan.year, 2100)
+        self.assertIn("No rows match", result.answer)
+        self.assertNotIn("$", result.answer)
+
+    def test_a_year_alone_still_scopes(self):
+        self.assertIn("$1.0K", self.ask("revenue in 2024").answer)
+        self.assertIn("$300.00", self.ask("revenue in january").answer)
+
+
+class CompositionTests(unittest.TestCase):
+    def setUp(self):
+        self.frame = grammar_fixture()
+        self.roles = detect_roles(self.frame)
+
+    def test_two_metrics_or_arithmetic_between_them_are_refused(self):
+        for question in (
+            "total Revenue and Profit",
+            "total Revenue / Profit",
+            "total Revenue - Profit",
+            "Revenue plus Profit",
+            "Revenue divided by Profit",
+            "Revenue vs Profit",
+            "Revenue compared to Profit",
+        ):
+            with self.subTest(question=question):
+                self.assertIsNone(parse_question(question, self.frame, self.roles))
+                self.assertFalse(question_is_representable(question, self.frame, self.roles))
+
+    def test_top_n_without_a_group_is_refused(self):
+        for question in ("top 2 Revenue", "bottom 2 Revenue"):
+            with self.subTest(question=question):
+                self.assertIsNone(parse_question(question, self.frame, self.roles))
+
+    def test_a_word_that_names_nothing_in_the_file_is_refused(self):
+        # "per customer" and "france" name nothing here; the old parser
+        # answered the all-time total for both.
+        for question in ("revenue per customer", "revenue for france", "revenue in the north"):
+            with self.subTest(question=question):
+                self.assertIsNone(parse_question(question, self.frame, self.roles))
+
+    def test_a_number_nobody_uses_is_refused(self):
+        for question in ("revenue 200", "top revenue 3", "revenue in h1"):
+            with self.subTest(question=question):
+                self.assertIsNone(parse_question(question, self.frame, self.roles))
+
+    def test_a_count_over_time_is_a_count_trend(self):
+        result = answer_question("count rows over time", self.frame, self.roles)
+        self.assertEqual(result.plan.intent, "trend")
+        self.assertEqual(result.plan.aggregation, "count")
+        self.assertIn("Records per month", result.answer)
+        self.assertIn("row count", result.calculation)
+        self.assertEqual(result.table["Value"].tolist(), [2, 1, 0, 1])
+
+    def test_growth_and_trend_without_a_date_explain_instead_of_totalling(self):
+        dateless = self.frame.drop(columns=["Date"])
+        roles = detect_roles(dateless)
+        for question in ("Revenue growth", "Revenue over time", "monthly revenue"):
+            with self.subTest(question=question):
+                result = answer_question(question, dateless, roles)
+                self.assertIsNotNone(result)
+                self.assertIn("no date column", result.answer)
+                self.assertNotIn("$", result.answer)
+
+    def test_average_growth_is_refused_rather_than_measured_on_sums(self):
+        # Monthly row revenues [100], [100], [100, 100]: the sums double,
+        # the average stays 100 throughout.
+        frame = pd.DataFrame(
+            {
+                "Date": pd.to_datetime(["2024-01-05", "2024-02-05", "2024-03-05", "2024-03-20"]),
+                "Revenue": [100, 100, 100, 100],
+            }
+        )
+        roles = detect_roles(frame)
+        self.assertIsNone(parse_question("average Revenue growth", frame, roles))
+        self.assertIn("up 100.0%", answer_question("Revenue growth", frame, roles).answer)
+
+    def test_an_empty_previous_period_is_named_not_treated_as_zero(self):
+        result = answer_question("Revenue growth", self.frame, self.roles)
+        self.assertIn("Mar 2024 has no rows", result.answer)
+        self.assertNotIn("%", result.answer)
+
+
+class ValueFilterTests(unittest.TestCase):
+    def test_a_short_value_is_matched_when_a_preposition_grounds_it(self):
+        frame = grammar_fixture()
+        roles = detect_roles(frame)
+        result = answer_question("total Revenue for UK", frame, roles)
+        self.assertEqual(result.plan.filters, (ValueFilter(column="Country", values=("UK",)),))
+        self.assertIn("$400.00", result.answer)
+        self.assertIn("calculated from 2 rows", result.answer)
+
+    def test_the_longest_value_wins_over_a_value_inside_it(self):
+        frame = pd.DataFrame(
+            {
+                "City": ["New York", "York", "York", "New York"],
+                "Revenue": [100, 200, 200, 100],
+            }
+        )
+        roles = detect_roles(frame)
+        new_york = answer_question("total Revenue for New York", frame, roles)
+        york = answer_question("total Revenue for York", frame, roles)
+        self.assertEqual(new_york.plan.filters, (ValueFilter(column="City", values=("New York",)),))
+        self.assertIn("$200.00", new_york.answer)
+        self.assertEqual(york.plan.filters, (ValueFilter(column="City", values=("York",)),))
+        self.assertIn("$400.00", york.answer)
+
+    def test_a_grouped_answer_keeps_a_filter_on_its_own_dimension(self):
+        frame = pd.DataFrame({"Region": ["West", "East", "West", "East"], "Revenue": [100, 300, 100, 300]})
+        roles = detect_roles(frame)
+        result = answer_question("Revenue by Region for West", frame, roles)
+        self.assertEqual(result.plan.dimension, "Region")
+        self.assertEqual(result.plan.filters, (ValueFilter(column="Region", values=("West",)),))
+        self.assertEqual(result.table["Region"].tolist(), ["West"])
+        self.assertIn("West is the leading Region", result.answer)
+        self.assertNotIn("East", result.answer)
+
+    def test_a_value_that_lives_in_two_columns_is_not_guessed(self):
+        frame = pd.DataFrame(
+            {
+                "Region": ["North", "South", "North", "South"],
+                "Territory": ["South", "South", "North", "North"],
+                "Revenue": [1, 2, 3, 4],
+            }
+        )
+        roles = detect_roles(frame)
+        self.assertIsNone(parse_question("revenue for North", frame, roles))
+
+
+class DistinctCountTests(unittest.TestCase):
+    def setUp(self):
+        self.frame = pd.DataFrame(
+            {
+                "Customer ID": ["001", "001", "002", "003", "003"],
+                "Region": ["West", "West", "West", "East", "East"],
+                "Revenue": [1, 1, 3, 4, 5],
+            }
+        )
+        self.roles = detect_roles(self.frame)
+
+    def test_entities_are_counted_distinctly_with_and_without_a_group(self):
+        # D-07: three customers overall, two in West and one in East -- not
+        # the three and two rows the grouped path used to count.
+        alone = answer_question("how many customers", self.frame, self.roles)
+        self.assertIn("3 distinct Customer ID", alone.answer)
+
+        for question in (
+            "how many customers by region",
+            "customers by region",
+            "number of customers per region",
+        ):
+            with self.subTest(question=question):
+                grouped = answer_question(question, self.frame, self.roles)
+                self.assertEqual(grouped.plan.count_column, "Customer ID")
+                counts = dict(
+                    zip(grouped.table["Region"], grouped.table["Distinct Customer ID"], strict=True)
+                )
+                self.assertEqual(counts, {"West": 2, "East": 1})
+                self.assertIn("count distinct Customer ID", grouped.calculation)
+
+    def test_rows_stay_rows(self):
+        rows = answer_question("how many rows by region", self.frame, self.roles)
+        self.assertIsNone(rows.plan.count_column)
+        self.assertEqual(
+            dict(zip(rows.table["Region"], rows.table["Rows"], strict=True)), {"West": 3, "East": 2}
+        )
+
+    def test_the_ai_plan_carries_the_counted_column_through_approval_and_execution(self):
+        from ai_insights import _to_query_plan, describe_query_plan
+        from nlq import execute_plan
+
+        parsed = AIQueryPlan(answerable=True, intent="count", aggregation="count", count_column="Customer ID")
+        plan = _to_query_plan(parsed, self.frame, self.roles)
+        self.assertEqual(plan.count_column, "Customer ID")
+        self.assertIn("Customer ID", describe_query_plan(plan))
+        self.assertIn("3 distinct", execute_plan(plan, self.frame, self.roles).answer)
+
+    def test_top_n_of_an_entity_ranks_one_row_per_entity(self):
+        result = answer_question("top 2 customers by revenue", self.frame, self.roles)
+        self.assertEqual(result.plan.dimension, "Customer ID")
+        self.assertEqual(result.table["Customer ID"].tolist(), ["003", "002"])
+
+
+class PlannerGateTests(unittest.TestCase):
+    """The optional planner is only asked what a plan can hold."""
+
+    def setUp(self):
+        self.frame = grammar_fixture()
+        self.roles = detect_roles(self.frame)
+
+    def test_unrepresentable_questions_never_reach_the_model(self):
+        parsed = AIQueryPlan(answerable=True, intent="aggregate", aggregation="sum", measure="Revenue")
+        for question in (
+            "total Revenue and Profit",
+            "Revenue / Profit",
+            "revenue in January and February",
+            "revenue > 200",
+        ):
+            with self.subTest(question=question):
+                client = CountingClient(parsed)
+                plan = plan_query_with_ai(
+                    question, self.frame, self.roles, api_key="k", safety_identifier="s", client=client
+                )
+                self.assertIsNone(plan)
+                self.assertEqual(client.calls, 0)
+
+    def test_a_plan_that_drops_a_number_from_the_question_is_refused(self):
+        # The model read "Revenue 2024-01-31" as January 2024.
+        parsed = AIQueryPlan(
+            answerable=True, intent="aggregate", aggregation="sum", measure="Revenue", year=2024, month=1
+        )
+        client = CountingClient(parsed)
+        plan = plan_query_with_ai(
+            "Revenue 2024-01-31", self.frame, self.roles, api_key="k", safety_identifier="s", client=client
+        )
+        self.assertEqual(client.calls, 1)
+        self.assertIsNone(plan)
+
+        whole = AIQueryPlan(
+            answerable=True,
+            intent="aggregate",
+            aggregation="sum",
+            measure="Revenue",
+            year=2024,
+            month=1,
+            day=31,
+        )
+        plan = plan_query_with_ai(
+            "Revenue 2024-01-31",
+            self.frame,
+            self.roles,
+            api_key="k",
+            safety_identifier="s",
+            client=CountingClient(whole),
+        )
+        self.assertEqual((plan.year, plan.month, plan.day), (2024, 1, 31))
+
+    def test_number_accounting(self):
+        plan = QueryPlan(intent="aggregate", measure="Revenue", year=2024, month=1)
+        self.assertTrue(plan_accounts_for_numbers("Revenue in January 2024", plan))
+        self.assertFalse(plan_accounts_for_numbers("Revenue in January 15 2024", plan))
+        self.assertFalse(plan_accounts_for_numbers("Revenue in q1", plan))
+        self.assertTrue(plan_accounts_for_numbers("top 3 countries", QueryPlan(intent="rank", top_n=3)))
+
+    def test_the_planner_sees_the_same_denylist_as_the_rules(self):
+        for question in ("Revenue - Profit", "Revenue × Profit", "revenue vs profit"):
+            with self.subTest(question=question):
+                self.assertTrue(unsupported_phrasing(question))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_contract_ingestion.py
+++ b/tests/test_contract_ingestion.py
@@ -1,0 +1,311 @@
+"""The ingestion contract: what leaves the reader is what the cleaner keeps.
+
+Each test here pins a finding from an independent review of the read -> clean
+-> detect path. They are written against the reviewer's own fixtures, and each
+one failed before the fix it names.
+"""
+
+import io
+import unittest
+import zipfile
+
+import numpy as np
+import openpyxl
+import pandas as pd
+
+from analysis import OFFSETS_DROPPED_NOTE, _read_formatted_number, clean_dataframe
+from file_io import list_excel_sheets, read_tabular_file
+from schema import detect_roles, is_identifier_name
+
+
+def workbook_bytes(rows: list[list[object]]) -> bytes:
+    book = openpyxl.Workbook()
+    sheet = book.active
+    sheet.title = "Data"
+    for row in rows:
+        sheet.append(row)
+    buffer = io.BytesIO()
+    book.save(buffer)
+    return buffer.getvalue()
+
+
+def truncated_member(contents: bytes, member: str, cut: int) -> bytes:
+    """The same workbook with the tail of one XML part missing."""
+    source = zipfile.ZipFile(io.BytesIO(contents))
+    out = io.BytesIO()
+    with zipfile.ZipFile(out, "w") as archive:
+        for item in source.infolist():
+            data = source.read(item.filename)
+            if item.filename == member:
+                data = data[: len(data) - cut]
+            archive.writestr(item, data)
+    return out.getvalue()
+
+
+class IdentifierNameTests(unittest.TestCase):
+    """One whole-word test decides what is a key, for the reader and the cleaner."""
+
+    def test_the_last_word_or_the_whole_name_says_key(self):
+        names = ("id", "Customer ID", "Account Number", "SKU", "Order No", "ZIP", "order_no", "customerId")
+        for name in names:
+            with self.subTest(name=name):
+                self.assertTrue(is_identifier_name(name))
+
+    def test_a_substring_is_not_a_word(self):
+        for name in ("Paid Amount", "Grid Value", "Valid Amount", "Revenue", "Skunk Count", "Zipper Sales"):
+            with self.subTest(name=name):
+                self.assertFalse(is_identifier_name(name))
+
+    def test_identifiers_survive_reading_and_cleaning_end_to_end(self):
+        raw = (
+            b"Customer ID,Account Number,SKU,Order No,ZIP,Revenue\n"
+            b"00042,00042,00042,00042,00042,10\n"
+            b"00007,00007,00007,00007,00007,20\n"
+        )
+
+        cleaned, _ = clean_dataframe(read_tabular_file(raw, "orders.csv"))
+
+        for column in ("Customer ID", "Account Number", "SKU", "Order No", "ZIP"):
+            with self.subTest(column=column):
+                self.assertEqual(cleaned[column].tolist(), ["00042", "00007"])
+        self.assertEqual(cleaned["Revenue"].tolist(), [10, 20])
+
+    def test_names_that_merely_contain_id_are_still_read_as_numbers(self):
+        frame = pd.DataFrame(
+            {
+                "Paid Amount": ["$1,000", "$2,000"],
+                "Grid Value": ["$1,000", "$3,000"],
+                "Valid Amount": ["$1,000", "$4,000"],
+            }
+        )
+
+        cleaned, report = clean_dataframe(frame)
+
+        self.assertEqual(cleaned["Paid Amount"].tolist(), [1000.0, 2000.0])
+        self.assertEqual(cleaned["Grid Value"].tolist(), [1000.0, 3000.0])
+        self.assertEqual(cleaned["Valid Amount"].tolist(), [1000.0, 4000.0])
+        self.assertEqual(report.numeric_columns_inferred, 3)
+
+    def test_an_identifier_column_of_dates_is_neither_a_date_nor_the_date_role(self):
+        frame = pd.DataFrame({"Customer ID": ["2024-01-01", "2024-01-02"] * 5, "Revenue": range(10)})
+
+        cleaned, report = clean_dataframe(frame)
+
+        self.assertEqual(cleaned["Customer ID"].tolist(), ["2024-01-01", "2024-01-02"] * 5)
+        self.assertEqual(report.datetime_columns_inferred, 0)
+        self.assertIsNone(detect_roles(cleaned).date)
+
+
+class FormattedNumberTests(unittest.TestCase):
+    def test_a_sign_after_the_currency_symbol_is_a_negative_not_a_gap(self):
+        frame = pd.DataFrame({"Amount": ["$-100"] + ["$200"] * 19})
+
+        cleaned, report = clean_dataframe(frame)
+
+        self.assertEqual(float(cleaned["Amount"].sum()), 3700.0)
+        self.assertEqual(int(cleaned["Amount"].isna().sum()), 0)
+        self.assertEqual(report.numeric_cells_unreadable, 0)
+
+    def test_every_correct_reading_is_kept(self):
+        cases = {
+            "-100": -100.0,
+            "+100": 100.0,
+            "1,000": 1000.0,
+            "-$1,000.00": -1000.0,
+            "(48.10)": -48.10,
+            "1.234,50": 1234.5,
+            "1 234,50": 1234.5,
+            "1'234.50": 1234.5,
+            "1.234.567": 1234567.0,
+            "1,234": 1234.0,
+            "12.5": 12.5,
+            "1234,50": 1234.5,
+            "€1.234,50": 1234.5,
+            "£12,345": 12345.0,
+            "$-100": -100.0,
+            "-(100)": -100.0,
+            "$(1,000.00)": -1000.0,
+        }
+        for text, value in cases.items():
+            with self.subTest(text=text):
+                self.assertEqual(_read_formatted_number(text), value)
+
+    def test_malformed_numbers_are_refused_rather_than_read_past(self):
+        malformed = (
+            "(100", "100)", "1,2,3", "1.2.3", "12 34", "1,,000", ",100", "100,", "--100", "1,000.000,50"
+        )
+        for text in malformed:
+            with self.subTest(text=text):
+                self.assertIsNone(_read_formatted_number(text))
+
+    def test_scientific_notation_is_plain_parsing_s_job(self):
+        self.assertIsNone(_read_formatted_number("1e3"))
+        cleaned, _ = clean_dataframe(pd.DataFrame({"Amount": ["1e3"] + ["1,000"] * 19}))
+        self.assertEqual(cleaned["Amount"].tolist(), [1000.0] * 20)
+
+    def test_a_cell_coerced_to_missing_is_counted_and_named(self):
+        frame = pd.DataFrame({"Amount": ["(100"] + ["200"] * 19})
+
+        cleaned, report = clean_dataframe(frame)
+
+        self.assertTrue(pd.api.types.is_numeric_dtype(cleaned["Amount"]))
+        self.assertEqual(int(cleaned["Amount"].isna().sum()), 1)
+        self.assertEqual(report.numeric_cells_unreadable, 1)
+        self.assertIn("1 Amount values could not be read as numbers and were left missing.", report.notes)
+        self.assertEqual(report.to_dict()["numeric_cells_unreadable"], 1)
+
+    def test_blank_cells_do_not_count_against_the_numeric_bar(self):
+        # A second column keeps the whitespace row in the frame; on its own it
+        # would be dropped as an empty row before inference ever saw it.
+        frame = pd.DataFrame({"Region": ["West", "East", "North"], "Amount": ["$100", "$200", "  "]})
+
+        cleaned, report = clean_dataframe(frame)
+
+        self.assertEqual(cleaned["Amount"].tolist()[:2], [100.0, 200.0])
+        self.assertTrue(pd.isna(cleaned["Amount"].iloc[2]))
+        self.assertEqual(report.numeric_columns_inferred, 1)
+        self.assertEqual(report.numeric_cells_unreadable, 0)
+
+    def test_whole_numbers_past_exact_float_range_are_flagged_when_forced_to_float(self):
+        frame = pd.DataFrame({"Balance": ["9007199254740993"] * 19 + ["$1"]})
+
+        cleaned, report = clean_dataframe(frame)
+
+        self.assertEqual(cleaned["Balance"].iloc[0], 9007199254740992.0)
+        flagged = [note for note in report.notes if "would not fit" in note and "Balance" in note]
+        self.assertEqual(len(flagged), 1)
+
+        exact, report = clean_dataframe(pd.DataFrame({"Balance": ["9007199254740993"] * 20}))
+
+        self.assertEqual(int(exact["Balance"].iloc[0]), 9007199254740993)
+        self.assertFalse(any("would not fit" in note for note in report.notes))
+
+    def test_infinity_in_text_becomes_missing_and_is_counted(self):
+        frame = pd.DataFrame({"Amount": ["inf"] + ["1"] * 19})
+
+        cleaned, report = clean_dataframe(frame)
+
+        self.assertEqual(int(cleaned["Amount"].isna().sum()), 1)
+        self.assertEqual(float(cleaned["Amount"].sum()), 19.0)
+        self.assertEqual(report.non_finite_cells, 1)
+        self.assertIn("1 Amount values were infinite and were left missing.", report.notes)
+
+    def test_infinity_the_reader_already_parsed_is_caught_too(self):
+        frame = read_tabular_file(b"Revenue\ninf\n-inf\n1\n", "f.csv")
+        self.assertTrue(np.isinf(frame["Revenue"]).any())
+
+        cleaned, report = clean_dataframe(frame)
+
+        self.assertEqual(cleaned["Revenue"].tolist()[2], 1.0)
+        self.assertEqual(int(cleaned["Revenue"].isna().sum()), 2)
+        self.assertEqual(report.non_finite_cells, 2)
+        self.assertIn("2 Revenue values were infinite and were left missing.", report.notes)
+
+
+class TimezoneOffsetTests(unittest.TestCase):
+    def test_a_rows_wall_clock_does_not_depend_on_the_rows_after_it(self):
+        first, second = "2024-01-01T00:30:00+01:00", "2024-01-15T12:00:00+01:00"
+        third = "2024-06-01T00:30:00+02:00"
+
+        two, report_two = clean_dataframe(pd.DataFrame({"created_at": [first, second]}))
+        three, report_three = clean_dataframe(pd.DataFrame({"created_at": [first, second, third]}))
+
+        self.assertEqual(two["created_at"].tolist(), three["created_at"].tolist()[:2])
+        self.assertEqual(two["created_at"].iloc[0], pd.Timestamp("2024-01-01 00:30:00"))
+        self.assertEqual(three["created_at"].iloc[2], pd.Timestamp("2024-06-01 00:30:00"))
+        self.assertFalse(isinstance(three["created_at"].dtype, pd.DatetimeTZDtype))
+        for report in (report_two, report_three):
+            self.assertEqual(report.notes.count(OFFSETS_DROPPED_NOTE), 1)
+
+    def test_every_offset_spelling_is_dropped_the_same_way(self):
+        frame = pd.DataFrame(
+            {"When": ["2024-03-31T23:30:00+01:00", "2024-03-31T23:30:00+0100", "2024-03-31T23:30:00Z"]}
+        )
+
+        cleaned, _ = clean_dataframe(frame)
+
+        self.assertEqual(cleaned["When"].tolist(), [pd.Timestamp("2024-03-31 23:30:00")] * 3)
+
+    def test_a_column_without_offsets_gets_no_offset_note(self):
+        frame = pd.DataFrame({"Order Date": ["2024-01-01", "2024-01-02"], "Revenue": [1, 2]})
+
+        _, report = clean_dataframe(frame)
+
+        self.assertNotIn(OFFSETS_DROPPED_NOTE, report.notes)
+
+
+class MalformedFileTests(unittest.TestCase):
+    def test_a_data_row_wider_than_the_header_is_refused_by_name(self):
+        raw = b"Region,Revenue\nWest,100,999\nEast,200,888\n"
+
+        with self.assertRaises(ValueError) as caught:
+            read_tabular_file(raw, "sales.csv")
+
+        message = str(caught.exception)
+        self.assertIn("Line 2", message)
+        self.assertIn("3 values", message)
+        self.assertIn("2 columns", message)
+
+    def test_a_trailing_delimiter_on_every_row_is_the_same_refusal(self):
+        with self.assertRaises(ValueError):
+            read_tabular_file(b"Region,Revenue\nWest,100,\nEast,200,\n", "sales.csv")
+
+    def test_a_report_title_above_the_header_is_still_rescued(self):
+        raw = b"Q3 Sales Report\nRegion,Revenue\nWest,100\nEast,200\n"
+
+        frame = read_tabular_file(raw, "report.csv")
+
+        self.assertEqual(list(frame.columns), ["Region", "Revenue"])
+        self.assertEqual(frame["Region"].tolist(), ["West", "East"])
+
+    def test_a_workbook_with_truncated_xml_is_a_readable_error(self):
+        good = workbook_bytes([["Region", "Revenue"]] + [[f"R{i}", i] for i in range(50)])
+        for member, cut, reader in (
+            ("xl/workbook.xml", 40, list_excel_sheets),
+            ("xl/workbook.xml", 40, read_tabular_file),
+            ("xl/worksheets/sheet1.xml", 400, read_tabular_file),
+        ):
+            with self.subTest(member=member, reader=reader.__name__):
+                with self.assertRaises(ValueError) as caught:
+                    reader(truncated_member(good, member, cut), "book.xlsx")
+                self.assertIn("damaged", str(caught.exception))
+
+    def test_formulas_without_saved_results_are_refused_with_the_reason(self):
+        contents = workbook_bytes(
+            [["Region", "Units", "Revenue"], ["West", 2, "=B2*10"], ["East", 3, "=B3*10"]]
+        )
+
+        with self.assertRaises(ValueError) as caught:
+            read_tabular_file(contents, "book.xlsx")
+
+        message = str(caught.exception)
+        self.assertIn("formulas without saved results", message)
+        self.assertIn("Revenue", message)
+
+    def test_a_genuinely_empty_column_is_not_mistaken_for_a_formula(self):
+        contents = workbook_bytes([["Region", "Notes", "Revenue"], ["West", None, 10], ["East", None, 20]])
+
+        frame = read_tabular_file(contents, "book.xlsx")
+
+        self.assertEqual(frame["Revenue"].tolist(), [10, 20])
+        self.assertTrue(frame["Notes"].isna().all())
+
+
+class DateTiebreakTests(unittest.TestCase):
+    def test_a_tie_between_long_names_resolves_the_same_in_either_column_order(self):
+        stamps = pd.to_datetime(["2024-01-01", "2024-02-01", "2024-03-01"])
+        columns = {
+            "Transaction Date A": stamps,
+            "Transaction Date B": stamps,
+            "Revenue": [1, 2, 3],
+        }
+
+        forwards = detect_roles(pd.DataFrame(columns)).date
+        backwards = detect_roles(pd.DataFrame(dict(reversed(columns.items())))).date
+
+        self.assertEqual(forwards, "Transaction Date A")
+        self.assertEqual(backwards, "Transaction Date A")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_contract_metrics.py
+++ b/tests/test_contract_metrics.py
@@ -1,0 +1,245 @@
+"""One metric contract, honoured on every surface.
+
+A rate is an average. It is never summed, it moves in percentage points, no
+segment holds a share of it, and nothing that draws or ranks it may quietly
+compute something else. These tests use the reviewer's fixtures, chosen so
+that a sum and a mean give different numbers.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+import pandas as pd
+
+from aggregation import build_trend, driver_frame, segment_period_change
+from ai_insights import AIQueryPlan, _to_query_plan, describe_query_plan
+from autovis import ChartSpec
+from business_insights import analyze_business, build_business_report
+from formatting import format_number
+from metrics import resolve_metric
+from nlq import answer_question, execute_plan
+from schema import detect_roles
+from ui import _explore_frame
+
+
+def rate_fixture() -> pd.DataFrame:
+    """December and January: one Alpha at 10% and three Beta at 20%.
+
+    February: three Alpha at 10% and one Beta at 40%. The overall mean is
+    17.5% in every month, while the segment means move.
+    """
+    rows = []
+    for month in ("2024-12-31", "2025-01-31"):
+        rows.append((month, "Alpha", 0.10))
+        rows.extend((month, "Beta", 0.20) for _ in range(3))
+    rows.extend(("2025-02-28", "Alpha", 0.10) for _ in range(3))
+    rows.append(("2025-02-28", "Beta", 0.40))
+    frame = pd.DataFrame(rows, columns=["Date", "Region", "Conversion Rate"])
+    frame["Date"] = pd.to_datetime(frame["Date"])
+    return frame
+
+
+class RateContractTests(unittest.TestCase):
+    def setUp(self):
+        self.frame = rate_fixture()
+        self.roles = detect_roles(self.frame)
+        self.assertEqual(self.roles.measure, "Conversion Rate")
+        self.assertEqual(self.roles.dimension, "Region")
+
+    def test_the_contract_says_what_a_rate_is(self):
+        metric = resolve_metric("Conversion Rate")
+        self.assertEqual(metric.aggregation, "mean")
+        self.assertEqual(metric.unit, "rate")
+        self.assertFalse(metric.additive)
+        self.assertEqual(metric.combines_as, "average")
+
+        amount = resolve_metric("Revenue")
+        self.assertEqual(amount.aggregation, "sum")
+        self.assertTrue(amount.additive)
+        self.assertEqual(resolve_metric(None).aggregation, "count")
+
+    def test_the_overall_rate_is_flat_and_the_brief_says_so(self):
+        series = build_trend(self.frame, self.roles)
+        np.testing.assert_allclose(series.frame["Value"].to_numpy(), [0.175, 0.175, 0.175])
+
+        brief = analyze_business(self.frame, self.roles)
+        trend = next(item for item in brief.evidence if item.kind == "trend")
+        self.assertEqual(trend.tone, "neutral")
+        self.assertIn("was unchanged", trend.statement)
+        self.assertIn("17.5%", trend.statement)
+        self.assertNotIn("+0.0%", brief.headline)
+
+    def test_segment_mean_changes_are_never_added_up_as_a_net(self):
+        # Alpha 10 -> 10 and Beta 20 -> 40 sum to twenty points of "movement"
+        # in a metric that did not move. Nothing may present that sum.
+        brief = analyze_business(self.frame, self.roles)
+        report = build_business_report(self.frame, brief, source_name="rates.csv")
+        driver = next(item for item in brief.evidence if item.kind == "driver")
+
+        self.assertIn("percentage points", driver.value)
+        self.assertIn("from 20.0% to 40.0%", driver.statement)
+        self.assertNotIn("increased by 20.0%", driver.statement)
+        self.assertNotIn("net movement", report)
+        self.assertNotIn("of all movement", report)
+        self.assertIn("do not add up", driver.statement)
+
+    def test_no_segment_holds_a_share_of_a_rate(self):
+        brief = analyze_business(self.frame, self.roles)
+        leader = next(item for item in brief.evidence if item.kind == "leader")
+        kinds = [item.kind for item in brief.evidence]
+
+        self.assertNotIn("concentration", kinds)
+        self.assertNotIn("contributing", leader.statement)
+        self.assertNotIn("69.6%", leader.statement)
+        self.assertIn("highest average", leader.statement)
+        self.assertNotIn("coming from the leading", brief.headline)
+
+    def test_the_movement_chart_has_no_net_bar_for_a_rate(self):
+        # driver_frame feeds the movement chart; for a rate it lists segment
+        # point changes and never an "Other segments" remainder to sum.
+        drivers = driver_frame(self.frame, self.roles)
+        self.assertNotIn("Other segments", drivers["Segment"].tolist())
+        by_segment = dict(zip(drivers["Segment"], drivers["Change"], strict=True))
+        self.assertAlmostEqual(by_segment["Beta"], 0.20)
+        self.assertAlmostEqual(by_segment["Alpha"], 0.0)
+
+    def test_a_segment_absent_from_a_period_has_no_change(self):
+        # Gamma appears only in February: it has no January average to have
+        # moved from, so it is not a driver "rising from 0.0%".
+        frame = pd.concat(
+            [
+                self.frame,
+                pd.DataFrame(
+                    {"Date": [pd.Timestamp("2025-02-28")], "Region": ["Gamma"], "Conversion Rate": [0.5]}
+                ),
+            ],
+            ignore_index=True,
+        )
+        grouped, _, _ = segment_period_change(frame, detect_roles(frame))
+        self.assertNotIn("Gamma", grouped.index.tolist())
+        report = build_business_report(frame, analyze_business(frame), source_name="rates.csv")
+        self.assertNotIn("from 0.0%", report)
+
+    def test_explore_groups_a_rate_by_its_mean(self):
+        # D-02: Alpha's records are all 10%; Explore used to show 0.5.
+        spec = ChartSpec(form="bar", rationale="", x="Region", y="Conversion Rate")
+        frame = _explore_frame(self.frame, spec)
+        by_region = dict(zip(frame["Region"], frame["Conversion Rate"], strict=True))
+        self.assertAlmostEqual(by_region["Alpha"], 0.10)
+        self.assertAlmostEqual(by_region["Beta"], 1.6 / 7)
+
+    def test_ranked_growth_of_a_rate_compares_period_means_in_points(self):
+        # D-02: sums said Alpha grew 200% (10% -> 30%) while every Alpha record
+        # stayed at 10%, and ranked Beta at -33% while its mean doubled.
+        result = answer_question("top 2 Region conversion rate growth", self.frame, self.roles)
+        self.assertIsNotNone(result)
+        self.assertIn("Beta moved fastest", result.answer)
+        self.assertIn("+20.0 percentage points", result.answer)
+        self.assertIn("(20.0% → 40.0%)", result.answer)
+        self.assertIn("Change (pp)", result.table.columns)
+        by_region = dict(zip(result.table["Region"], result.table["Change (pp)"], strict=True))
+        self.assertAlmostEqual(by_region["Alpha"], 0.0)
+        self.assertNotIn("200", result.answer)
+
+    def test_overall_growth_of_a_rate_is_in_points(self):
+        result = answer_question("conversion rate growth", self.frame, self.roles)
+        self.assertIn("0.0 percentage points", result.answer)
+        self.assertIn("(17.5% → 17.5%)", result.answer)
+        self.assertIn("average", result.calculation)
+
+    def test_ai_time_plans_are_validated_against_the_executed_aggregation(self):
+        # D-03: a sum over a rate trend was approved as "total ... per month"
+        # and executed as means. Now it is refused, and the honest plan runs.
+        summed = AIQueryPlan(
+            answerable=True, intent="trend", aggregation="sum", measure="Conversion Rate", grain="M"
+        )
+        self.assertIsNone(_to_query_plan(summed, self.frame, self.roles))
+
+        averaged = AIQueryPlan(
+            answerable=True, intent="trend", aggregation="mean", measure="Conversion Rate", grain="M"
+        )
+        plan = _to_query_plan(averaged, self.frame, self.roles)
+        self.assertIsNotNone(plan)
+        sentence = describe_query_plan(plan)
+        self.assertIn("average", sentence.lower())
+        self.assertNotIn("total", sentence.lower())
+        answer = execute_plan(plan, self.frame, self.roles)
+        self.assertIn("mean(Conversion Rate)", answer.calculation)
+        self.assertIn("17.5%", answer.answer)
+
+    def test_every_intent_agrees_with_the_contract_for_amounts_and_rates(self):
+        amounts = self.frame.assign(Revenue=[100, 200, 200, 200, 100, 200, 200, 200, 100, 100, 100, 400])
+        roles = detect_roles(amounts)
+        for measure, wanted in (("Conversion Rate", "mean"), ("Revenue", "sum")):
+            for intent, kwargs in (
+                ("aggregate", {}),
+                ("breakdown", {"dimension": "Region"}),
+                ("rank", {"dimension": "Region", "top_n": 1}),
+                ("trend", {"grain": "M"}),
+                ("growth", {}),
+            ):
+                other = "sum" if wanted == "mean" else "mean"
+                with self.subTest(measure=measure, intent=intent):
+                    honest = AIQueryPlan(
+                        answerable=True, intent=intent, aggregation=wanted, measure=measure, **kwargs
+                    )
+                    plan = _to_query_plan(honest, amounts, roles)
+                    self.assertIsNotNone(plan)
+                    self.assertEqual(plan.aggregation, wanted)
+                    if intent in ("trend", "growth"):
+                        dishonest = AIQueryPlan(
+                            answerable=True, intent=intent, aggregation=other, measure=measure, **kwargs
+                        )
+                        self.assertIsNone(_to_query_plan(dishonest, amounts, roles))
+
+    def test_an_explicit_grouped_sum_is_honoured_or_refused_like_the_ungrouped_one(self):
+        # D-06: "total conversion rate" summed; adding "by Region" silently
+        # switched to a mean. The two must agree.
+        alone = answer_question("total conversion rate", self.frame, self.roles)
+        grouped = answer_question("total conversion rate by Region", self.frame, self.roles)
+        plain = answer_question("conversion rate by Region", self.frame, self.roles)
+
+        self.assertEqual(alone.plan.aggregation, "sum")
+        self.assertEqual(grouped.plan.aggregation, "sum")
+        self.assertEqual(plain.plan.aggregation, "mean")
+        self.assertIn("average conversion rate", plain.answer)
+        self.assertIn("22.9%", plain.answer)
+
+
+class RateScaleTests(unittest.TestCase):
+    def test_a_scalar_is_formatted_against_its_column(self):
+        # D-08: [0.5, 2.0] is in percentage points. The minimum is 0.5%, not
+        # the 50.0% that formatting the scalar alone produced.
+        frame = pd.DataFrame({"Conversion Rate": [0.5, 2.0], "Channel": ["a", "b"]})
+        roles = detect_roles(frame)
+        answer = answer_question("minimum conversion rate", frame, roles)
+        self.assertIn("0.5%", answer.answer)
+        self.assertNotIn("50.0%", answer.answer)
+
+        brief = analyze_business(frame, roles)
+        values = [item.value for item in brief.kpis if "Conversion Rate" in item.label]
+        self.assertIn("1.2%", values)
+        self.assertEqual(
+            format_number(0.5, "Conversion Rate", column_values=frame["Conversion Rate"]), "0.5%"
+        )
+
+    def test_a_rate_change_is_reported_in_points_on_the_dashboard(self):
+        frame = pd.DataFrame(
+            {
+                "Date": pd.to_datetime(["2025-01-31", "2025-02-28", "2025-03-31", "2025-04-30"]),
+                "Conversion Rate": [0.10, 0.10, 0.10, 0.20],
+                "Channel": ["a", "a", "a", "a"],
+            }
+        )
+        brief = analyze_business(frame, detect_roles(frame))
+        trend = next(item for item in brief.evidence if item.kind == "trend")
+        self.assertIn("10.0 percentage points", trend.statement)
+        self.assertEqual(trend.value, "+10.0 pp")
+        self.assertNotIn("100.0%", trend.statement)
+        self.assertIn("percentage points", trend.calculation)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_contract_names.py
+++ b/tests/test_contract_names.py
@@ -1,0 +1,145 @@
+"""Nothing ADA computes may depend on what the user called their columns.
+
+Every intermediate column is private, and every display column is chosen
+against the names actually present, so a dimension called "Latest", a
+measure called "__period" or a metric called "None" is just a column.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import pandas as pd
+
+from autovis import ChartSpec
+from nlq import answer_question
+from pipeline import NO_SELECTION, apply_role_selection
+from schema import detect_roles
+from ui import _explore_frame
+
+ADVERSARIAL_NAMES = (
+    "Latest",
+    "Previous",
+    "Change %",
+    "Change (pp)",
+    "Share %",
+    "Rows",
+    "Records",
+    "Value",
+    "Segment",
+    "Period",
+    "__period",
+    "__segment",
+    "__measure",
+    "__value",
+    "__0",
+    "None",
+)
+
+
+def base_frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "Date": pd.to_datetime(
+                ["2024-01-01", "2024-02-01", "2024-01-01", "2024-02-01", "2024-01-01", "2024-02-01"]
+            ),
+            "Region": ["Alpha", "Alpha", "Beta", "Beta", "Gamma", "Gamma"],
+            "Revenue": [100.0, 200.0, 100.0, 150.0, 50.0, 40.0],
+        }
+    )
+
+
+class RenameInvarianceTests(unittest.TestCase):
+    """The same data under adversarial headers gives the same answers."""
+
+    def answers(self, frame: pd.DataFrame, dimension: str, measure: str) -> dict[str, tuple]:
+        roles = detect_roles(frame)
+        # Chat questions name the columns as the user did.
+        growth = answer_question(f"which {dimension} grew fastest", frame, roles)
+        breakdown = answer_question(f"{measure} by {dimension}", frame, roles)
+        ranked = answer_question(f"top 2 {dimension} by {measure}", frame, roles)
+        counted = answer_question(f"how many rows by {dimension}", frame, roles)
+        return {
+            "growth": (
+                str(growth.table.iloc[0][dimension]),
+                float(
+                    growth.table.iloc[0][
+                        [c for c in growth.table.columns if c.startswith("Change") and c != dimension][0]
+                    ]
+                ),
+                growth.answer.split(" moved")[0],
+            ),
+            "breakdown": tuple(breakdown.table[dimension].tolist()),
+            "ranked": (tuple(ranked.table[dimension].tolist()), ranked.answer.split(" is the")[0]),
+            "counted": tuple(counted.table[dimension].tolist()),
+        }
+
+    def test_a_dimension_may_be_called_anything(self):
+        expected = self.answers(base_frame(), "Region", "Revenue")
+        self.assertEqual(expected["growth"][:2], ("Alpha", 100.0))
+        for name in ADVERSARIAL_NAMES:
+            with self.subTest(dimension=name):
+                frame = base_frame().rename(columns={"Region": name})
+                self.assertEqual(self.answers(frame, name, "Revenue"), expected)
+
+    def test_a_measure_may_be_called_anything(self):
+        expected = self.answers(base_frame(), "Region", "Revenue")
+        for name in ("Period", "__period", "__measure", "Value", "Latest", "Rows", "None"):
+            with self.subTest(measure=name):
+                frame = base_frame().rename(columns={"Revenue": name})
+                self.assertEqual(self.answers(frame, "Region", name), expected)
+
+    def test_the_growth_table_never_overwrites_the_dimension(self):
+        for name in ("Latest", "Previous", "Change %"):
+            with self.subTest(dimension=name):
+                frame = base_frame().rename(columns={"Region": name})
+                result = answer_question(f"which {name} grew fastest", frame, detect_roles(frame))
+                self.assertIn("Alpha moved fastest", result.answer)
+                self.assertEqual(result.table[name].tolist()[0], "Alpha")
+                self.assertEqual(len(set(result.table.columns)), len(result.table.columns))
+
+    def test_a_share_column_never_overwrites_the_dimension(self):
+        frame = base_frame().rename(columns={"Region": "Share %"})
+        result = answer_question("revenue by share %", frame, detect_roles(frame))
+        self.assertIn("Alpha is the leading", result.answer)
+        self.assertEqual(result.table["Share %"].tolist()[0], "Alpha")
+
+    def test_a_dimension_called_rows_survives_a_count(self):
+        frame = base_frame().rename(columns={"Region": "Rows"})
+        result = answer_question("how many rows by rows", frame, detect_roles(frame))
+        self.assertIsNotNone(result)
+        self.assertEqual(sorted(result.table["Rows"].tolist()), ["Alpha", "Beta", "Gamma"])
+
+
+class ExploreNameTests(unittest.TestCase):
+    def test_a_count_chart_finds_a_free_name_however_many_are_taken(self):
+        # D-14: Records, Record count and Rows all present exhausted the
+        # three-name generator and raised StopIteration.
+        frame = pd.DataFrame(
+            {
+                "Records": ["a", "b", "a", "c"],
+                "Record count": [1, 2, 3, 4],
+                "Rows": [5, 6, 7, 8],
+                "Records (2)": [9, 9, 9, 9],
+            }
+        )
+        spec = ChartSpec(form="bar", rationale="", x="Records", aggregation="count")
+        counted = _explore_frame(frame, spec)
+        value = [column for column in counted.columns if column != "Records"][0]
+        self.assertNotIn(value, frame.columns)
+        self.assertEqual(dict(zip(counted["Records"], counted[value], strict=True)), {"a": 2, "b": 1, "c": 1})
+
+
+class SelectionSentinelTests(unittest.TestCase):
+    def test_a_column_called_none_can_be_the_metric(self):
+        frame = base_frame().rename(columns={"Revenue": "None"})
+        detected = detect_roles(frame)
+        self.assertEqual(detected.measure, "None")
+        chosen = apply_role_selection(detected, date="Date", measure="None", dimension="Region")
+        self.assertEqual(chosen.measure, "None")
+        cleared = apply_role_selection(detected, date="Date", measure=NO_SELECTION, dimension="Region")
+        self.assertIsNone(cleared.measure)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_contract_presentation.py
+++ b/tests/test_contract_presentation.py
@@ -1,0 +1,226 @@
+"""What the page shows is a preview of what was computed, and says so.
+
+Direction and desirability are separate things; a cap is a reading budget,
+not a result; a sample is disclosed; and a period with no observation is
+not a period that measured zero.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+
+import numpy as np
+import pandas as pd
+
+from aggregation import build_trend
+from autovis import ChartSpec
+from business_insights import Evidence, analyze_business, build_business_report, preview_evidence
+from metrics import increase_is_welcome
+from pipeline import prepare_analysis
+from schema import ColumnRoles, detect_roles
+from ui import _explore_frame
+
+
+def cost_fixture() -> pd.DataFrame:
+    rows = []
+    for month, costs in (
+        ("2024-11-15", (100, 100, 100)),
+        ("2024-12-15", (100, 100, 100)),
+        ("2025-01-15", (100, 100, 100)),
+        ("2025-02-15", (20, 130, 130)),
+    ):
+        rows.extend(
+            (month, segment, cost) for segment, cost in zip(("Alpha", "Beta", "Gamma"), costs, strict=True)
+        )
+    frame = pd.DataFrame(rows, columns=["Date", "Segment", "Cost"])
+    frame["Date"] = pd.to_datetime(frame["Date"])
+    return frame
+
+
+class DirectionAndDesirabilityTests(unittest.TestCase):
+    def test_a_cost_reduction_keeps_its_driver_and_asks_for_more_of_it(self):
+        # D-17: total cost 300 -> 280 is good news, driven by Alpha's 80
+        # reduction. The driver used to be discarded as "negative" and the
+        # recommendation asked which segment created the latest increase.
+        frame = cost_fixture()
+        roles = detect_roles(frame)
+        self.assertEqual(roles.measure, "Cost")
+        brief = analyze_business(frame, roles)
+        trend = next(item for item in brief.evidence if item.kind == "trend")
+        driver = next(item for item in brief.evidence if item.kind == "driver")
+        report = build_business_report(frame, brief, source_name="costs.csv")
+
+        self.assertEqual(trend.tone, "positive")
+        self.assertIn("decreased", trend.statement)
+        self.assertEqual(driver.tone, "positive")
+        self.assertEqual(driver.subject, "Alpha")
+        self.assertNotIn("latest increase", report)
+        self.assertNotIn("growth plan", report.lower())
+        self.assertIn("reduction", report.lower())
+
+    def test_direction_of_good_is_read_from_the_whole_name(self):
+        self.assertTrue(increase_is_welcome("Revenue After Returns"))
+        self.assertTrue(increase_is_welcome("Cost Savings"))
+        self.assertFalse(increase_is_welcome("Refund Amount"))
+        self.assertFalse(increase_is_welcome("Cost"))
+        self.assertTrue(increase_is_welcome("Units"))
+
+    def test_a_flat_metric_is_flat(self):
+        frame = pd.DataFrame(
+            {
+                "Date": pd.to_datetime(["2025-01-31", "2025-02-28", "2025-03-31", "2025-04-30"]),
+                "Revenue": [100.0, 100.0, 100.0, 100.0],
+            }
+        )
+        brief = analyze_business(frame, detect_roles(frame))
+        trend = next(item for item in brief.evidence if item.kind == "trend")
+        self.assertEqual(trend.tone, "neutral")
+        self.assertIn("was unchanged", trend.statement)
+        self.assertNotIn("increased 0", trend.statement)
+        titles = [item.title for item in brief.recommendations]
+        self.assertNotIn("Protect what improved", titles)
+
+
+class CapTests(unittest.TestCase):
+    def test_every_anomaly_is_counted_and_the_preview_says_how_many_it_shows(self):
+        # D-18: 60 quarter-ends, every sixth at 1,000. Ten anomalies, of
+        # which the card shows five -- and must say so.
+        dates = pd.date_range("2010-03-31", periods=60, freq="QE")
+        values = np.where(np.arange(60) % 6 == 5, 1000.0, 100.0)
+        frame = pd.DataFrame({"Date": dates, "Revenue": values})
+        brief = analyze_business(frame, detect_roles(frame))
+        anomaly = next(item for item in brief.evidence if item.kind == "anomaly")
+        self.assertEqual(anomaly.value, "10")
+        self.assertIn("10 periods sit outside", anomaly.statement)
+        self.assertIn("showing the sharpest 5", anomaly.statement)
+
+    def test_a_preview_never_drops_the_quality_card(self):
+        cards = [
+            Evidence(kind=f"k{i}", title=str(i), value="", statement="", calculation="") for i in range(7)
+        ]
+        quality = Evidence(kind="quality", title="Data quality", value="", statement="", calculation="")
+        shown = preview_evidence([*cards, quality], limit=4)
+        self.assertEqual(len(shown), 4)
+        self.assertIs(shown[-1], quality)
+        self.assertEqual([item.title for item in shown[:3]], ["0", "1", "2"])
+        untouched = preview_evidence(cards[:3], limit=4)
+        self.assertEqual(untouched, cards[:3])
+
+    def test_the_brief_keeps_every_finding(self):
+        rng = np.random.default_rng(7)
+        months = pd.date_range("2022-01-31", periods=36, freq="ME")
+        rows = []
+        for index, month in enumerate(months):
+            for region, weight in (("North", 3.0), ("South", 1.0), ("East", 1.0)):
+                revenue = 1000.0 * weight * (1 + 0.02 * index) + rng.normal(0, 20)
+                if index in (10, 20) and region == "North":
+                    revenue *= 4
+                rows.append(
+                    (month, region, revenue, revenue * 0.6 + rng.normal(0, 10), None if index % 5 else 1.0)
+                )
+        frame = pd.DataFrame(rows, columns=["Date", "Region", "Revenue", "Cost", "Discount"])
+        frame.loc[3, "Region"] = None
+        brief = analyze_business(frame, detect_roles(frame))
+        kinds = [item.kind for item in brief.evidence]
+        self.assertGreater(len(kinds), 6, kinds)
+        self.assertEqual(len(kinds), len(set(kinds)))
+        self.assertLessEqual(len(preview_evidence(brief.evidence, 6)), 6)
+
+
+class ChartPayloadTests(unittest.TestCase):
+    def test_a_distribution_is_binned_over_every_row(self):
+        # D-19: 20,000 ones then 1,000 of 10,000; the first-N sample showed
+        # no tail at all.
+        frame = pd.DataFrame({"Revenue": [1.0] * 20_000 + [10_000.0] * 1_000})
+        spec = ChartSpec(form="histogram", rationale="", x="Revenue")
+        binned = _explore_frame(frame, spec)
+        self.assertEqual(int(binned["Records"].sum()), 21_000)
+        self.assertEqual(int(binned["Records"].iloc[-1]), 1_000)
+        self.assertIn("All 21,000 values", binned.attrs["note"])
+
+    def test_a_time_series_is_trimmed_in_whole_periods(self):
+        # D-19: five series over 81 dates, one missing on the last date, is
+        # 404 rows. A 400-row cut split the earliest date across series.
+        dates = pd.date_range("2024-01-01", periods=81, freq="D")
+        rows = [(date, series, 1.0) for date in dates for series in "ABCDE"]
+        rows = [row for row in rows if not (row[0] == dates[-1] and row[1] == "E")]
+        frame = pd.DataFrame(rows, columns=["Date", "Series", "Value"])
+        spec = ChartSpec(form="line", rationale="", x="Date", y="Value", color="Series")
+        plotted = _explore_frame(frame, spec, limit=400)
+        per_date = plotted.groupby("Date")["Series"].nunique()
+        self.assertTrue((per_date.iloc[:-1] == 5).all(), per_date.value_counts())
+        self.assertLessEqual(len(plotted), 400)
+        self.assertIn("most recent", plotted.attrs["note"])
+
+    def test_a_scatter_sample_is_spread_and_disclosed(self):
+        frame = pd.DataFrame({"X": np.arange(50_000, dtype=float), "Y": np.arange(50_000, dtype=float)})
+        spec = ChartSpec(form="scatter", rationale="", x="X", y="Y")
+        points = _explore_frame(frame, spec)
+        self.assertLessEqual(len(points), 20_000)
+        self.assertGreater(points["X"].max(), 49_000)
+        self.assertIn("every 3th point", points.attrs["note"].replace("3rd", "3th"))
+
+
+class CalendarTests(unittest.TestCase):
+    def test_a_rate_with_no_observation_in_a_month_has_no_rate_that_month(self):
+        # D-13: 20% in January, March and April got a 0% February inserted.
+        frame = pd.DataFrame(
+            {
+                "Date": pd.to_datetime(["2025-01-31", "2025-03-31", "2025-04-30"]),
+                "Conversion Rate": [0.2, 0.2, 0.2],
+            }
+        )
+        series = build_trend(frame, detect_roles(frame))
+        february = series.frame.loc[series.frame["Period"] == pd.Timestamp("2025-02-01"), "Value"]
+        self.assertEqual(len(february), 1)
+        self.assertTrue(np.isnan(float(february.iloc[0])))
+        brief = analyze_business(frame, detect_roles(frame))
+        report = build_business_report(frame, brief, source_name="rates.csv")
+        self.assertIsNone(re.search(r"(?<![\d.])0\.0%", report), report)
+
+    def test_a_row_with_a_missing_value_is_a_missing_period_not_a_zero(self):
+        frame = pd.DataFrame(
+            {
+                "Date": pd.to_datetime(["2025-01-31", "2025-02-28", "2025-03-31", "2025-04-30"]),
+                "Revenue": [100.0, np.nan, 100.0, 100.0],
+            }
+        )
+        series = build_trend(frame, detect_roles(frame))
+        february = float(
+            series.frame.loc[series.frame["Period"] == pd.Timestamp("2025-02-01"), "Value"].iloc[0]
+        )
+        self.assertTrue(np.isnan(february))
+
+    def test_two_readings_are_not_spread_into_invented_weeks(self):
+        frame = pd.DataFrame(
+            {"Month": pd.to_datetime(["2024-01-31", "2024-02-29"]), "Revenue": [100.0, 120.0]}
+        )
+        series = build_trend(frame, detect_roles(frame))
+        self.assertEqual(len(series.frame), 2)
+        self.assertEqual(series.filled_periods, 0)
+
+    def test_a_truncated_leading_period_is_dropped_not_reported_as_a_jump(self):
+        # D-13: cutting a two-record February to one record produced an
+        # artificial February 100 -> March 200 jump.
+        rows = [(f"2025-{month:02d}-{day:02d}", 100.0) for month in range(2, 10) for day in (10, 20)]
+        frame = pd.DataFrame(rows, columns=["Date", "Revenue"])
+        frame["Date"] = pd.to_datetime(frame["Date"])
+        # Fifteen of sixteen rows: one February record is cut, so February
+        # is a partial period and must not be analyzed as a whole one.
+        prepared = prepare_analysis(frame, row_limit=15)
+        roles = ColumnRoles(
+            date="Date",
+            measure="Revenue",
+            dimension=None,
+            identifier=None,
+            numeric=("Revenue",),
+            dimensions=(),
+        )
+        series = build_trend(prepared.dataframe, roles)
+        self.assertEqual(series.frame["Period"].min(), pd.Timestamp("2025-03-01"))
+        self.assertEqual(prepared.analyzed_from, pd.Timestamp("2025-03-10"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_contract_review_fixes.py
+++ b/tests/test_contract_review_fixes.py
@@ -1,0 +1,140 @@
+"""The eight defects a review of the consistency release found.
+
+Every one of them passed the 385 tests that shipped with the change. They are
+here so the tests and the behaviour are the same size: a suite that is green
+against a forecast reading "nan" is a suite measuring the wrong thing.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+import pandas as pd
+
+from aggregation import build_trend
+from ai_insights import _usable_dimension
+from analysis import _read_formatted_number
+from anomalies import detect_anomalies
+from autovis import ChartSpec
+from forecasting import build_forecast
+from nlq import answer_question
+from pipeline import prepare_analysis
+from schema import detect_roles
+from ui import _explore_frame
+
+
+def monthly(values, *, measure="Revenue", start="2022-01-31"):
+    dates = pd.date_range(start, periods=len(values), freq="ME")
+    return pd.DataFrame({"Date": dates, measure: values})
+
+
+class UnobservedPeriodTests(unittest.TestCase):
+    """A blank month is not a number the arithmetic can carry."""
+
+    def test_one_blank_month_does_not_make_the_whole_forecast_nan(self):
+        values = [100.0 + 5 * i for i in range(24)]
+        values[7] = np.nan
+        frame = monthly(values)
+        series = build_trend(frame, detect_roles(frame))
+        self.assertTrue(series.frame["Value"].isna().any(), "fixture must contain the gap")
+
+        forecast = build_forecast(series.frame)
+        self.assertIsNotNone(forecast)
+        for name in ("values", "lower", "upper"):
+            numbers = np.asarray(getattr(forecast, name), dtype=float)
+            self.assertFalse(np.isnan(numbers).any(), f"{name} carries NaN")
+
+    def test_a_spike_is_still_found_when_a_month_is_blank(self):
+        values = [100.0] * 24
+        values[5] = np.nan
+        values[18] = 1000.0
+        frame = monthly(values)
+        series = build_trend(frame, detect_roles(frame))
+        found = detect_anomalies(series.frame)
+        self.assertTrue(found, "an obvious spike went unreported")
+
+    def test_a_rate_with_a_missing_month_still_forecasts(self):
+        # The other path into NaN: rate gaps are filled with NaN by design.
+        dates = [d for d in pd.date_range("2022-01-31", periods=24, freq="ME")]
+        del dates[9]
+        frame = pd.DataFrame({"Date": dates, "Conversion Rate": [0.2 + 0.001 * i for i in range(23)]})
+        series = build_trend(frame, detect_roles(frame))
+        self.assertEqual(series.filled_periods, 1)
+
+        forecast = build_forecast(series.frame)
+        self.assertIsNotNone(forecast)
+        self.assertFalse(np.isnan(np.asarray(forecast.values, dtype=float)).any())
+
+    def test_the_caption_does_not_call_a_rate_gap_a_zero(self):
+        dates = [d for d in pd.date_range("2022-01-31", periods=12, freq="ME")]
+        del dates[4]
+        rates = pd.DataFrame({"Date": dates, "Conversion Rate": [0.2] * 11})
+        note = " ".join(build_trend(rates, detect_roles(rates)).notes)
+        self.assertIn("left empty", note)
+        self.assertNotIn("counted as zero", note)
+
+        # An amount still says zero, because for an amount that is true.
+        amounts = pd.DataFrame({"Date": dates, "Revenue": [100.0] * 11})
+        amount_note = " ".join(build_trend(amounts, detect_roles(amounts)).notes)
+        self.assertIn("counted as zero", amount_note)
+
+
+class TrimTests(unittest.TestCase):
+    def test_a_row_cap_never_empties_a_single_period_file(self):
+        # A quarter of a million rows from one busy week: every kept row sits
+        # in the one truncated period, and dropping it left nothing at all.
+        dates = pd.to_datetime(["2025-03-03"] * 400)
+        frame = pd.DataFrame({"Date": dates, "Revenue": np.arange(400.0)})
+        prepared = prepare_analysis(frame, row_limit=100)
+        self.assertEqual(len(prepared.dataframe), 100)
+        self.assertGreater(prepared.dataframe["Revenue"].sum(), 0)
+
+
+class FilterTests(unittest.TestCase):
+    def test_a_filter_matches_every_spelling_of_the_value(self):
+        # "West" and "west" are one word to the parser and two rows to pandas.
+        frame = pd.DataFrame(
+            {
+                "Region": ["West"] * 15 + ["west"] * 15 + ["East"] * 10,
+                "Revenue": [10.0] * 40,
+            }
+        )
+        answer = answer_question("total revenue for west", frame, detect_roles(frame))
+        self.assertIsNotNone(answer)
+        self.assertIn("300", answer.answer.replace(",", ""))
+
+
+class NumberTests(unittest.TestCase):
+    def test_a_parenthesised_number_stays_negative_whatever_leads_it(self):
+        self.assertEqual(_read_formatted_number("(+100)"), -100.0)
+        self.assertEqual(_read_formatted_number("(100)"), -100.0)
+        self.assertEqual(_read_formatted_number("(-100)"), -100.0)
+        self.assertEqual(_read_formatted_number("-100"), -100.0)
+        self.assertEqual(_read_formatted_number("100"), 100.0)
+
+
+class DimensionGuardTests(unittest.TestCase):
+    def test_a_unique_text_column_is_not_a_segment_even_without_code_shapes(self):
+        # Sixty distinct emails group into sixty rows of one - the table
+        # again, with a chart drawn on it.
+        emails = pd.DataFrame({"Customer Email": [f"person{i}@example.com" for i in range(60)]})
+        self.assertFalse(_usable_dimension(emails, "Customer Email"))
+        # A real segment still passes.
+        regions = pd.DataFrame({"Region": ["North", "South"] * 30})
+        self.assertTrue(_usable_dimension(regions, "Region"))
+
+
+class ChartNameTests(unittest.TestCase):
+    def test_a_measure_called_records_survives_a_histogram(self):
+        frame = pd.DataFrame({"Records": np.random.default_rng(3).normal(100, 10, 500)})
+        binned = _explore_frame(frame, ChartSpec(form="histogram", rationale="", x="Records"))
+        counts = binned.attrs["count_column"]
+        self.assertNotEqual(counts, "Records")
+        self.assertEqual(int(binned[counts].sum()), 500)
+        # The bin edges are the measure, not the counts.
+        self.assertLess(binned["Records"].max(), 200)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_contract_runtime.py
+++ b/tests/test_contract_runtime.py
@@ -1,0 +1,219 @@
+"""What a long-lived server process serves after the code under it changes.
+
+Streamlit re-executes app.py on every rerun and reloads a stale module before
+any local import, but a reload is only half of a deploy: the parsed uploads
+are cached, the build label is cached, and the chat transcript is keyed on
+the dataset alone. Each of these could keep serving the previous revision
+after the reload had already replaced it. These tests reproduce that in a
+subprocess -- one process, two runs, source changed between them -- so the
+test process's own modules are never touched.
+"""
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+import pandas as pd
+
+from schema import ColumnRoles
+
+LABEL = re.compile(r"^[0-9a-f]{7}$")
+
+
+def _run_in_scratch(script: str) -> subprocess.CompletedProcess:
+    """Run a simulation script against a private copy of the checkout."""
+    root = Path(__file__).resolve().parent.parent
+    with tempfile.TemporaryDirectory() as scratch:
+        for path in root.glob("*.py"):
+            shutil.copy(path, scratch)
+        for folder in ("samples", ".streamlit", "assets"):
+            if (root / folder).exists():
+                shutil.copytree(root / folder, Path(scratch) / folder)
+        return subprocess.run(
+            [sys.executable, "-c", script],
+            cwd=scratch,
+            capture_output=True,
+            text=True,
+            timeout=600,
+            env={**os.environ, "PYTHONPATH": scratch},
+        )
+
+
+def _report(result: subprocess.CompletedProcess) -> dict:
+    if result.returncode != 0:
+        raise AssertionError(result.stderr[-3000:])
+    return json.loads(result.stdout.strip().splitlines()[-1])
+
+
+class UploadCacheTests(unittest.TestCase):
+    """A reloaded reader must not be answered from the old reader's cache."""
+
+    SIM = textwrap.dedent(
+        r"""
+        import sys, runpy, warnings, logging, io, contextlib, json
+        warnings.filterwarnings("ignore"); logging.disable(logging.CRITICAL)
+        def run():
+            with contextlib.redirect_stderr(io.StringIO()):
+                return runpy.run_path("app.py", run_name="__main__")
+        contents = b"Revenue\n10\n20\n"
+        page = run()
+        label1 = page["build_identifier"]()
+        first = page["read_uploaded_file"](contents, "t.csv", None, label1)["Revenue"].tolist()
+        with open("file_io.py", "a") as handle:
+            handle.write(
+                "\n\ndef read_tabular_file(contents, filename, sheet_name=None):\n"
+                "    import pandas as pd\n"
+                "    return pd.DataFrame({'Revenue': [100, 200]})\n"
+            )
+        page = run()
+        label2 = page["build_identifier"]()
+        second = page["read_uploaded_file"](contents, "t.csv", None, label2)["Revenue"].tolist()
+        print(json.dumps({"first": first, "second": second, "label1": label1, "label2": label2}))
+        """
+    )
+
+    def test_a_changed_reader_is_a_cache_miss_and_a_new_build_label(self):
+        report = _report(_run_in_scratch(self.SIM))
+
+        self.assertEqual(report["first"], [10, 20])
+        self.assertEqual(report["second"], [100, 200])
+        self.assertNotEqual(report["label1"], report["label2"])
+        # The scratch copy has no checkout, so the label is the digest alone.
+        self.assertRegex(report["label1"], LABEL)
+        self.assertRegex(report["label2"], LABEL)
+
+
+class BuildLabelTests(unittest.TestCase):
+    """The build label says what is served, and the commit is only a suffix."""
+
+    def setUp(self):
+        import app  # noqa: PLC0415 - importing runs the page once, in bare mode
+
+        self.app = app
+
+    def test_the_label_is_the_source_digest_with_the_commit_appended(self):
+        digest = hashlib.sha256()
+        for name in self.app._LOCAL_MODULES + ("app",):
+            digest.update(self.app._source_digest(name).encode())
+        sha = self.app._git_short_sha()
+        expected = digest.hexdigest()[:7] + (f"@{sha}" if sha else "")
+
+        self.assertEqual(self.app.build_identifier(), expected)
+
+    def test_the_commit_is_read_from_a_checkout(self):
+        with tempfile.TemporaryDirectory() as scratch:
+            root = Path(scratch)
+            (root / ".git" / "refs" / "heads").mkdir(parents=True)
+            (root / ".git" / "HEAD").write_text("ref: refs/heads/main\n")
+            head = root / ".git" / "refs" / "heads" / "main"
+            head.write_text("47b45020248c4021a0e1c0413409ee4e7a4ab49e\n")
+            self.assertEqual(self.app._git_short_sha(root), "47b4502")
+
+            (root / ".git" / "HEAD").write_text("0d12cc65a514a4dee6d483f260cd604676adea7e\n")
+            self.assertEqual(self.app._git_short_sha(root), "0d12cc6")
+
+        with tempfile.TemporaryDirectory() as scratch:
+            self.assertEqual(self.app._git_short_sha(Path(scratch)), "")
+
+
+class RevisionIdentityTests(unittest.TestCase):
+    """An answer, or a pending plan, must not survive the code that made it."""
+
+    def setUp(self):
+        import app  # noqa: PLC0415 - importing runs the page once, in bare mode
+
+        self.app = app
+        self.roles = ColumnRoles(
+            date=None, measure="revenue", dimension="region",
+            identifier=None, numeric=("revenue",), dimensions=("region",),
+        )
+        self.frame = pd.DataFrame({"region": ["N", "S"], "revenue": [1.0, 2.0]})
+
+    def test_a_new_build_is_a_different_dataset(self):
+        before = self.app.dataset_fingerprint(self.frame, self.roles, "q.csv")
+        original = self.app.build_identifier
+        self.app.build_identifier = lambda: "0000000@1111111"
+        try:
+            after = self.app.dataset_fingerprint(self.frame, self.roles, "q.csv")
+            again = self.app.dataset_fingerprint(self.frame, self.roles, "q.csv")
+        finally:
+            self.app.build_identifier = original
+
+        self.assertNotEqual(before, after)
+        self.assertEqual(after, again)
+        self.assertEqual(before, self.app.dataset_fingerprint(self.frame, self.roles, "q.csv"))
+
+
+class WarmReloadFailureTests(unittest.TestCase):
+    """A deploy that breaks a module must fail the way a cold start would.
+
+    The optional AI layer is guarded at import, but a stale copy of it is
+    reloaded before that guard runs. If the reload raises, the page is down
+    for a dependency the product does not need. A broken deterministic module
+    is a real outage, and the page must say which file, not show the redacted
+    traceback the host serves.
+    """
+
+    SIM = textwrap.dedent(
+        r"""
+        import json, warnings, logging
+        warnings.filterwarnings("ignore"); logging.disable(logging.CRITICAL)
+        from streamlit.testing.v1 import AppTest
+        first = AppTest.from_file("app.py", default_timeout=180).run()
+        broken = 'raise ImportError("simulated: %(module)s is broken on this deploy")\n'
+        open("%(module)s.py", "w").write(broken)
+        second = AppTest.from_file("app.py", default_timeout=180).run()
+        print(json.dumps({
+            "first_exceptions": [str(e.value) for e in first.exception],
+            "first_warnings": [str(w.value) for w in first.warning],
+            "second_exceptions": [str(e.value) for e in second.exception],
+            "second_warnings": [str(w.value) for w in second.warning],
+            "second_captions": [str(c.value) for c in second.caption],
+            "second_errors": [str(e.value) for e in second.error],
+            "second_tabs": len(second.tabs),
+        }))
+        """
+    )
+    AI_WARNING = "optional AI layer could not be loaded"
+
+    def test_a_broken_optional_module_degrades_the_page_instead_of_crashing_it(self):
+        report = _report(_run_in_scratch(self.SIM % {"module": "ai_insights"}))
+
+        self.assertEqual(report["first_exceptions"], [])
+        self.assertFalse(any(self.AI_WARNING in text for text in report["first_warnings"]))
+
+        self.assertEqual(report["second_exceptions"], [])
+        self.assertTrue(any(self.AI_WARNING in text for text in report["second_warnings"]))
+        self.assertIn(
+            "ImportError: simulated: ai_insights is broken on this deploy",
+            report["second_captions"],
+        )
+        # The deterministic product is untouched.
+        self.assertEqual(report["second_tabs"], 6)
+
+    def test_a_broken_deterministic_module_names_itself_and_still_fails(self):
+        report = _report(_run_in_scratch(self.SIM % {"module": "formatting"}))
+
+        self.assertEqual(report["first_exceptions"], [])
+        self.assertEqual(len(report["second_exceptions"]), 1)
+        self.assertIn("simulated: formatting is broken on this deploy", report["second_exceptions"][0])
+        self.assertEqual(
+            [text for text in report["second_errors"] if "formatting.py" in text],
+            [
+                "ADA could not load the deployed formatting.py into the running server: "
+                "ImportError: simulated: formatting is broken on this deploy. The page will "
+                "not render until the file is fixed or the server is restarted."
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_forecasting.py
+++ b/tests/test_forecasting.py
@@ -88,7 +88,7 @@ class ForecastTests(unittest.TestCase):
         assert forecast is not None
         self.assertIsNotNone(forecast.backtest.mase)
         self.assertLess(forecast.backtest.mase, 1.0)
-        self.assertIs(forecast.backtest.beats_no_change, True)
+        self.assertIs(forecast.backtest.beats_naive_on_holdout, True)
 
     def test_an_unforecastable_series_admits_it_did_not_beat_no_change(self):
         """A random walk has no trend to extrapolate; the scaled error says so."""
@@ -100,7 +100,7 @@ class ForecastTests(unittest.TestCase):
         assert forecast is not None
         self.assertIsNotNone(forecast.backtest.mase)
         self.assertGreater(forecast.backtest.mase, 1.0)
-        self.assertIs(forecast.backtest.beats_no_change, False)
+        self.assertIs(forecast.backtest.beats_naive_on_holdout, False)
 
     def test_seasonal_adjustments_do_not_shift_the_level(self):
         rng = np.random.default_rng(31)
@@ -129,9 +129,9 @@ class ForecastTests(unittest.TestCase):
 
         assert forecast is not None
         note = describe_backtest(forecast.backtest)
-        self.assertIn("held out the last", note)
-        self.assertIn("better than assuming no change", note)
-        self.assertNotIn("no better", note)
+        self.assertIn("on the last 4 held-out periods", note)
+        self.assertIn("would have erred 4.9% on the same periods, so the model beat it", note)
+        self.assertNotIn("did not beat", note)
 
     def test_the_error_note_is_honest_when_there_is_no_backtest(self):
         self.assertEqual(

--- a/tests/test_nlq.py
+++ b/tests/test_nlq.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 
 from demo_data import make_demo_data
-from nlq import QueryPlan, answer_question, execute_plan, parse_question, suggested_questions
+from nlq import QueryPlan, answer_question, execute_plan, suggested_questions
 from pipeline import prepare_analysis
 from schema import ColumnRoles, detect_roles
 
@@ -136,8 +136,16 @@ class NLQParsingTests(unittest.TestCase):
         roles = detect_roles(frame)
         result = answer_question("top 2 products by revenue", frame, roles)
         self.assertIsNotNone(result)
-        plan = parse_question("monthly revenue trend", frame, roles)
-        self.assertNotEqual(plan.intent if plan else None, "trend")
+        # Without a date column a trend question is not a total in disguise:
+        # the answer says there is no timeline, instead of quoting the all-time
+        # figure under a sentence about months.
+        result = answer_question("monthly revenue trend", frame, roles)
+        self.assertIsNotNone(result)
+        self.assertIn("no date column", result.answer)
+        self.assertNotIn("$", result.answer)
+        growth = answer_question("revenue growth", frame, roles)
+        self.assertIn("no date column", growth.answer)
+
     def test_asking_for_the_bottom_of_a_ranking_ranks_ascending(self):
         """"Least" and "fewest" ask for the bottom, not the top."""
         leader = self.ask("top product by revenue").answer

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -2,6 +2,7 @@ import unittest
 
 from demo_data import make_demo_data
 from pipeline import (
+    NO_SELECTION,
     apply_focus,
     apply_role_selection,
     cleaning_audit_frame,
@@ -27,7 +28,7 @@ class PipelineTests(unittest.TestCase):
 
         selected = apply_role_selection(
             prepared.detected_roles,
-            date="None",
+            date=NO_SELECTION,
             measure="Profit",
             dimension="Region",
         )

--- a/timeseries.py
+++ b/timeseries.py
@@ -157,3 +157,34 @@ def robust_scale(residuals: np.ndarray) -> float:
 
     fallback = float(np.mean(deviations)) * MEAN_ABS_DEV_SCALE
     return fallback if fallback > 0 else 0.0
+
+
+def observed_periods(trend: pd.DataFrame) -> pd.DataFrame:
+    """A trend with its unobserved periods removed.
+
+    A period whose every value was missing is held as NaN rather than zero -
+    that distinction is the whole point of the calendar rules in aggregation,
+    and it is right. But NaN is not a number the arithmetic downstream can
+    carry: ``to_numpy(dtype=float)`` hands it to Theil-Sen, one NaN makes the
+    slope NaN, and from there every forecast value, every band edge and every
+    residual is NaN. The visible damage was a forecast card reading "nan" and
+    the backtest caption saying the model "did not beat" a naive one it was
+    never scored against, plus anomaly detection returning nothing at all for
+    a series with an obvious spike in it.
+
+    So the gap is preserved where it means something - the chart, the caption,
+    the filled-period count - and dropped here, where a period with no
+    observation is simply not evidence about the trend. Fitting a line through
+    the periods that WERE observed is the honest reading of a series with a
+    hole in it; the alternative is refusing to forecast at all because one
+    month of a three-year history was blank.
+
+    Returns the frame unchanged when nothing is missing, so the common path
+    pays one ``isna`` and no copy.
+    """
+    if trend.empty or "Value" not in trend.columns:
+        return trend
+    missing = trend["Value"].isna()
+    if not missing.any():
+        return trend
+    return trend.loc[~missing]

--- a/ui.py
+++ b/ui.py
@@ -6,6 +6,7 @@ from html import escape
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import numpy as np
 import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
@@ -17,8 +18,9 @@ from anomalies import detect_anomalies
 from autovis import fold_small_series, recommend_chart
 from business_insights import BusinessBrief
 from forecasting import build_forecast, describe_backtest
-from formatting import format_number, format_period
-from nlq import QueryAnswer
+from formatting import format_number, format_period, rate_scale
+from metrics import resolve_metric
+from nlq import QueryAnswer, distinct_label
 from schema import ColumnRoles
 
 if TYPE_CHECKING:  # The AI layer is optional; ui must import without it.
@@ -313,7 +315,29 @@ def render_dashboard(dataframe: pd.DataFrame, roles: ColumnRoles) -> None:
     movement_columns = st.columns(2, gap="medium")
     with movement_columns[0]:
         drivers = driver_frame(dataframe, roles)
-        if not drivers.empty:
+        if not drivers.empty and not resolve_metric(roles.measure).additive:
+            # Changes in segment averages do not add up to the change in the
+            # overall average, so a waterfall (which draws exactly that sum)
+            # would be a picture of an arithmetic that does not hold. Points
+            # per segment, side by side, is what can honestly be shown.
+            fraction = rate_scale(dataframe[roles.measure].dropna()) == "fraction"
+            points = drivers.assign(Change=drivers["Change"] * (100.0 if fraction else 1.0))
+            movement = px.bar(
+                points.sort_values("Change"),
+                x="Change",
+                y="Segment",
+                orientation="h",
+                title=f"Change in average {roles.measure} by {roles.dimension} — latest vs previous period",
+                color=points.sort_values("Change")["Change"].ge(0).map({True: "up", False: "down"}),
+                color_discrete_map={"up": RISE, "down": FALL},
+            )
+            movement.update_layout(showlegend=False, xaxis_title="percentage points")
+            movement.update_traces(
+                marker_line_width=0, hovertemplate="%{y}: %{x:+.1f} pp<extra></extra>"
+            )
+            st.plotly_chart(style_chart(movement), width="stretch", config={"displayModeBar": False})
+            st.caption("Segment averages do not add up to the overall average, so there is no net bar.")
+        elif not drivers.empty:
             waterfall = go.Figure(
                 go.Waterfall(
                     x=[*drivers["Segment"], "Net change"],
@@ -459,29 +483,61 @@ def _cap(frame: pd.DataFrame, spec, value: str, limit: int) -> pd.DataFrame:
 
     Taking the first N groups drops the newest periods off a trend and the
     biggest categories off a ranking -- exactly the rows the reader opened the
-    chart for. Time keeps its most recent end; anything else keeps its largest.
+    chart for. Time keeps its most recent end, in whole periods so that no
+    date is left with some of its series and not others; anything else keeps
+    its largest. Whatever was dropped is written into the frame's note.
     """
     if len(frame) <= limit:
         return frame
     if spec.x and spec.x in frame.columns and is_datetime64_any_dtype(frame[spec.x]):
-        return frame.nlargest(limit, spec.x).sort_values(spec.x).reset_index(drop=True)
-    return frame.nlargest(limit, value).reset_index(drop=True)
+        per_bucket = frame.groupby(spec.x).size().sort_index(ascending=False)
+        kept_buckets = per_bucket.index[per_bucket.cumsum() <= limit]
+        trimmed = frame[frame[spec.x].isin(kept_buckets)].sort_values(spec.x).reset_index(drop=True)
+        trimmed.attrs["note"] = (
+            f"Showing the most recent {len(kept_buckets):,} of {len(per_bucket):,} periods."
+        )
+        return trimmed
+    trimmed = frame.nlargest(limit, value).reset_index(drop=True)
+    trimmed.attrs["note"] = f"Showing the {limit:,} largest of {len(frame):,} rows."
+    return trimmed
 
 
 def _explore_frame(
     dataframe: pd.DataFrame, spec, *, limit: int = 400
 ) -> pd.DataFrame:
     """Aggregate the raw rows into what the recommended chart plots."""
-    if spec.form in ("scatter", "histogram"):
+    if spec.form == "histogram":
+        # Binned on the server over every row: a first-N sample of a
+        # distribution hides whatever arrives late in the file, and 20,000
+        # values of 1 followed by 1,000 of 10,000 showed no tail at all.
+        values = pd.to_numeric(dataframe[spec.x], errors="coerce").dropna()
+        counts, edges = np.histogram(values, bins=35)
+        binned = pd.DataFrame({spec.x: edges[:-1], "__width": np.diff(edges), "Records": counts})
+        binned.attrs["note"] = f"All {len(values):,} values, in 35 equal-width bins."
+        return binned
+    if spec.form == "scatter":
         columns = [column for column in (spec.x, spec.y) if column]
-        return dataframe[columns].dropna().head(20_000)
+        points = dataframe[columns].dropna()
+        if len(points) > 20_000:
+            # Every k-th point rather than the first 20,000, and say so.
+            step = int(np.ceil(len(points) / 20_000))
+            sampled = points.iloc[::step].reset_index(drop=True)
+            sampled.attrs["note"] = (
+                f"Showing every {step}th point: {len(sampled):,} of {len(points):,}."
+            )
+            return sampled
+        return points
 
     grouping = [column for column in (spec.x, spec.y, spec.color) if column]
     # A heatmap, and the table it falls back to when the grid is too large,
     # are both "measure across two categories".
     if spec.color and spec.x and spec.y and spec.form in ("heatmap", "table"):
         keys = [spec.y, spec.x]
-        grid = dataframe.groupby(keys, dropna=True, observed=True)[spec.color].sum().reset_index()
+        grid = (
+            dataframe.groupby(keys, dropna=True, observed=True)[spec.color]
+            .agg(resolve_metric(spec.color).aggregation)
+            .reset_index()
+        )
         if spec.form == "table":
             return grid.nlargest(limit, spec.color).reset_index(drop=True)
         return grid
@@ -493,15 +549,23 @@ def _explore_frame(
     if spec.aggregation == "count" or not spec.y:
         # A column the file calls "Records" collides with the count column
         # built here, so the count takes a name the frame is not using.
-        value = next(name for name in ("Records", "Record count", "Rows") if name not in dataframe.columns)
+        value = distinct_label("Records", dataframe.columns)
         frame = dataframe.groupby(keys, dropna=True, observed=True).size().reset_index(name=value)
     else:
-        frame = dataframe.groupby(keys, dropna=True, observed=True)[spec.y].sum().reset_index()
+        frame = (
+            dataframe.groupby(keys, dropna=True, observed=True)[spec.y]
+            .agg(resolve_metric(spec.y).aggregation)
+            .reset_index()
+        )
         value = spec.y
 
     if spec.color and spec.color in frame.columns:
         frame = fold_small_series(frame, spec.color, value)
-        frame = frame.groupby(keys, dropna=True, observed=True)[value].sum().reset_index()
+        frame = (
+            frame.groupby(keys, dropna=True, observed=True)[value]
+            .agg(resolve_metric(spec.y).aggregation if spec.y else "sum")
+            .reset_index()
+        )
     return _cap(frame, spec, value, limit)
 
 
@@ -529,7 +593,9 @@ def _explore_figure(frame: pd.DataFrame, spec) -> go.Figure | None:
             color_discrete_sequence=[LEAF],
         )
     elif spec.form == "histogram":
-        figure = px.histogram(frame, x=spec.x, nbins=35, color_discrete_sequence=[ACCENT])
+        figure = px.bar(frame, x=spec.x, y="Records", color_discrete_sequence=[ACCENT])
+        if "__width" in frame.columns:
+            figure.update_traces(width=frame["__width"].to_numpy(), offset=0)
     elif spec.form == "scatter":
         figure = px.scatter(frame, x=spec.x, y=spec.y, color_discrete_sequence=[ACCENT])
         figure.update_traces(marker={"size": 8, "opacity": 0.7})
@@ -600,6 +666,8 @@ def render_explore(dataframe: pd.DataFrame, roles: ColumnRoles) -> None:
         figure = _explore_figure(frame, spec)
         if figure is not None:
             st.plotly_chart(figure, width="stretch", config={"displayModeBar": False})
+    if frame.attrs.get("note"):
+        st.caption(frame.attrs["note"])
 
     st.markdown(
         f'<p class="calculation">WHY THIS CHART · {escape(spec.rationale)}</p>',

--- a/ui.py
+++ b/ui.py
@@ -512,8 +512,13 @@ def _explore_frame(
         # values of 1 followed by 1,000 of 10,000 showed no tail at all.
         values = pd.to_numeric(dataframe[spec.x], errors="coerce").dropna()
         counts, edges = np.histogram(values, bins=35)
-        binned = pd.DataFrame({spec.x: edges[:-1], "__width": np.diff(edges), "Records": counts})
+        # distinct_label, as the count path below already does: a column
+        # literally called "Records" is otherwise overwritten by the counts in
+        # this dict literal, and the chart plots counts against counts.
+        records = distinct_label("Records", [spec.x])
+        binned = pd.DataFrame({spec.x: edges[:-1], "__width": np.diff(edges), records: counts})
         binned.attrs["note"] = f"All {len(values):,} values, in 35 equal-width bins."
+        binned.attrs["count_column"] = records
         return binned
     if spec.form == "scatter":
         columns = [column for column in (spec.x, spec.y) if column]

--- a/ui.py
+++ b/ui.py
@@ -16,7 +16,7 @@ from pandas.api.types import is_datetime64_any_dtype
 from aggregation import build_trend, driver_frame, heatmap_frame, segment_frame
 from anomalies import detect_anomalies
 from autovis import fold_small_series, recommend_chart
-from business_insights import BusinessBrief
+from business_insights import BusinessBrief, preview_evidence
 from forecasting import build_forecast, describe_backtest
 from formatting import format_number, format_period, rate_scale
 from metrics import resolve_metric
@@ -168,7 +168,7 @@ def render_recommendations(brief: BusinessBrief) -> None:
 
 
 def render_evidence(brief: BusinessBrief, *, limit: int | None = None) -> None:
-    evidence = brief.evidence[:limit] if limit else brief.evidence
+    evidence = preview_evidence(brief.evidence, limit) if limit else list(brief.evidence)
     if not evidence:
         st.markdown(
             '<div class="empty-state">No strong signal yet. Open “Tune detection” and select a date, metric, and segment.</div>',


### PR DESCRIPTION
**Draft while a deep review finishes. Do not merge yet — I will mark it ready.**

Everything left on `consistency-release` that never reached `main`, merged and re-verified, plus the bugs found while verifying it.

## The merge

Three conflicts, all trivial and resolved in favour of the release branch:

- `analysis.py` — `_drop_non_finite` is an addition `main` did not have
- `forecasting.py` — the import list gains `period_positions`
- `pipeline.py` — comment wording only, both hunks

## Bugs found and fixed while verifying

**A first period the data only starts part-way into became the baseline for every movement.** `_trailing_partial_period` asks how far *into* a period the data reaches, which a late-starting first period answers perfectly well — an export beginning on a Saturday still reaches Sunday, so it looked complete. What makes it partial is where it *begins*.

On the bundled `ecommerce-orders.csv`, whose first week holds two days of trade:

```
before:  Revenue per week moved from $780.94 to $5.3K (+578.9% across 78 weeks)
after:   Revenue per week moved from $7.5K   to $5.3K  (-29.7% across 77 weeks)
```

New `_leading_partial_period` mirrors the trailing check, measuring from the period start instead, and excludes the period under the same guard — never drop the only evidence there is. The reader is told, the same way they are told about a trailing partial period.

**A report title above the table was defeated by a thousands separator.** `_skip_title_row` compared `header.count(",")` against `first_row.count(",")`. A quoted `"1,234.50"` holds a comma that is not a delimiter, so the counts disagreed and the rescue gave up — on the single most ordinary export there is, a titled report of amounts. Fields are now counted with `csv.reader`, which respects quoting. (On `main` the same file silently became a one-column frame, which is worse than the error this branch was raising.)

## Verification

- `ruff check` clean.
- **448 tests pass**, up from 309 on `main`.
- Every module imports; the Streamlit app runs with no exception, 6 tabs, all widgets.
- Drove every option of all four selectors and a spread of chat questions including empty, whitespace and nonsense input — no crashes.
- All three bundled samples run end to end: brief, trend, forecast, anomalies, segments, drivers, heatmap.
- Edge-case sweep through the pipeline: empty frame, one row, all-NaN measure, no date column, no numeric column, single distinct date, duplicate column names, columns literally named `Period` / `Value` / `Segment` / `__date`, all-zero and all-negative measures, infinities, 1e300, unicode labels, 1,200 distinct segments, mixed-type columns. No crashes; the two errors raised are deliberate and carry clear messages.
- File reader: UTF-8, BOM, UTF-16, latin-1, cp1252, semicolon and tab delimiters, CRLF, title rows, trailing blanks, ragged rows, duplicate and blank headers, header-only, empty, binary garbage, multi-sheet workbooks, corrupt workbooks, wrong extensions.

## Known gap, not fixed here

Relative time scopes do not work — `last quarter`, `last month`, `last year`, `this year`, `in the last 3 months` all refuse. Absolute scopes (`in 2025`, `in October`) work. This is pre-existing on `main`, not a regression, and the refusal is the designed behaviour rather than a wrong answer, so it is a feature gap rather than a bug. Worth its own change.